### PR TITLE
feat(data): merge detection and stream publishing — phase 3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -143,6 +143,15 @@ OUTBOX_MAX_ATTEMPTS=10
 OUTBOX_BACKSTOP_GRACE_SECONDS=60
 
 ##
+# Source-data change-request publish notifications
+# Best-effort XADD announcing that a change-request batch has become publishable (approved,
+# whether by an admin or auto-approved on the write path). A HINT only — Postgres remains the
+# queue of record and the publish cron is the backstop, so a lost/duplicated message, or Redis
+# being unset entirely, costs latency and nothing else.
+##
+REDIS_SOURCEDATA_PUBLISH_STREAM=litcal:sourcedata-publish-stream
+
+##
 # Docker Compose Port Configuration
 # These variables are read by docker-compose.yml for port mappings
 # All services are bound to 127.0.0.1 (localhost only)

--- a/.env.example
+++ b/.env.example
@@ -147,9 +147,14 @@ OUTBOX_BACKSTOP_GRACE_SECONDS=60
 # Best-effort XADD announcing that a change-request batch has become publishable (approved,
 # whether by an admin or auto-approved on the write path). A HINT only — Postgres remains the
 # queue of record and the publish cron is the backstop, so a lost/duplicated message, or Redis
-# being unset entirely, costs latency and nothing else.
+# being unset entirely, costs latency and nothing else: with Redis absent, everything still
+# publishes on the next cron tick instead of waking in under a second. GROUP and CONSUMER are
+# read only by bin/publish-sourcedata-consumer (the optional accelerator); leaving CONSUMER
+# blank defaults to this host's hostname.
 ##
 REDIS_SOURCEDATA_PUBLISH_STREAM=litcal:sourcedata-publish-stream
+REDIS_SOURCEDATA_PUBLISH_GROUP=sourcedata-publisher
+REDIS_SOURCEDATA_PUBLISH_CONSUMER=          # default: hostname
 
 ##
 # Docker Compose Port Configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,10 @@
   /auth/notifications`'s `items` is now a discriminated list:** alongside the existing
   `access_request_reviewed` items it now also carries `change_request_published` items (a submitter's own
   batch merged or closed on GitHub), and the two shapes share only `type` and `unread` — clients must
-  switch on `type` before reading any other key. Publishing can additionally be driven by an optional
+  switch on `type` before reading any other key. **The OpenAPI schema formerly named
+  `UserNotification` is renamed `AccessRequestNotification`**, alongside the new `ChangeRequestNotification`
+  schema for the second shape — a codegen-breaking change for any client generated from `openapi.json`
+  under the old schema name. Publishing can additionally be driven by an optional
   Redis stream (`REDIS_SOURCEDATA_PUBLISH_STREAM`/`_GROUP`/`_CONSUMER`) via the new
   `bin/publish-sourcedata-consumer`, which wakes on an approved batch and polls merges on its idle tick;
   this is a latency accelerator only — a deployment with no Redis configured still publishes and detects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,29 @@
   unpublishable batch cannot block every other editor's approved work. Parked batches are reported by
   `GET /health`'s `source_data_publisher` block (`parked_batches`) and by each run's summary line, and are
   retried by clearing `publish_attempts` — see the runbook's "Parked batches".
+* add source-data merge detection (phase 3): a new `scripts/poll-sourcedata-merges.php` cron job polls the
+  rolling pull requests phase 2 opens and records whether each carried batch merged, closed unmerged, or
+  merged without a batch that shared its pull request number (a review that landed concurrently with a
+  publish — containment is verified with the GitHub compare API rather than assumed, and an unverified
+  batch is republished under a fresh pull request rather than marked merged, so its content is never lost
+  silently). This closes the phase 2 known limitation: a merged batch that deleted a calendar or test
+  definition now has its OpenFGA editor/viewer tuples purged automatically, keyed on
+  `metadata.deletes_resource` (never `operation = 'delete'`, which also fires for an ordinary locale
+  removal on a calendar that still exists) and requiring every row of the batch to agree, or nothing is
+  purged; `admin` tuples deliberately survive so a recreated resource id keeps its owner. **`GET
+  /auth/notifications`'s `items` is now a discriminated list:** alongside the existing
+  `access_request_reviewed` items it now also carries `change_request_published` items (a submitter's own
+  batch merged or closed on GitHub), and the two shapes share only `type` and `unread` — clients must
+  switch on `type` before reading any other key. Publishing can additionally be driven by an optional
+  Redis stream (`REDIS_SOURCEDATA_PUBLISH_STREAM`/`_GROUP`/`_CONSUMER`) via the new
+  `bin/publish-sourcedata-consumer`, which wakes on an approved batch and polls merges on its idle tick;
+  this is a latency accelerator only — a deployment with no Redis configured still publishes and detects
+  merges correctly, just on the next cron tick rather than in under a second. `GET /health`'s
+  `source_data_publisher` block gains two keys, `open_batches` and `oldest_open_age_seconds`, warning once
+  the oldest open pull request has waited 30 days — a signal an operator should read as either a slow
+  reviewer or a stopped poller, since an undetected merge is indistinguishable from an unreviewed one from
+  this side. See `docs/ops/change-request-runbook.md`'s "Merge detection (phase 3)" section for the full
+  operator playbook.
 -->
 
 ## [v5.7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/releases/tag/v5.7) (December 15th 2025)

--- a/bin/publish-sourcedata-consumer
+++ b/bin/publish-sourcedata-consumer
@@ -47,6 +47,7 @@ require_once dirname(__DIR__) . '/vendor/autoload.php';
 use Dotenv\Dotenv;
 use LiturgicalCalendar\Api\Services\SourceData\PublishConsumerLoop;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisherFactory;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier;
 use LiturgicalCalendar\Api\Services\Outbox\RedisStreamConsumer;
 
 // ---------------------------------------------------------------------------
@@ -92,20 +93,33 @@ if (!extension_loaded('redis')) {
 }
 
 $redis = new \Redis();
-if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
-    $redis->connect($_ENV['REDIS_SOCKET']);
-} else {
-    // Narrowed with is_string()/is_numeric() rather than a blind (string)/(int) cast on $_ENV's
-    // `mixed` values — the same reasoning as every src/ env read in this feature: PHPStan level
-    // 10 rejects casting mixed away, and this file is one of the three scanned standalone
-    // (`phpstan.neon.dist` only covers `paths: [src]`) precisely so a cast like that cannot hide
-    // here either.
-    $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
-    $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
-    $redis->connect($redisHost, $redisPort);
-}
-if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
-    $redis->auth($_ENV['REDIS_PASSWORD']);
+try {
+    if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
+        $redis->connect($_ENV['REDIS_SOCKET'], 0, 2.0); // 2 second timeout
+    } else {
+        // Narrowed with is_string()/is_numeric() rather than a blind (string)/(int) cast on $_ENV's
+        // `mixed` values — the same reasoning as every src/ env read in this feature: PHPStan level
+        // 10 rejects casting mixed away, and this file is one of the three scanned standalone
+        // (`phpstan.neon.dist` only covers `paths: [src]`) precisely so a cast like that cannot hide
+        // here either.
+        $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
+        $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
+        $redis->connect($redisHost, $redisPort, 2.0); // 2 second timeout
+    }
+    if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
+        $redis->auth($_ENV['REDIS_PASSWORD']);
+    }
+} catch (\Throwable $e) {
+    // Redis being down at startup is this process's most likely failure, and it is this
+    // process's entire reason to exist (see the ext-redis guard above) — so an unguarded
+    // connect()/auth() would fatal with nothing past "starting" in this process's log every
+    // time systemd restarts it. Same crash-loop reasoning as the dependency-wiring catch below.
+    $logger->error(
+        'publish-sourcedata-consumer could not connect to Redis; the consumer cannot start.',
+        ['exception' => $e::class, 'message' => $e->getMessage()]
+    );
+    fwrite(STDERR, 'Error: could not connect to Redis: ' . $e->getMessage() . "\n");
+    exit(1);
 }
 
 // ---------------------------------------------------------------------------
@@ -158,13 +172,14 @@ $consumerName = is_string($_ENV['REDIS_SOURCEDATA_PUBLISH_CONSUMER'] ?? null)
     ? $_ENV['REDIS_SOURCEDATA_PUBLISH_CONSUMER']
     : ( gethostname() ?: 'consumer' );
 
-// The sixth argument, 'batch_id', is NOT this class's default ('row_id', which is the OpenFGA
-// outbox's field name). Getting it wrong makes every message on this stream look malformed —
-// SourceDataPublishNotifier::notify() writes only a `batch_id` field — and RedisStreamConsumer
-// ACKs a malformed message away silently, logging "bad message" and carrying on, with no other
-// symptom: the consumer would run forever, waking on every notification and doing nothing with
-// any of them, while the cron backstop quietly did all the real work.
-$stream = new RedisStreamConsumer($redis, $streamName, $groupName, $consumerName, $logger, 'batch_id');
+// The sixth argument is NOT this class's default ('row_id', which is the OpenFGA outbox's field
+// name) — it must match SourceDataPublishNotifier::BATCH_ID_FIELD, the field name
+// SourceDataPublishNotifier::notify() actually writes. Getting it wrong makes every message on
+// this stream look malformed, and RedisStreamConsumer ACKs a malformed message away silently,
+// logging "bad message" and carrying on, with no other symptom: the consumer would run forever,
+// waking on every notification and doing nothing with any of them, while the cron backstop
+// quietly did all the real work.
+$stream = new RedisStreamConsumer($redis, $streamName, $groupName, $consumerName, $logger, SourceDataPublishNotifier::BATCH_ID_FIELD);
 $loop   = new PublishConsumerLoop(
     $stream,
     $publishRunner,

--- a/bin/publish-sourcedata-consumer
+++ b/bin/publish-sourcedata-consumer
@@ -1,0 +1,176 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Long-lived consumer for the source-data publish stream — systemd manages restart on failure,
+ * exactly as `bin/reconcile-outbox`'s `consumer` mode does for the OpenFGA outbox.
+ *
+ * Wakes on `XADD`s from {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier}
+ * (fired on approval, best-effort) and, on its idle tick, polls open pull requests for merges.
+ * The message it wakes on is a HINT, not a work item — see
+ * {@see \LiturgicalCalendar\Api\Services\SourceData\PublishConsumerLoop}'s own class docblock for
+ * why the batch id it carries is used only for logging, and `scripts/publish-sourcedata.php` /
+ * `scripts/poll-sourcedata-merges.php` remain the cron backstop behind both paths this consumer
+ * drives.
+ *
+ * Required environment variables (loaded from .env* files if present):
+ *   DB_HOST, DB_NAME, DB_USER, DB_PASSWORD (DB_PORT optional, defaults to 5432)
+ *   GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, GITHUB_APP_PRIVATE_KEY_PATH, GITHUB_REPOSITORY
+ *
+ * Optional:
+ *   REDIS_SOCKET, or REDIS_HOST/REDIS_PORT (default 127.0.0.1:6379), plus REDIS_PASSWORD
+ *   REDIS_SOURCEDATA_PUBLISH_STREAM   (default: litcal:sourcedata-publish-stream)
+ *   REDIS_SOURCEDATA_PUBLISH_GROUP    (default: sourcedata-publisher)
+ *   REDIS_SOURCEDATA_PUBLISH_CONSUMER (default: this host's hostname, or "consumer")
+ *   OPENFGA_API_URL, OPENFGA_STORE_ID, OPENFGA_MODEL_ID — same optional purge step as
+ *   scripts/poll-sourcedata-merges.php.
+ *
+ * Exit codes:
+ *   2  ext-redis is not installed. This is a guard, not a failure this process can recover
+ *      from — install the extension and restart.
+ *
+ * There is no exit 0: `run()` never returns (`@codeCoverageIgnore`d for exactly that reason);
+ * systemd is what stops this process.
+ */
+
+declare(strict_types=1);
+
+// Refuse any entry that is not the CLI — see the identical guard in every other scripts/*.php
+// and bin/reconcile-outbox for why this is not redundant with the shebang line above it.
+if (PHP_SAPI !== 'cli') {
+    http_response_code(404);
+    exit(1);
+}
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+use Dotenv\Dotenv;
+use LiturgicalCalendar\Api\Services\SourceData\PublishConsumerLoop;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisherFactory;
+use LiturgicalCalendar\Api\Services\Outbox\RedisStreamConsumer;
+
+// ---------------------------------------------------------------------------
+// Bootstrap: load environment from .env* files if present. Same chain as bin/reconcile-outbox
+// and every scripts/*.php entry point, for the same reason — CLI's variables_order may not
+// include "E", so a systemd EnvironmentFile or exported shell vars would not reach $_ENV;
+// Dotenv reading the files directly is what makes configuration reach this process regardless.
+// ---------------------------------------------------------------------------
+$root = dirname(__DIR__);
+Dotenv::createImmutable(
+    $root,
+    ['.env', '.env.local', '.env.development', '.env.test', '.env.staging', '.env.production'],
+    false
+)->safeLoad();
+
+// ---------------------------------------------------------------------------
+// Logging — see SourceDataPublisherFactory::logger()'s own docblock for why
+// includeProcessors: false is load-bearing here, exactly as it is for the two cron scripts this
+// consumer sits alongside.
+// ---------------------------------------------------------------------------
+$factory = new SourceDataPublisherFactory();
+try {
+    $logger = $factory->logger('publish-sourcedata-consumer');
+} catch (\Throwable $e) {
+    fwrite(STDERR, 'Error: could not open the publish-sourcedata-consumer log: ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+$logger->info('publish-sourcedata-consumer starting.');
+
+// --- ext-redis guard ---
+//
+// This machine may not have it (a self-hoster without the Redis-backed acceleration path is
+// expected to run the two cron scripts alone), but THIS process's entire reason to exist is the
+// stream — so unlike SourceDataPublisherFactory::publishNotifier() on the producer side, there
+// is no silent no-op fallback here. Exit 2, distinctly from the configuration-error exit 1 the
+// two cron scripts use, so an operator (or the process supervisor) can tell "not installed" from
+// "installed but misconfigured" at a glance.
+if (!extension_loaded('redis')) {
+    $logger->error('publish-sourcedata-consumer requires ext-redis, which is not installed.');
+    fwrite(STDERR, "ext-redis is required for publish-sourcedata-consumer but is not installed.\n");
+    exit(2);
+}
+
+$redis = new \Redis();
+if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
+    $redis->connect($_ENV['REDIS_SOCKET']);
+} else {
+    // Narrowed with is_string()/is_numeric() rather than a blind (string)/(int) cast on $_ENV's
+    // `mixed` values — the same reasoning as every src/ env read in this feature: PHPStan level
+    // 10 rejects casting mixed away, and this file is one of the three scanned standalone
+    // (`phpstan.neon.dist` only covers `paths: [src]`) precisely so a cast like that cannot hide
+    // here either.
+    $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
+    $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
+    $redis->connect($redisHost, $redisPort);
+}
+if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
+    $redis->auth($_ENV['REDIS_PASSWORD']);
+}
+
+// ---------------------------------------------------------------------------
+// Installation-token cache — the umask window
+//
+// SourceDataPublisherFactory::publishRunner() and ::mergePollRunner(), called below, both build
+// (the same, memoised) filesystem-backed cache for the GitHub App installation token. Neither
+// touches the process umask, deliberately — see scripts/publish-sourcedata.php's identical
+// comment for the full rationale. What differs for a long-lived consumer: there is no "restore
+// afterward" point, because the run never ends until systemd stops it, and the token is
+// refetched throughout that lifetime. So the restrictive umask set here simply stays in effect
+// for the life of this process — which is also strictly safer than a cron script's bounded
+// window, not a weaker version of it.
+// ---------------------------------------------------------------------------
+umask(0o077);
+
+// ---------------------------------------------------------------------------
+// Dependency wiring — routed through SourceDataPublisherFactory exactly as both cron scripts
+// are, for the same reason: phpstan.neon.dist scans `paths: [src]` only, so keeping every
+// environment-variable read there is what keeps this entry point covered by PHPStan level 10.
+//
+// Same \Throwable-not-\RuntimeException reasoning as scripts/publish-sourcedata.php and
+// scripts/poll-sourcedata-merges.php: SourceDataPublisherFactory::publishRunner() and
+// ::mergePollRunner() both throw InvalidArgumentException — a LogicException, not a
+// RuntimeException — for a malformed GITHUB_REPOSITORY. A daemon under systemd would otherwise
+// crash-loop on an uncaught fatal with nothing past "starting" in its log every time it
+// restarts; catching here means the operator gets one clear log line and one clean exit
+// instead, and systemd's restart-on-failure still applies to exit 1 exactly as it would to a
+// crash — the difference is entirely in what gets logged first.
+// ---------------------------------------------------------------------------
+try {
+    $publishRunner = $factory->publishRunner($logger);
+    $mergePoller   = $factory->mergePollRunner($logger);
+} catch (\Throwable $e) {
+    $logger->error(
+        'publish-sourcedata-consumer is not configured; the consumer cannot start.',
+        ['exception' => $e::class, 'message' => $e->getMessage()]
+    );
+    fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+$streamName   = is_string($_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM'] ?? null)
+    ? $_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM']
+    : 'litcal:sourcedata-publish-stream';
+$groupName    = is_string($_ENV['REDIS_SOURCEDATA_PUBLISH_GROUP'] ?? null)
+    ? $_ENV['REDIS_SOURCEDATA_PUBLISH_GROUP']
+    : 'sourcedata-publisher';
+$consumerName = is_string($_ENV['REDIS_SOURCEDATA_PUBLISH_CONSUMER'] ?? null)
+    ? $_ENV['REDIS_SOURCEDATA_PUBLISH_CONSUMER']
+    : ( gethostname() ?: 'consumer' );
+
+// The sixth argument, 'batch_id', is NOT this class's default ('row_id', which is the OpenFGA
+// outbox's field name). Getting it wrong makes every message on this stream look malformed —
+// SourceDataPublishNotifier::notify() writes only a `batch_id` field — and RedisStreamConsumer
+// ACKs a malformed message away silently, logging "bad message" and carrying on, with no other
+// symptom: the consumer would run forever, waking on every notification and doing nothing with
+// any of them, while the cron backstop quietly did all the real work.
+$stream = new RedisStreamConsumer($redis, $streamName, $groupName, $consumerName, $logger, 'batch_id');
+$loop   = new PublishConsumerLoop(
+    $stream,
+    $publishRunner,
+    $mergePoller,
+    blockMs: 5000,
+    logger: $logger
+);
+
+$loop->run();

--- a/bin/publish-sourcedata-consumer
+++ b/bin/publish-sourcedata-consumer
@@ -162,14 +162,22 @@ try {
     exit(1);
 }
 
-$streamName   = is_string($_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM'] ?? null)
-    ? $_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM']
+// A blank or whitespace-only value is treated as unset, not as a deliberately empty name — an
+// empty stream, group, or consumer name is exactly as wrong as a missing one, and .env.example
+// ships REDIS_SOURCEDATA_PUBLISH_CONSUMER blank (documenting "default: hostname"), so following
+// the shipped configuration verbatim must still fall through to the documented default.
+$streamNameRaw   = $_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM'] ?? null;
+$groupNameRaw    = $_ENV['REDIS_SOURCEDATA_PUBLISH_GROUP'] ?? null;
+$consumerNameRaw = $_ENV['REDIS_SOURCEDATA_PUBLISH_CONSUMER'] ?? null;
+
+$streamName   = is_string($streamNameRaw) && trim($streamNameRaw) !== ''
+    ? $streamNameRaw
     : 'litcal:sourcedata-publish-stream';
-$groupName    = is_string($_ENV['REDIS_SOURCEDATA_PUBLISH_GROUP'] ?? null)
-    ? $_ENV['REDIS_SOURCEDATA_PUBLISH_GROUP']
+$groupName    = is_string($groupNameRaw) && trim($groupNameRaw) !== ''
+    ? $groupNameRaw
     : 'sourcedata-publisher';
-$consumerName = is_string($_ENV['REDIS_SOURCEDATA_PUBLISH_CONSUMER'] ?? null)
-    ? $_ENV['REDIS_SOURCEDATA_PUBLISH_CONSUMER']
+$consumerName = is_string($consumerNameRaw) && trim($consumerNameRaw) !== ''
+    ? $consumerNameRaw
     : ( gethostname() ?: 'consumer' );
 
 // The sixth argument is NOT this class's default ('row_id', which is the OpenFGA outbox's field

--- a/bin/publish-sourcedata-consumer
+++ b/bin/publish-sourcedata-consumer
@@ -94,20 +94,26 @@ if (!extension_loaded('redis')) {
 
 $redis = new \Redis();
 try {
-    if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
-        $redis->connect($_ENV['REDIS_SOCKET'], 0, 2.0); // 2 second timeout
+    // Every env read here goes through SourceDataPublisherFactory::envString(), which checks
+    // $_ENV and THEN getenv(). That second layer is not belt-and-braces: Dotenv fills $_ENV from
+    // the .env* files, but PHP CLI commonly runs with `variables_order` excluding `E`, so a
+    // variable set by this process's systemd unit (`Environment=` / `EnvironmentFile=`) reaches
+    // getenv() and never $_ENV. The change-request runbook ships exactly such a unit, so reading
+    // only $_ENV would silently ignore the configuration mechanism we tell operators to use and
+    // connect to 127.0.0.1 instead. It also narrows `mixed` without a blind cast, which is what
+    // keeps this file clean under the standalone PHPStan level 10 pass.
+    $redisSocket   = SourceDataPublisherFactory::envString('REDIS_SOCKET');
+    $redisPassword = SourceDataPublisherFactory::envString('REDIS_PASSWORD');
+
+    if ('' !== $redisSocket) {
+        $redis->connect($redisSocket, 0, 2.0); // 2 second timeout
     } else {
-        // Narrowed with is_string()/is_numeric() rather than a blind (string)/(int) cast on $_ENV's
-        // `mixed` values — the same reasoning as every src/ env read in this feature: PHPStan level
-        // 10 rejects casting mixed away, and this file is one of the three scanned standalone
-        // (`phpstan.neon.dist` only covers `paths: [src]`) precisely so a cast like that cannot hide
-        // here either.
-        $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
-        $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
-        $redis->connect($redisHost, $redisPort, 2.0); // 2 second timeout
+        $redisHost = SourceDataPublisherFactory::envString('REDIS_HOST') ?: '127.0.0.1';
+        $redisPort = SourceDataPublisherFactory::envString('REDIS_PORT');
+        $redis->connect($redisHost, is_numeric($redisPort) ? (int) $redisPort : 6379, 2.0); // 2 second timeout
     }
-    if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
-        $redis->auth($_ENV['REDIS_PASSWORD']);
+    if ('' !== $redisPassword) {
+        $redis->auth($redisPassword);
     }
 } catch (\Throwable $e) {
     // Redis being down at startup is this process's most likely failure, and it is this
@@ -166,19 +172,17 @@ try {
 // empty stream, group, or consumer name is exactly as wrong as a missing one, and .env.example
 // ships REDIS_SOURCEDATA_PUBLISH_CONSUMER blank (documenting "default: hostname"), so following
 // the shipped configuration verbatim must still fall through to the documented default.
-$streamNameRaw   = $_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM'] ?? null;
-$groupNameRaw    = $_ENV['REDIS_SOURCEDATA_PUBLISH_GROUP'] ?? null;
-$consumerNameRaw = $_ENV['REDIS_SOURCEDATA_PUBLISH_CONSUMER'] ?? null;
-
-$streamName   = is_string($streamNameRaw) && trim($streamNameRaw) !== ''
-    ? $streamNameRaw
-    : 'litcal:sourcedata-publish-stream';
-$groupName    = is_string($groupNameRaw) && trim($groupNameRaw) !== ''
-    ? $groupNameRaw
-    : 'sourcedata-publisher';
-$consumerName = is_string($consumerNameRaw) && trim($consumerNameRaw) !== ''
-    ? $consumerNameRaw
-    : ( gethostname() ?: 'consumer' );
+// envString() treats an empty value as unset AND reads getenv() as well as $_ENV — see the
+// comment on the connection block above for why the second layer is load-bearing under systemd.
+// The empty-is-unset half matters just as much: .env.example ships
+// REDIS_SOURCEDATA_PUBLISH_CONSUMER with an empty value and the comment "default: hostname", so
+// an is_string()-only check would hand RedisStreamConsumer an empty consumer name.
+$streamName   = SourceDataPublisherFactory::envString('REDIS_SOURCEDATA_PUBLISH_STREAM')
+    ?: 'litcal:sourcedata-publish-stream';
+$groupName    = SourceDataPublisherFactory::envString('REDIS_SOURCEDATA_PUBLISH_GROUP')
+    ?: 'sourcedata-publisher';
+$consumerName = SourceDataPublisherFactory::envString('REDIS_SOURCEDATA_PUBLISH_CONSUMER')
+    ?: ( gethostname() ?: 'consumer' );
 
 // The sixth argument is NOT this class's default ('row_id', which is the OpenFGA outbox's field
 // name) — it must match SourceDataPublishNotifier::BATCH_ID_FIELD, the field name

--- a/docs/ops/change-request-runbook.md
+++ b/docs/ops/change-request-runbook.md
@@ -746,10 +746,11 @@ on schedule (check `logs/cron-poll.log`, or `journalctl` for the consumer unit i
 
 The "Parked batches" SQL above (`UPDATE sourcedata_change_requests SET publish_attempts = 0, …`) clears a
 batch's attempt counter so the publisher will claim it again. It is not the whole recovery: the same
-grace-period reclaim that clears `publish_attempts` also clears `publish_claim_token` back to `NULL` — the
-column `claimNextPublishableBatch()` stamps with a fresh token on every claim and `releaseClaim()` /
-`reclaimStaleClaims()` compare against before clearing, so that a late release from one runner can never
-revoke a different runner's live claim (see "Claim ownership" in
+grace-period reclaim actually *increments* `publish_attempts` — that increment is precisely the mechanism
+by which a merely-slow batch parks in the first place — but in that same statement it also clears
+`publish_claim_token` back to `NULL` — the column `claimNextPublishableBatch()` stamps with a fresh token
+on every claim and `releaseClaim()` / `reclaimStaleClaims()` compare against before clearing, so that a
+late release from one runner can never revoke a different runner's live claim (see "Claim ownership" in
 `docs/superpowers/2026-08-30-phase-3-handoff.md`). A row `queued` with a token older than
 `PublishRunner::DEFAULT_GRACE_SECONDS` is reclaimed automatically on the next run — an operator does not
 need to touch `publish_claim_token` by hand; clearing `publish_attempts` on a genuinely stuck batch is

--- a/docs/ops/change-request-runbook.md
+++ b/docs/ops/change-request-runbook.md
@@ -171,9 +171,10 @@ separate status columns, and conflating them is the most common way to misread t
   what `POST /admin/change-requests/{batchId}/approve|reject` and
   `POST /auth/change-requests/{batchId}/withdraw` move.
 - **`publication_status`** — GitHub's side of the same change: `none` → `queued` → `open` → `merged` /
-  `closed`. The phase 2 publisher writes `queued` and `open`; `merged` and `closed` are reserved for phase
-  3 merge polling, which does not exist yet. See "Publishing to GitHub (phase 2)" below for exactly what
-  each value means and what a row's `branch`/`commit_sha`/`pr_number`/`base_sha` columns hold once filled.
+  `closed`. The phase 2 publisher writes `queued` and `open`; the phase 3 merge poller writes `merged` and
+  `closed`. See "Publishing to GitHub (phase 2)" below for exactly what each value means and what a row's
+  `branch`/`commit_sha`/`pr_number`/`base_sha` columns hold once filled, and "Merge detection (phase 3)"
+  below for how `merged` and `closed` are decided.
 
 They are kept separate on purpose: an `approved` batch that failed to push must stay distinguishable from
 one still awaiting review, and from one whose PR is open and waiting on CI. Flattening the two into one
@@ -325,8 +326,8 @@ row of a batch at once (a batch is never mixed-status):
 | `none`   | phase 1 (submit), or a release/reclaim | Not yet claimed for publishing, or a failed/stranded attempt was put back so it is claimable again. |
 | `queued` | `claimNextPublishableBatch()`          | A claim held by one runner, mid-publish. Not yet on GitHub.                                         |
 | `open`   | `recordPublication()`                  | A pull request exists for this batch's commit.                                                      |
-| `merged` | phase 3 (not built yet)                | Reserved. Nothing in phase 2 writes this.                                                           |
-| `closed` | phase 3 (not built yet)                | Reserved. Nothing in phase 2 writes this.                                                           |
+| `merged` | phase 3 (`MergePollRunner`)            | The pull request merged, and this batch's commit is verified contained in that merge.               |
+| `closed` | phase 3 (`MergePollRunner`)            | The pull request closed without merging. `review_status` is set to `rejected` alongside it.         |
 
 `queued` is a **claim**, not a milestone on GitHub — nothing has been pushed yet while a batch sits there.
 `open` means a real pull request exists; it does not mean the PR merged, and does not mean CI passed.
@@ -577,45 +578,247 @@ genuine `<id>+<login>@users.noreply.github.com` address the way GitHub's own UI 
 authored under an unverified email therefore carries the same placeholder address regardless of who
 actually submitted it — the author *name* still varies, but the email does not.
 
-## Known limitation: a deleted resource's editors keep access
+## Merge detection (phase 3)
 
-**Not closed by phase 2:** deleting a calendar or test through a change request does not purge its OpenFGA
-authorization tuples. Nothing between "PR merged" and "next redeploy" performs that purge, so a deleted
-diocese's former editors retain edit access on an object whose files are gone. This is deliberate — only
-merge detection (phase 3) knows the deletion actually happened — and it is a known limitation, not an
-oversight.
+Phase 2 stops at `open`: a pull request exists, and nothing watches what happens to it. Phase 3 adds a
+second cron-invoked script, `scripts/poll-sourcedata-merges.php`, driven by `MergePollRunner`
+(`src/Services/SourceData/MergePollRunner.php`), that polls every `open` batch's pull request and records
+what became of it.
 
-In disk mode, `RegionalDataHandler::deleteCalendar()` (and `TestsHandler`'s equivalent
-`handleDeleteRequest()`) both remove the resource's files **and** purge its OpenFGA editor/viewer
-operational tuples via `ResourceTuplePurgeServiceInterface`, in the same request. In queue mode, that same
-purge is gated on the write actually having landed on disk (`disposition === 'applied'`) — which a queued
-delete never is. Publishing a delete-operation batch's PR does not make the deletion true on disk, and
-even an open PR can still be closed unmerged; purging authorization at publish time would revoke real
-access on the strength of a proposal rather than a fact. The corresponding purge is deferred to phase 3,
-at merge detection — the same moment the redeploy that follows a merge would actually remove the files, so
-authorization and files become true together instead of drifting apart.
+### The lifecycle, completed: `none` → `queued` → `open` → `merged` | `closed`
 
-**Operator consequence:** if a change request deletes a diocesan or national calendar, or a test
-definition, before phase 3 ships, its former editors and admins keep their OpenFGA `editor`/`viewer`
-relations on that resource even after the deleting PR is merged and the files are gone from
-`jsondata/sourcedata`. If this needs to be closed out manually before phase 3 exists, purge the resource's
-operational tuples by hand through the same `ResourceTuplePurgeServiceInterface` mapping
-(`RegionalDataHandler::fgaObjectForRequest()` / `changeResourceForRequest()` for calendars,
-`TestsHandler::changeResourceForTest()` for test definitions) — the admin/governance tuple is deliberately
-retained by that purge, not removed, so the resource can be recreated without losing ownership.
+`merged` and `closed` are the two states "Publishing to GitHub (phase 2)" above left reserved. Both are
+written by `MergePollRunner`, never by the publisher:
 
-## Deliberately not in phase 1 or 2
+- **`merged`** — the pull request merged, and this batch's commit is verified **contained** in the merge.
+  Containment is checked, not assumed: a batch whose commit sha equals the pull request's own head is
+  contained for free (the ordinary case, one batch per pull request), and any other batch on that pull
+  request is checked with one GitHub compare-commits call. See "`reset=N`" below for what happens when a
+  batch is NOT contained.
+- **`closed`** — the pull request closed without merging. `review_status` is set to `rejected` alongside
+  it, in the same update, so a closed-unmerged batch is unambiguously a decided, dead proposal — not
+  merely "no longer open."
 
-- **Re-validating a payload against its JSON schema at approval or publish time.** Both phases validate
-  once, at submit. Nothing re-checks a batch's content against its JSON schema between then and the
-  commit `SourceDataPublisher::publish()` pushes, even though real time — and potentially a schema
-  change — can pass in between.
-- **Purging OpenFGA authorization tuples for a deleted calendar or test definition once its deletion is
-  actually live on GitHub.** See "Known limitation: a deleted resource's editors keep access" above —
-  this is deliberate, not an oversight, and is scoped to phase 3.
+A poll that cannot decide either way (the GitHub call itself fails) changes nothing: the batch stays
+`open` for the next tick rather than guessing, because both wrong guesses have a real cost — assuming
+`merged` on a batch that never landed loses no data itself, but assuming `closed` on a batch that actually
+merged would mark good work rejected.
+
+### The two cron entries
+
+Both scripts are idempotent and safe to run concurrently with themselves — a second overlapping
+invocation finds nothing left to claim or poll and exits cleanly. A five-minute interval is what this
+deployment runs in practice:
+
+```cron
+*/5 * * * * cd /path/to/api && php scripts/publish-sourcedata.php >> logs/cron-publish.log 2>&1
+*/5 * * * * cd /path/to/api && php scripts/poll-sourcedata-merges.php >> logs/cron-poll.log 2>&1
+```
+
+Both require the same GitHub App credentials as phase 2 (`GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`,
+`GITHUB_APP_PRIVATE_KEY_PATH`, `GITHUB_REPOSITORY`) and the same database connection. The poller's
+OpenFGA purge step (see "Closed", below) is optional — left unconfigured, merge detection still works and
+the purge is a quiet no-op.
+
+### The consumer as an optional accelerator
+
+`bin/publish-sourcedata-consumer` is a long-lived process, managed by systemd, that wakes on a Redis
+`XADD` the instant a batch becomes publishable and also runs a merge poll on its own idle tick — the same
+two jobs the cron entries above perform, just event-driven rather than interval-driven. It shares one
+`GuzzleClient` and one GitHub App installation-token cache between the publish and poll sides
+(`SourceDataPublisherFactory::publishRunner()` / `::mergePollRunner()`).
+
+**It is optional. Cron alone is a complete, correct deployment.** A self-hoster who has not configured
+Redis (`REDIS_SOCKET`/`REDIS_HOST` both unset, or `ext-redis` not installed) is not running a degraded or
+broken feature — every approved batch still publishes, and every merge is still detected, within one
+cron interval. The consumer only removes that interval's latency; it introduces no new correctness the
+cron scripts do not already provide on their own.
+
+Install it exactly as `deploy/systemd/liturgical-calendar-reconciler.service` installs the OpenFGA outbox
+consumer:
+
+```ini
+[Unit]
+Description=Liturgical Calendar source-data publish/merge consumer
+After=network-online.target postgresql.service redis-server.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=litcal
+Group=litcal
+WorkingDirectory=/opt/liturgical-calendar
+EnvironmentFile=/opt/liturgical-calendar/.env.local
+ExecStart=/usr/bin/php /opt/liturgical-calendar/bin/publish-sourcedata-consumer
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=litcal-sourcedata-consumer
+
+# Hardening (adjust per ops policy)
+ProtectSystem=full
+PrivateTmp=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Save that as `/etc/systemd/system/liturgical-calendar-sourcedata-consumer.service` (there is no
+`deploy/systemd/` copy of it the way there is for the OpenFGA outbox reconciler — this consumer is
+optional in a way the outbox reconciler is not, so it is documented here rather than shipped as a unit
+this repository installs by default), then:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now liturgical-calendar-sourcedata-consumer.service
+sudo systemctl status liturgical-calendar-sourcedata-consumer.service
+```
+
+If it is not installed, or `ext-redis` is missing, or it exits (its exit code 2 specifically means
+`ext-redis` is not installed — see the script's own docblock), do nothing: the two cron entries above
+keep publishing and polling on their own schedule with no operator action required. Running the consumer
+alongside the cron entries is also safe — the claim protocol (below) and the poller's `WHERE
+publication_status = 'open'` guard both make a redundant attempt a no-op, not a double-publish or a
+double-decision.
+
+### `reset=N` on the poll summary line
+
+`scripts/poll-sourcedata-merges.php`'s summary line —
+`poll-sourcedata-merges merged=… closed=… reset=… unpollable=… stopped_on_failure=…` — carries a `reset`
+counter for a specific, expected race: **a concurrent merge**. The rolling branch is per resource, and a
+reviewer clicking Merge on the pull request at the same moment a publish lands a new commit on that same
+branch separates the two — the merge takes the head the branch had a moment earlier, and the publish's
+batch is left recorded against a pull request that closed without actually carrying it.
+
+**The batch is republished under a fresh pull request, never marked `merged`.** Marking it `merged` would
+assert its content reached the repository. The publisher only ever selects rows that are not yet
+`merged`, so a wrongly-`merged` batch would never be attempted again and its content would be lost
+silently — exactly the failure mode containment verification exists to prevent, reached from the other
+direction. Instead, `returnBatchToUnpublished()` puts the batch back to `publication_status = 'none'`; the
+next `publish-sourcedata.php` tick claims it again and opens a new pull request carrying it.
+
+A `reset` count of zero or an occasional one-off is unremarkable — it is what this race looks like when
+it happens rarely. **A value that keeps climbing means publishes and merges are racing routinely** on one
+or more resources, which usually means either the publish cron and a human reviewer are both very active
+on the same resource, or the publish interval is short enough to collide with typical review latency.
+Investigate which resource's branch is repeatedly involved before assuming this is expected background
+noise.
+
+### `unpollable=N`
+
+The same summary line's `unpollable` count should **always be zero**. The publisher records a pull
+request number on every row it publishes (`recordPublication()` stamps `pr_number` unconditionally when a
+batch reaches `open`), so an `open` batch with `pr_number IS NULL` is not a race or a timing window — it
+is an unexplained state that needs an operator, because nothing in the normal lifecycle can produce it.
+
+```sql
+SELECT batch_id, resource_type, resource_id, commit_sha, updated_at
+  FROM sourcedata_change_requests
+ WHERE publication_status = 'open' AND pr_number IS NULL;
+```
+
+**`unpollable` does NOT affect the exit code.** Like `reset`, and like `parked` on the publisher's own
+summary line, it is a value to monitor over time via this summary line and `GET /health`, not a failure of
+the run that reported it — a poll run that finishes cleanly and merely reports a persistent `unpollable`
+count has still done its job. Do not rely on the exit code alone to catch this.
+
+### The two new `/health` keys, and reading the stale warning honestly
+
+`GET /health`'s `source_data_publisher` block gains two keys alongside `parked_batches`:
+
+- **`open_batches`** — how many batches currently sit at `publication_status = 'open'`, awaiting a merge
+  decision. This is the ordinary state for a healthy pipeline and never alarms on its own — a pull request
+  waiting on human review is exactly what is supposed to happen.
+- **`oldest_open_age_seconds`** — how long the oldest of them has been waiting.
+
+`/health` turns `warning` once `oldest_open_age_seconds` exceeds `Health::STALE_OPEN_BATCH_SECONDS` (30
+days). Read that warning as naming **two** possible causes, not one: **either a slow reviewer, or a
+stopped poller.** An undetected merge is invisible from this side of the system — a pull request that
+merged three weeks ago but was never polled looks, in `sourcedata_change_requests`, exactly like a pull
+request still genuinely awaiting review, and every editor waiting on it is told it is still open. Before
+concluding "the reviewers are just slow," confirm `scripts/poll-sourcedata-merges.php` is actually running
+on schedule (check `logs/cron-poll.log`, or `journalctl` for the consumer unit if one is installed) —
+30 days of silence from the poller produces the identical symptom to 30 days of silence from a reviewer.
+
+### Un-parking and claim tokens
+
+The "Parked batches" SQL above (`UPDATE sourcedata_change_requests SET publish_attempts = 0, …`) clears a
+batch's attempt counter so the publisher will claim it again. It is not the whole recovery: the same
+grace-period reclaim that clears `publish_attempts` also clears `publish_claim_token` back to `NULL` — the
+column `claimNextPublishableBatch()` stamps with a fresh token on every claim and `releaseClaim()` /
+`reclaimStaleClaims()` compare against before clearing, so that a late release from one runner can never
+revoke a different runner's live claim (see "Claim ownership" in
+`docs/superpowers/2026-08-30-phase-3-handoff.md`). A row `queued` with a token older than
+`PublishRunner::DEFAULT_GRACE_SECONDS` is reclaimed automatically on the next run — an operator does not
+need to touch `publish_claim_token` by hand; clearing `publish_attempts` on a genuinely stuck batch is
+sufficient, because the next run's stranded-claim recovery step handles the token itself.
+
+## Closed: a deleted resource's editors used to keep access
+
+**Closed by phase 3.** Phase 2 shipped with a known limitation: deleting a calendar or test through a
+change request did not purge its OpenFGA authorization tuples, so a deleted diocese's former editors
+retained edit access on an object whose files were gone. Phase 3's merge poller
+(`MergePollRunner::purgeIfResourceDeletion()`, called once a batch is confirmed `merged`) closes it: the
+same moment the batch's deletion becomes real in the repository, its editor/viewer operational tuples are
+purged via `ResourceTuplePurgeServiceInterface`.
+
+**The trigger is `metadata.deletes_resource`, NEVER `operation = 'delete'`.** The operation column cannot
+answer "did this batch delete the resource" — `RegionalDataHandler::writeI18nFiles()` stages a `DELETE`
+row for every locale file dropped from `metadata.locales`, on a calendar that still exists, so a translator
+removing one language from a calendar's `i18n` set produces `DELETE` rows exactly as a real calendar
+deletion does. Keying the purge on the operation would revoke every editor and viewer on a live calendar
+because of an ordinary translation edit. `metadata.deletes_resource` is the flag `RegionalDataHandler` and
+`TestsHandler` set specifically to distinguish "the resource itself is gone" from "some of its files
+changed."
+
+**The purge requires EVERY row of the batch to carry the flag — it fails closed.** A batch that mixes a
+flagged row with an unflagged one (an exotic carry-forward can produce this) purges nothing; the tuples
+stay live until an operator or `ResourceTuplePurgeReconciler`'s sweep removes them. This asymmetry is
+deliberate: wrongly purging revokes real access on a live calendar, while wrongly not purging only leaves
+tuples live — exactly phase 2's status quo, which was already visible and recoverable.
+
+**`admin` tuples deliberately survive the purge.** Only the operational `editor`/`viewer` relations are
+removed, so ownership outlives a deletion — if the same resource id is recreated later (a diocese
+re-added, a test redefined), whoever administered it before the deletion still does, rather than the
+resource coming back ownerless.
+
+To find a deletion batch that merged, and confirm what it purged:
+
+```sql
+SELECT DISTINCT batch_id, resource_type, resource_id, merge_commit_sha, publication_settled_at
+  FROM sourcedata_change_requests
+ WHERE publication_status = 'merged'
+   AND metadata->>'deletes_resource' = 'true'
+ ORDER BY publication_settled_at DESC;
+```
+
+If a deletion batch merged before phase 3 was deployed, or the purge's own best-effort OpenFGA call
+failed (logged, not retried in-process — see `purgeIfResourceDeletion()`'s docblock), its former editors
+may still hold live tuples. Purge them by hand through the same `ResourceTuplePurgeServiceInterface`
+mapping (`RegionalDataHandler::fgaObjectForRequest()` / `changeResourceForRequest()` for calendars,
+`TestsHandler::changeResourceForTest()` for test definitions) — the admin tuple is retained by that purge,
+not removed, exactly as the automatic path retains it.
+
+## Deliberately not in phase 1, 2, or 3
+
+- **Re-validating a payload against its JSON schema at approval or publish time.** All three phases
+  validate once, at submit. Nothing re-checks a batch's content against its JSON schema between then and
+  the commit `SourceDataPublisher::publish()` pushes, even though real time — and potentially a schema
+  change — can pass in between. A batch approved against one schema and published after that schema
+  changed produces a pull request whose CI fails `lint:jsondata` — visible, but a backstop on the wrong
+  side of the gate.
+- **Per-file `base_sha` and rebase detection.** `recordPublication()` overwrites every row's `base_sha`
+  with the batch-level branch head, destroying the per-file bookkeeping a rebase check would need. See
+  "`base_sha` was speculative in phase 1 and is now defined" below.
 
 Neither is an oversight to be quietly forgotten; both are required before this system is considered
-complete.
+complete. Each has its own follow-up issue — see `docs/superpowers/2026-08-30-phase-3-handoff.md`.
+
+Purging OpenFGA authorization tuples for a deleted calendar or test definition, once mentioned here as
+deferred to phase 3, is no longer on this list — see "Closed: a deleted resource's editors used to keep
+access" above.
 
 **`base_sha` was speculative in phase 1 and is now defined.** Phase 1's runbook predicted the column
 would eventually hold "GitHub's blob sha." That is not what phase 2 actually wrote: `recordPublication()`

--- a/docs/superpowers/2026-08-30-phase-3-handoff.md
+++ b/docs/superpowers/2026-08-30-phase-3-handoff.md
@@ -1,0 +1,118 @@
+# Source-data change requests — phase 3 handoff
+
+Written 2026-08-30, at the end of the session that built phase 2. Phases 1 and 2 are merged to
+`development`. This exists so a fresh session can start phase 3 without re-deriving decisions or
+re-discovering traps.
+
+**Read first:** `docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md` — the
+approved design, corrected during phase 2 wherever it described things that were never built. Its
+"Phase 3: merge detection" section is the starting point.
+
+## Where things stand
+
+| Phase                                                      | State       | PR   |
+| ---------------------------------------------------------- | ----------- | ---- |
+| 1 — change request store, approval gate, RBAC-scoped views | merged      | #912 |
+| 2 — the publisher (GitHub App, Git Data API, rolling PRs)  | merged      | #914 |
+| 3 — merge detection                                        | not started | —    |
+
+Issue #902 tracks the whole arc and stays open until phase 3 lands.
+
+The GitHub App is registered and installed: `litcal-publisher[bot]`, bot user id `322643714`.
+`GITHUB_APP_*`, `GITHUB_REPOSITORY` and `GITHUB_BASE_BRANCH` are set in `.env.staging` on the live
+server.
+
+**Not yet done, and worth confirming before assuming phase 2 is live:** no cron entry invokes
+`scripts/publish-sourcedata.php`. Until one does, `/health` reports the publisher `ok` while
+approved batches sit at `publication_status = 'none'` indefinitely. Check
+`GET /health` → `source_data_publisher` on staging.
+
+## What phase 3 owes, inherited explicitly
+
+These are obligations phase 2 deferred **on the record**, not oversights. Each is documented in the
+spec or the runbook; do not treat any of them as newly discovered.
+
+1. **Purge OpenFGA tuples for deleted calendars and test definitions.** Today, deleting a calendar
+   through a change request leaves its authorization tuples live: a deleted diocese's former editors
+   retain edit access on an object whose files are gone. Only merge detection knows a deletion
+   actually happened, which is why it was deferred here rather than done at publish time. Use the
+   same resource-to-object mapping the disk path uses —
+   `RegionalDataHandler::changeResourceForRequest()` and `TestsHandler::changeResourceForTest()`.
+   CodeRabbit added a nuance worth keeping: consider **preserving the `admin` tuple** so ownership
+   survives a recreation of the same resource id.
+
+2. **Decide whether `closed` belongs in the accumulation-base exclusion.** The predicate excludes
+   `merged` and nothing else. Phase 3 is what first writes `closed`, so phase 3 must decide, and stop
+   relying on the `review_status = 'rejected'` filter to carry it by coincidence.
+
+3. **Claim ownership.** `releaseClaim()`'s `publication_status = 'queued'` guard identifies *a* claim,
+   not *whose*, so a late release can revoke another runner's live claim. Bounded and visible today.
+   The fix is a claim-token column compared in the `WHERE` — and phase 3 must touch the same columns
+   and the same claim/release/reclaim contract anyway, so doing both together costs one migration
+   instead of two.
+
+4. **`base_sha` is currently unusable for rebase detection.** `recordPublication()` overwrites every
+   row's `base_sha` with the batch-level branch head, destroying the per-file bookkeeping a rebase
+   check would need. Decide whether to keep per-file base shas before promising that feature.
+
+5. **Schema re-validation before publication.** `approveBatch()` is a single status `UPDATE`. A batch
+   approved against one schema and published after that schema changed will produce a PR whose CI
+   fails `lint:jsondata` — visible, but a backstop on the wrong side of the gate.
+
+## Decisions already made — do not re-open
+
+Each cost real analysis; the reasoning is in the spec and in the phase 2 commit messages.
+
+- **Ancestor exclusion is by age**, not by rewriting status. Marking an ancestor `merged` would assert
+  it was published, and the publisher skips already-merged rows — so a broken containment assumption
+  would lose content silently. An `id`-based tiebreak was tried and rejected: `id` is
+  `gen_random_uuid()` and carries no temporal information.
+- **`markBatchPublicationStatus()` is deliberately unconditional** — it is what marks `merged`.
+  `releaseClaim()` is the conditional one.
+- **`force: false` is load-bearing, not defensive.** Serialisation per resource is optimistic
+  concurrency: the loser of a same-resource race gets a 422 and retries against the moved ref.
+- **A 422 is not an outage** — GitHub answering in detail is evidence the API is healthy. It logs a
+  warning, continues, and still consumes an attempt.
+- **The decrees layout stays aggregate.** Splitting `decrees.json` would not remove the collision, as
+  the `i18n/` and `lectionary/` sidecars are aggregates across 14 locales too.
+- **There is no dead-letter queue.** A repeatedly failing batch is *parked* after
+  `MAX_PUBLISH_ATTEMPTS` and reported as `parked_batches` in `/health`.
+
+## Traps this project has already paid for
+
+Every one of these cost at least one round. They are not hypothetical.
+
+- **Green tests, dead in production.** Twice: an OIDC sub-route allowlist that no test could exercise
+  (tests inject `oidc_user` directly), and a logger whose default processors threw on every record the
+  runner wrote (tests injected a logger with no processors). When a script *constructs* what tests
+  *inject*, no test crosses that seam. Run the actual entry point.
+- **`GITHUB_REPOSITORY` is a GitHub Actions built-in.** It is injected into every job as `owner/repo`.
+  Tests that clear only `$_ENV` are undone by `getEnvString()`'s `getenv()` fallback — this failed CI
+  while passing locally every time. Clear both layers.
+- **Concurrency defects hide from single-threaded tests.** Four were found in this feature, each only
+  by *running* the concurrent case. PHP is single-threaded: use two connections, or `proc_open` two
+  real processes. A test that hand-duplicates the fixed SQL instead of calling the real method passes
+  even with the fix reverted.
+- **`openapi.json` is canonical literal UTF-8, zero `\uXXXX` escapes.** Never round-trip it through
+  `json_decode`/`json_encode` — PHP escapes non-ASCII by default and you get a ~14,000-line phantom
+  diff. Edit as text. `composer lint:jsondata`, not `lint:openapi`, is what catches encoding drift.
+- **`phpstan.neon.dist` scans `paths: [src]` only.** Anything under `scripts/` needs a standalone run.
+- **Unquoted heredocs run command substitution** and silently eat backticked words from commit
+  messages and docs. Use `<<'EOF'`.
+- **PostgreSQL rejects `FOR UPDATE` with `GROUP BY`.** The candidate-then-lock pattern in
+  `claimNextPublishableBatch()` exists for that reason, and its lock query repeats the claimability
+  predicate — without it, two runners claim the same batch once the first commits.
+
+## Related open issues
+
+- **#915** — publish from a Redis stream with cron as the backstop. Latency, not correctness; the
+  queue of record stays in Postgres. Note three of phase 2's four concurrency defects were in
+  machinery Redis consumer groups provide natively.
+- **#913** — `PATCH` on `/data/*` returns `201 Created` when updating. Pre-existing, published in
+  `openapi.json`, so fixing it is a contract change needing its own CHANGELOG entry.
+
+## Working agreements
+
+Feature branches from `development`, PRs target `development`, never `main`. Never `--no-verify`.
+Do not push immediately after committing — batch, because CodeRabbit is rate-limited. Never skip git
+hooks.

--- a/docs/superpowers/2026-08-30-phase-3-handoff.md
+++ b/docs/superpowers/2026-08-30-phase-3-handoff.md
@@ -31,7 +31,7 @@ approved batches sit at `publication_status = 'none'` indefinitely. Check
 
 These were obligations phase 2 deferred **on the record**, not oversights. Each was documented in the
 spec or the runbook; none was newly discovered mid-phase-3. Items 1–3 are now **done**; 4 and 5 remain
-and each needs its own follow-up issue (see "Follow-up issues to file" below).
+and each now has its own filed follow-up issue (see "Follow-up issues filed" below).
 
 1. **DONE — purge OpenFGA tuples for deleted calendars and test definitions.** Closed by
    `0142f820` (flag a batch that deletes a resource, not merely one of its files — `metadata.deletes_resource`),
@@ -65,23 +65,23 @@ and each needs its own follow-up issue (see "Follow-up issues to file" below).
 
 4. **Remains — `base_sha` is currently unusable for rebase detection.** `recordPublication()` still
    overwrites every row's `base_sha` with the batch-level branch head, destroying the per-file
-   bookkeeping a rebase check would need. Not attempted in phase 3; needs its own issue.
+   bookkeeping a rebase check would need. Not attempted in phase 3; filed as #917.
 
 5. **Remains — schema re-validation before publication.** `approveBatch()` is still a single status
    `UPDATE`. A batch approved against one schema and published after that schema changed will produce a
    PR whose CI fails `lint:jsondata` — visible, but a backstop on the wrong side of the gate. Not
-   attempted in phase 3; needs its own issue.
+   attempted in phase 3; filed as #918.
 
-### Follow-up issues to file
+### Follow-up issues filed
 
-Task 15 deliberately does not run `gh issue create` — creating public GitHub issues is left to the
-repository owner. The two issues to open, verbatim:
+Task 15 deliberately did not run `gh issue create` — creating public GitHub issues was left to the
+repository owner. Both are now filed:
 
-- **"Keep per-file `base_sha` so rebase detection is possible"** — Deferred from phase 3 (#902).
+- **#917 — "Keep per-file `base_sha` so rebase detection is possible"** — Deferred from phase 3 (#902).
   `recordPublication()` overwrites every row's `base_sha` with the batch-level branch head, destroying
   the per-file bookkeeping a rebase check needs. See
   `docs/superpowers/specs/2026-08-30-sourcedata-merge-detection-design.md`, Scope.
-- **"Re-validate a change request against the current schema before publishing"** — Deferred from
+- **#918 — "Re-validate a change request against the current schema before publishing"** — Deferred from
   phase 3 (#902). `approveBatch()` is a single status `UPDATE`, so a batch approved against one schema
   and published after that schema changed produces a pull request whose CI fails `lint:jsondata` — a
   backstop on the wrong side of the gate. See

--- a/docs/superpowers/2026-08-30-phase-3-handoff.md
+++ b/docs/superpowers/2026-08-30-phase-3-handoff.md
@@ -10,13 +10,13 @@ approved design, corrected during phase 2 wherever it described things that were
 
 ## Where things stand
 
-| Phase                                                      | State       | PR   |
-| ---------------------------------------------------------- | ----------- | ---- |
-| 1 — change request store, approval gate, RBAC-scoped views | merged      | #912 |
-| 2 — the publisher (GitHub App, Git Data API, rolling PRs)  | merged      | #914 |
-| 3 — merge detection                                        | not started | —    |
+| Phase                                                       | State  | PR             |
+| ------------------------------------------------------------|--------|----------------|
+| 1 — change request store, approval gate, RBAC-scoped views  | merged | #912           |
+| 2 — the publisher (GitHub App, Git Data API, rolling PRs)   | merged | #914           |
+| 3 — merge detection, the purge, claim ownership, the stream | built  | not yet opened |
 
-Issue #902 tracks the whole arc and stays open until phase 3 lands.
+Issue #902 tracks the whole arc and stays open until phase 3's pull request merges.
 
 The GitHub App is registered and installed: `litcal-publisher[bot]`, bot user id `322643714`.
 `GITHUB_APP_*`, `GITHUB_REPOSITORY` and `GITHUB_BASE_BRANCH` are set in `.env.staging` on the live
@@ -29,35 +29,63 @@ approved batches sit at `publication_status = 'none'` indefinitely. Check
 
 ## What phase 3 owes, inherited explicitly
 
-These are obligations phase 2 deferred **on the record**, not oversights. Each is documented in the
-spec or the runbook; do not treat any of them as newly discovered.
+These were obligations phase 2 deferred **on the record**, not oversights. Each was documented in the
+spec or the runbook; none was newly discovered mid-phase-3. Items 1–3 are now **done**; 4 and 5 remain
+and each needs its own follow-up issue (see "Follow-up issues to file" below).
 
-1. **Purge OpenFGA tuples for deleted calendars and test definitions.** Today, deleting a calendar
-   through a change request leaves its authorization tuples live: a deleted diocese's former editors
-   retain edit access on an object whose files are gone. Only merge detection knows a deletion
-   actually happened, which is why it was deferred here rather than done at publish time. Use the
-   same resource-to-object mapping the disk path uses —
-   `RegionalDataHandler::changeResourceForRequest()` and `TestsHandler::changeResourceForTest()`.
-   CodeRabbit added a nuance worth keeping: consider **preserving the `admin` tuple** so ownership
-   survives a recreation of the same resource id.
+1. **DONE — purge OpenFGA tuples for deleted calendars and test definitions.** Closed by
+   `0142f820` (flag a batch that deletes a resource, not merely one of its files — `metadata.deletes_resource`),
+   `22cfa70a` (purge a deleted resource's tuples once its deletion has merged), and `f85b321b`
+   (require unanimous `deletes_resource` across a batch before purging — the CodeRabbit nuance below
+   was folded into this same commit, not left as a follow-up). `MergePollRunner::purgeIfResourceDeletion()`
+   uses the same resource-to-object mapping the disk path uses —
+   `RegionalDataHandler::changeResourceForRequest()` and `TestsHandler::changeResourceForTest()` — and
+   is called only once a batch is confirmed `merged`. The `admin` tuple is preserved, exactly as
+   CodeRabbit's nuance asked, so ownership survives a recreation of the same resource id. See the
+   runbook's "Closed: a deleted resource's editors used to keep access".
 
-2. **Decide whether `closed` belongs in the accumulation-base exclusion.** The predicate excludes
-   `merged` and nothing else. Phase 3 is what first writes `closed`, so phase 3 must decide, and stop
-   relying on the `review_status = 'rejected'` filter to carry it by coincidence.
+2. **DONE — decided whether `closed` belongs in the accumulation-base exclusion.** Closed by
+   `024c9f21` (pin the closed-in-accumulation-base decision). `closed` is deliberately **not** added to
+   the publication-axis exclusion (`publication_status <> 'merged'` stays as-is): a closed-unmerged
+   batch published nothing, so the publication axis correctly still admits it to the accumulation base.
+   What excludes it is the review axis — phase 3 always writes `review_status = 'rejected'` alongside
+   `closed`, in the same update, rather than relying on that pairing as a coincidence the exclusion
+   predicate happens to benefit from. Pinned by
+   `SourceDataChangeRequestRepositoryTest::testClosedAndRejectedRowIsExcludedFromTheAccumulationBase()`
+   and its deliberate mirror image proving a `closed`-but-still-`approved` row stays in the base.
 
-3. **Claim ownership.** `releaseClaim()`'s `publication_status = 'queued'` guard identifies *a* claim,
-   not *whose*, so a late release can revoke another runner's live claim. Bounded and visible today.
-   The fix is a claim-token column compared in the `WHERE` — and phase 3 must touch the same columns
-   and the same claim/release/reclaim contract anyway, so doing both together costs one migration
-   instead of two.
+3. **DONE — claim ownership.** Closed by `9df17e80` (add `publish_claim_token` and
+   `publication_settled_at`), `2031ed8a` (a claim now identifies whose it is, not merely that one
+   exists), `75ab5056` (fix `releaseClaim()`'s docblock to describe the token it now checks), and
+   `56d57896` (`CLAIM_LOST` continues under branch contention, not stops). `claimNextPublishableBatch()`
+   stamps a fresh token on every claim; `releaseClaim()` and `reclaimStaleClaims()` both compare it in
+   their `WHERE` before clearing, so a late release from one runner can no longer revoke a different
+   runner's live claim. One migration did carry both this and the merge-detection schema work, as
+   anticipated.
 
-4. **`base_sha` is currently unusable for rebase detection.** `recordPublication()` overwrites every
-   row's `base_sha` with the batch-level branch head, destroying the per-file bookkeeping a rebase
-   check would need. Decide whether to keep per-file base shas before promising that feature.
+4. **Remains — `base_sha` is currently unusable for rebase detection.** `recordPublication()` still
+   overwrites every row's `base_sha` with the batch-level branch head, destroying the per-file
+   bookkeeping a rebase check would need. Not attempted in phase 3; needs its own issue.
 
-5. **Schema re-validation before publication.** `approveBatch()` is a single status `UPDATE`. A batch
-   approved against one schema and published after that schema changed will produce a PR whose CI
-   fails `lint:jsondata` — visible, but a backstop on the wrong side of the gate.
+5. **Remains — schema re-validation before publication.** `approveBatch()` is still a single status
+   `UPDATE`. A batch approved against one schema and published after that schema changed will produce a
+   PR whose CI fails `lint:jsondata` — visible, but a backstop on the wrong side of the gate. Not
+   attempted in phase 3; needs its own issue.
+
+### Follow-up issues to file
+
+Task 15 deliberately does not run `gh issue create` — creating public GitHub issues is left to the
+repository owner. The two issues to open, verbatim:
+
+- **"Keep per-file `base_sha` so rebase detection is possible"** — Deferred from phase 3 (#902).
+  `recordPublication()` overwrites every row's `base_sha` with the batch-level branch head, destroying
+  the per-file bookkeeping a rebase check needs. See
+  `docs/superpowers/specs/2026-08-30-sourcedata-merge-detection-design.md`, Scope.
+- **"Re-validate a change request against the current schema before publishing"** — Deferred from
+  phase 3 (#902). `approveBatch()` is a single status `UPDATE`, so a batch approved against one schema
+  and published after that schema changed produces a pull request whose CI fails `lint:jsondata` — a
+  backstop on the wrong side of the gate. See
+  `docs/superpowers/specs/2026-08-30-sourcedata-merge-detection-design.md`, Scope.
 
 ## Decisions already made — do not re-open
 
@@ -103,13 +131,42 @@ Every one of these cost at least one round. They are not hypothetical.
   `claimNextPublishableBatch()` exists for that reason, and its lock query repeats the claimability
   predicate — without it, two runners claim the same batch once the first commits.
 
+### What phase 3 added to this list
+
+- **`operation = 'delete'` does not mean a resource was deleted.**
+  `RegionalDataHandler::writeI18nFiles()` stages a `DELETE` row for every locale file dropped from
+  `metadata.locales`, on a calendar that still exists — a translator removing one language from a
+  calendar's `i18n` set produces the same operation an actual calendar deletion does. Keying an
+  authorization decision on the operation, rather than on the purpose-built
+  `metadata.deletes_resource` flag, would revoke every editor on a live calendar because of an ordinary
+  translation edit. This is the exact mistake `purgeIfResourceDeletion()` was written to avoid — see the
+  runbook's "Closed: a deleted resource's editors used to keep access".
+- **Sharing a pull request number is not being in its merge.** The rolling branch is per resource, so
+  two batches for that resource can share one `pr_number`. A reviewer clicking Merge concurrently with a
+  publish separates them: the merge takes the branch head a moment before the publish's own commit
+  lands, and that batch is left recorded against a pull request that closed without actually carrying
+  it. Marking it `merged` on the strength of the shared `pr_number` alone would assert it reached the
+  repository and lose its content silently — the publisher never re-attempts a row it believes already
+  `merged`. `MergePollRunner` verifies containment instead (an equality check against the merge head, or
+  one `compareCommits()` call), and a batch that fails the check is returned to `publication_status =
+  'none'` and republished under a fresh pull request rather than trusted. See the runbook's "`reset=N`
+  on the poll summary line".
+- **A DB-level state combination with no code path to reach it still needs a test.** `closed` paired
+  with `approved` (rather than the `rejected` phase 3 always writes alongside it) cannot be produced by
+  any handler today, but the accumulation-base predicate would silently do the wrong thing if someone
+  ever "simplified" it to exclude `closed` directly. `024c9f21` constructs that state with a raw `UPDATE`
+  in the test itself specifically to pin the current, correct behaviour against that future edit — see
+  `SourceDataChangeRequestRepositoryTest::testClosedButStillApprovedRowRemainsInTheAccumulationBase()`.
+
 ## Related open issues
 
-- **#915** — publish from a Redis stream with cron as the backstop. Latency, not correctness; the
-  queue of record stays in Postgres. Note three of phase 2's four concurrency defects were in
-  machinery Redis consumer groups provide natively.
 - **#913** — `PATCH` on `/data/*` returns `201 Created` when updating. Pre-existing, published in
   `openapi.json`, so fixing it is a contract change needing its own CHANGELOG entry.
+
+`#915` (publish from a Redis stream with cron as the backstop) is no longer open here: phase 3 built it
+— `bin/publish-sourcedata-consumer`, `SourceDataPublishNotifier`, `PublishConsumerLoop` — as the
+"consumer as an optional accelerator" the runbook's "Merge detection (phase 3)" section documents. Close
+`#915` alongside phase 3's own pull request, not as a separate follow-up.
 
 ## Working agreements
 

--- a/docs/superpowers/plans/2026-08-30-sourcedata-merge-detection-phase3.md
+++ b/docs/superpowers/plans/2026-08-30-sourcedata-merge-detection-phase3.md
@@ -1255,7 +1255,7 @@ Add to `src/Repositories/SourceDataChangeRequestRepository.php`, after `recordPu
         /** @var list<int|string> $numbers */
         $numbers = $stmt->fetchAll(PDO::FETCH_COLUMN);
 
-        return array_map(static fn (int|string $n): int => (int) $n, $numbers);
+        return array_map(static fn (int|string $n): int => self::requireInt($n, 'pr_number'), $numbers);
     }
 
     /**

--- a/docs/superpowers/plans/2026-08-30-sourcedata-merge-detection-phase3.md
+++ b/docs/superpowers/plans/2026-08-30-sourcedata-merge-detection-phase3.md
@@ -1922,13 +1922,18 @@ final class MergePollRunner
      */
     private function pollOne(int $prNumber): array
     {
-        $pr     = $this->client->getPullRequest($prNumber);
-        $tally  = ['merged' => 0, 'closed' => 0, 'reset' => 0];
-        $states = $this->repository->listOpenBatchesForPullRequest($prNumber);
+        $pr    = $this->client->getPullRequest($prNumber);
+        $tally = ['merged' => 0, 'closed' => 0, 'reset' => 0];
 
+        // Short-circuit BEFORE the repository read, not after. An open pull request is the
+        // steady-state majority — a reviewer has simply not got to it yet — so fetching its
+        // batches first would issue one needless GROUP BY per awaiting-review pull request on
+        // every single tick, for a result nothing then looks at.
         if ('open' === $pr->state) {
             return $tally;
         }
+
+        $states = $this->repository->listOpenBatchesForPullRequest($prNumber);
 
         if ($pr->isClosedUnmerged()) {
             foreach ($states as $batch) {

--- a/docs/superpowers/plans/2026-08-30-sourcedata-merge-detection-phase3.md
+++ b/docs/superpowers/plans/2026-08-30-sourcedata-merge-detection-phase3.md
@@ -1,0 +1,4332 @@
+# Source-data change requests, phase 3 — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect when a rolling pull request merges or closes, write the resulting status and side effects, and
+publish approved batches from a Redis stream with cron demoted to the backstop.
+
+**Architecture:** A `MergePollRunner` polls the distinct pull-request numbers among `open` rows and writes
+`merged` / `closed`, verifying per-batch containment before asserting anything was published. A claim token
+closes the ownership hole in phase 2's claim protocol. A best-effort `XADD` on approval wakes a long-lived
+consumer that calls the existing `PublishRunner` path; Postgres stays the queue of record.
+
+**Tech Stack:** PHP 8.4, PostgreSQL (PDO), Doctrine Migrations, ext-redis, Guzzle (PSR-18), Monolog, PHPUnit 12,
+PHPStan level 10, phpcs (PSR-12).
+
+**Spec:** `docs/superpowers/specs/2026-08-30-sourcedata-merge-detection-design.md`
+
+## Global Constraints
+
+- PHP >= 8.4. Short array syntax, 4-space indent, single quotes unless interpolating. PSR-12 via `phpcs`.
+- `composer analyse` is PHPStan **level 10**, and `phpstan.neon.dist` scans `paths: [src]` **only** — anything
+  under `scripts/` or `bin/` needs a standalone run: `vendor/bin/phpstan analyse --level=10 scripts/foo.php`.
+- Every non-HTTP caller of `LoggerFactory::create()` MUST pass `includeProcessors: false` (the sixth argument).
+  The default attaches `RequestResponseProcessor`, which THROWS on any record whose context lacks
+  `type => request|response`. This shipped once already and killed the runner inside its own catch blocks.
+- `GITHUB_REPOSITORY` is a GitHub Actions built-in injected into every job as `owner/repo`. Tests that clear it
+  must clear **both** `$_ENV` and the process environment (`putenv`), because `getEnvString()` falls back to
+  `getenv()`. Clearing only `$_ENV` passes locally and fails CI, every time.
+- Never round-trip `jsondata/schemas/openapi.json` through `json_decode`/`json_encode` — it is canonical literal
+  UTF-8 with zero `\uXXXX` escapes and PHP re-escapes non-ASCII, producing a ~14,000-line phantom diff. Edit it
+  as text. `composer lint:jsondata` is what catches encoding drift, not `lint:openapi`.
+- PostgreSQL rejects `FOR UPDATE` combined with `GROUP BY`. Any new claim-shaped query must keep the
+  candidate-then-lock pattern `claimNextPublishableBatch()` uses, repeating the claimability predicate on the
+  lock query.
+- Use quoted heredocs (`<<'EOF'`) for commit messages and docs. An unquoted heredoc runs command substitution
+  and silently eats backticked words.
+- Feature branches from `development`; PRs target `development`, never `main`. Never `--no-verify`. Do not push
+  immediately after committing — CodeRabbit is rate-limited; batch commits.
+- Work happens on branch `feature/sourcedata-merge-detection`, which already carries the spec commit.
+
+## File Structure
+
+**Created:**
+
+| Path                                                     | Responsibility                                             |
+| -------------------------------------------------------- | ---------------------------------------------------------- |
+| `src/Migrations/Version20260830120000.php`               | `publish_claim_token`, `publication_settled_at`, 2 indexes |
+| `src/Services/SourceData/PublishClaim.php`               | `{batchId, token}` returned by the claim                   |
+| `src/Services/GitHub/PullRequestState.php`               | `{state, merged, mergeCommitSha, headSha}`                 |
+| `src/Services/SourceData/MergePollRunner.php`            | Poll PRs, verify containment, write transitions            |
+| `src/Services/SourceData/MergePollRunResult.php`         | `{merged, closed, reset, unpollable, stoppedOnFailure}`    |
+| `src/Services/SourceData/SourceDataPublishNotifier.php`  | Best-effort `XADD` of a batch id                           |
+| `src/Services/SourceData/PublishConsumerLoop.php`        | Stream tick → `PublishRunner`, plus rate-limited idle poll |
+| `src/Services/SourceData/SourceDataPublisherFactory.php` | The one place all three entry points wire from             |
+| `scripts/poll-sourcedata-merges.php`                     | Cron entry for merge detection                             |
+| `bin/publish-sourcedata-consumer`                        | Long-lived stream consumer                                 |
+
+**Modified:**
+
+| Path                                                                 | Change                                                                 |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `src/Enum/ClaimReleaseOutcome.php`                                   | add `CLAIM_LOST`                                                       |
+| `src/Repositories/SourceDataChangeRequestRepository.php`             | claim token; merge-detection queries; `UNPUBLISHED_PREDICATE` docblock |
+| `src/Services/SourceData/PublishRunner.php`                          | carry the token through claim → release                                |
+| `src/Services/GitHub/GitHubGitDataClient.php`                        | `getPullRequest()`, `compareCommits()`                                 |
+| `src/Services/SourceData/SourceDataWriter.php`                       | `commit(ChangeResource, bool $deletesResource = false)`                |
+| `src/Services/SourceData/DiskSourceDataWriter.php`                   | accept and ignore the flag                                             |
+| `src/Services/SourceData/ChangeRequestSourceDataWriter.php`          | write `deletes_resource` into `metadata`                               |
+| `src/Handlers/RegionalDataHandler.php`                               | pass `true` from `deleteCalendar()`                                    |
+| `src/Handlers/TestsHandler.php`                                      | pass `true` from the DELETE path                                       |
+| `src/Handlers/Concerns/WritesSourceData.php`                         | thread the flag through `commitStagedFiles()`                          |
+| `src/Handlers/Admin/ChangeRequestAdminHandler.php`                   | `XADD` after `approve()` commits                                       |
+| `src/Repositories/UserNotificationRepository.php`                    | change-request inbox items                                             |
+| `src/Services/Outbox/StreamConsumerInterface.php`                    | `callable(string)`                                                     |
+| `src/Services/Outbox/RedisStreamConsumer.php`                        | payload field name as a constructor argument                           |
+| `src/Services/Outbox/ConsumerLoop.php`                               | `(int)` cast and the `<= 0` guard move here                            |
+| `src/Health.php`                                                     | `open_batches`, `oldest_open_age_seconds`                              |
+| `scripts/publish-sourcedata.php`                                     | wire through the factory                                               |
+| `docs/ops/change-request-runbook.md`, `.env.example`, `CHANGELOG.md` | operator-facing docs                                                   |
+
+---
+
+### Task 1: Migration — claim token and settled-at
+
+**Files:**
+
+- Create: `src/Migrations/Version20260830120000.php`
+- Test: `phpunit_tests/Repositories/SourceDataChangeRequestSchemaTest.php` (modify)
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: columns `sourcedata_change_requests.publish_claim_token UUID NULL` and
+  `sourcedata_change_requests.publication_settled_at TIMESTAMPTZ NULL`; indexes
+  `idx_scr_open_pr` and `idx_scr_settled_for_submitter`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `phpunit_tests/Repositories/SourceDataChangeRequestSchemaTest.php`:
+
+```php
+public function testPublishClaimTokenAndSettledAtColumnsExist(): void
+{
+    $stmt = self::$pdo->query(
+        "SELECT column_name, data_type, is_nullable
+           FROM information_schema.columns
+          WHERE table_name = 'sourcedata_change_requests'
+            AND column_name IN ('publish_claim_token', 'publication_settled_at')
+          ORDER BY column_name"
+    );
+    self::assertNotFalse($stmt);
+    /** @var list<array<string, mixed>> $rows */
+    $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+    self::assertCount(2, $rows, 'Both phase-3 columns must exist');
+    self::assertSame('publication_settled_at', $rows[0]['column_name']);
+    self::assertSame('timestamp with time zone', $rows[0]['data_type']);
+    self::assertSame('YES', $rows[0]['is_nullable']);
+    self::assertSame('publish_claim_token', $rows[1]['column_name']);
+    self::assertSame('uuid', $rows[1]['data_type']);
+    self::assertSame('YES', $rows[1]['is_nullable']);
+}
+
+public function testPhase3IndexesExist(): void
+{
+    $stmt = self::$pdo->query(
+        "SELECT indexname FROM pg_indexes
+          WHERE tablename = 'sourcedata_change_requests'
+            AND indexname IN ('idx_scr_open_pr', 'idx_scr_settled_for_submitter')
+          ORDER BY indexname"
+    );
+    self::assertNotFalse($stmt);
+    self::assertSame(
+        ['idx_scr_open_pr', 'idx_scr_settled_for_submitter'],
+        $stmt->fetchAll(\PDO::FETCH_COLUMN)
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/SourceDataChangeRequestSchemaTest.php --filter 'Phase3|PublishClaimToken'`
+
+Expected: FAIL — `assertCount(2, …)` sees 0 rows; the index query returns `[]`.
+
+If instead the whole class is SKIPPED, Postgres credentials are missing. Set `DB_HOST` / `DB_NAME` / `DB_USER` /
+`DB_PASSWORD` in `.env.local` (CI does this) before continuing — a skipped test proves nothing here.
+
+- [ ] **Step 3: Write the migration**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Phase 3: claim ownership, and a stable cursor for publication notifications.
+ *
+ * `publish_claim_token` closes the hole `releaseClaim()`'s own docblock describes: its
+ * `publication_status = 'queued'` guard identifies *a* claim, not *whose*, so a runner whose
+ * publish failed late can release a claim a DIFFERENT runner has since taken — spending a second
+ * attempt against `MAX_PUBLISH_ATTEMPTS` and parking a merely-slow batch in three cycles instead
+ * of five. Comparing a token in the `WHERE` makes a stale release match nothing, which costs the
+ * batch nothing.
+ *
+ * `publication_settled_at` is the notification cursor. `updated_at` cannot be: it moves on every
+ * claim, release, reclaim and record, so it answers "when was this row last touched" rather than
+ * "when did this become news for the submitter". This column is written once, by the transition to
+ * `merged` or `closed`, and is compared against `user_notification_state.last_notification_seen_at`.
+ */
+final class Version20260830120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add sourcedata_change_requests.publish_claim_token and .publication_settled_at (phase 3)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql('ALTER TABLE sourcedata_change_requests ADD COLUMN publish_claim_token UUID NULL');
+        $this->addSql('ALTER TABLE sourcedata_change_requests ADD COLUMN publication_settled_at TIMESTAMPTZ NULL');
+
+        $this->addSql(
+            'COMMENT ON COLUMN sourcedata_change_requests.publish_claim_token IS '
+            . "'Identifies WHICH runner holds the queued claim; compared in releaseClaim() so a stale release is a no-op'"
+        );
+        $this->addSql(
+            'COMMENT ON COLUMN sourcedata_change_requests.publication_settled_at IS '
+            . "'Written once, by the transition to merged or closed; the notification cursor (updated_at is not)'"
+        );
+
+        // The merge poller scans DISTINCT pr_number among open rows.
+        $this->addSql(
+            'CREATE INDEX idx_scr_open_pr ON sourcedata_change_requests (pr_number) '
+            . "WHERE publication_status = 'open'"
+        );
+
+        // The notifications inbox reads a submitter's settled batches, newest first.
+        $this->addSql(
+            'CREATE INDEX idx_scr_settled_for_submitter ON sourcedata_change_requests '
+            . '(submitted_by_sub, publication_settled_at DESC) WHERE publication_settled_at IS NOT NULL'
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql('DROP INDEX IF EXISTS idx_scr_settled_for_submitter');
+        $this->addSql('DROP INDEX IF EXISTS idx_scr_open_pr');
+        $this->addSql('ALTER TABLE sourcedata_change_requests DROP COLUMN IF EXISTS publication_settled_at');
+        $this->addSql('ALTER TABLE sourcedata_change_requests DROP COLUMN IF EXISTS publish_claim_token');
+    }
+}
+```
+
+- [ ] **Step 4: Apply the migration and run the test**
+
+Run:
+
+```bash
+vendor/bin/doctrine-migrations migrate --no-interaction
+vendor/bin/phpunit phpunit_tests/Repositories/SourceDataChangeRequestSchemaTest.php
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify `down()` actually reverses**
+
+Run:
+
+```bash
+vendor/bin/doctrine-migrations migrate prev --no-interaction
+vendor/bin/doctrine-migrations migrate --no-interaction
+```
+
+Expected: both succeed. A `down()` that leaves an index behind makes the second `migrate` fail on a duplicate
+index name — which is exactly what this step is for.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Migrations/Version20260830120000.php phpunit_tests/Repositories/SourceDataChangeRequestSchemaTest.php
+git commit -m "feat(sourcedata): add publish_claim_token and publication_settled_at"
+```
+
+---
+
+### Task 2: Claim ownership
+
+**Files:**
+
+- Create: `src/Services/SourceData/PublishClaim.php`
+- Modify: `src/Enum/ClaimReleaseOutcome.php`, `src/Repositories/SourceDataChangeRequestRepository.php`,
+  `src/Services/SourceData/PublishRunner.php`
+- Test: `phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php`,
+  `phpunit_tests/Services/SourceData/PublishRunnerTest.php`
+
+**Interfaces:**
+
+- Consumes: the columns from Task 1.
+- Produces:
+  - `final readonly class PublishClaim { public function __construct(public string $batchId, public string $token) {} }`
+  - `SourceDataChangeRequestRepository::claimNextPublishableBatch(array $skipBatchIds = []): ?PublishClaim`
+    (**was** `?string` — every caller changes)
+  - `SourceDataChangeRequestRepository::releaseClaim(string $batchId, string $token): ClaimReleaseOutcome`
+    (**was** one argument)
+  - `ClaimReleaseOutcome::CLAIM_LOST`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php`:
+
+```php
+public function testClaimReturnsATokenAndReleaseRequiresIt(): void
+{
+    $batchId = $this->submitAndApprove('editor-1');
+
+    $claim = $this->repo->claimNextPublishableBatch();
+    self::assertNotNull($claim);
+    self::assertSame($batchId, $claim->batchId);
+    self::assertMatchesRegularExpression(
+        '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/',
+        $claim->token
+    );
+
+    self::assertSame(ClaimReleaseOutcome::RELEASED, $this->repo->releaseClaim($batchId, $claim->token));
+}
+
+/**
+ * The defect this column exists for: runner A is slow, the grace period elapses,
+ * reclaimStaleClaims() frees the batch, runner B claims it — and then A's late release must
+ * NOT revoke B's live claim, and must NOT spend one of B's attempts.
+ */
+public function testStaleReleaseNeitherRevokesTheLiveClaimNorSpendsAnAttempt(): void
+{
+    $batchId = $this->submitAndApprove('editor-1');
+
+    $claimA = $this->repo->claimNextPublishableBatch();
+    self::assertNotNull($claimA);
+
+    // The grace period elapses and the reclaim frees it (spending A's attempt), then B claims.
+    $this->backdateUpdatedAt($batchId, 60);
+    self::assertSame(1, $this->repo->reclaimStaleClaims(new \DateTimeImmutable('-30 minutes')));
+    $claimB = $this->repo->claimNextPublishableBatch();
+    self::assertNotNull($claimB);
+    self::assertNotSame($claimA->token, $claimB->token);
+
+    $attemptsBefore = $this->publishAttempts($batchId);
+
+    // A's doomed GitHub call finally returns and A releases.
+    self::assertSame(ClaimReleaseOutcome::CLAIM_LOST, $this->repo->releaseClaim($batchId, $claimA->token));
+
+    self::assertSame(
+        ChangePublicationStatus::QUEUED->value,
+        $this->publicationStatus($batchId),
+        "B's claim must survive A's stale release"
+    );
+    self::assertSame($attemptsBefore, $this->publishAttempts($batchId), 'A stale release spends no attempt');
+}
+
+public function testRecordPublicationClearsTheClaimToken(): void
+{
+    $batchId = $this->submitAndApprove('editor-1');
+    $claim   = $this->repo->claimNextPublishableBatch();
+    self::assertNotNull($claim);
+
+    $this->repo->recordPublication($batchId, 'litcal-data/national_calendar/roman/US', 'sha1', 7, 'base');
+
+    self::assertNull($this->claimToken($batchId));
+}
+
+public function testReclaimStaleClaimsClearsTheClaimToken(): void
+{
+    $batchId = $this->submitAndApprove('editor-1');
+    self::assertNotNull($this->repo->claimNextPublishableBatch());
+
+    $this->backdateUpdatedAt($batchId, 60);
+    self::assertSame(1, $this->repo->reclaimStaleClaims(new \DateTimeImmutable('-30 minutes')));
+
+    self::assertNull($this->claimToken($batchId));
+}
+```
+
+Add these helpers to the same class (next to the existing fixtures):
+
+```php
+private function claimToken(string $batchId): ?string
+{
+    $stmt = self::$pdo->prepare(
+        'SELECT publish_claim_token FROM sourcedata_change_requests WHERE batch_id = :b LIMIT 1'
+    );
+    $stmt->execute(['b' => $batchId]);
+    $value = $stmt->fetchColumn();
+
+    return is_string($value) ? $value : null;
+}
+
+private function publishAttempts(string $batchId): int
+{
+    $stmt = self::$pdo->prepare(
+        'SELECT MAX(publish_attempts) FROM sourcedata_change_requests WHERE batch_id = :b'
+    );
+    $stmt->execute(['b' => $batchId]);
+
+    return (int) $stmt->fetchColumn();
+}
+
+private function publicationStatus(string $batchId): string
+{
+    $stmt = self::$pdo->prepare(
+        'SELECT publication_status FROM sourcedata_change_requests WHERE batch_id = :b LIMIT 1'
+    );
+    $stmt->execute(['b' => $batchId]);
+
+    return (string) $stmt->fetchColumn();
+}
+
+private function backdateUpdatedAt(string $batchId, int $minutesAgo): void
+{
+    $stmt = self::$pdo->prepare(
+        "UPDATE sourcedata_change_requests
+            SET updated_at = NOW() - (:mins || ' minutes')::interval
+          WHERE batch_id = :b"
+    );
+    $stmt->execute(['mins' => (string) $minutesAgo, 'b' => $batchId]);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php`
+
+Expected: FAIL — `claimNextPublishableBatch()` returns a `string`, so `$claim->batchId` is an
+"Attempt to read property on string" error, and `releaseClaim()` rejects the second argument.
+
+- [ ] **Step 3: Add the DTO and the enum case**
+
+`src/Services/SourceData/PublishClaim.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+/**
+ * A held claim on one publishable batch: which batch, and — the part phase 2 lacked — WHICH
+ * runner holds it.
+ *
+ * Phase 2 returned a bare batch id, so `releaseClaim()`'s `publication_status = 'queued'` guard
+ * could only ask "is this batch under SOME claim", never "under MINE". The token closes that:
+ * see {@see \LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository::releaseClaim()}.
+ */
+final readonly class PublishClaim
+{
+    public function __construct(
+        public string $batchId,
+        /** Generated inside the claiming transaction; cleared by record and by reclaim. */
+        public string $token
+    ) {
+    }
+}
+```
+
+In `src/Enum/ClaimReleaseOutcome.php`, add a case beside the existing four:
+
+```php
+    /**
+     * The batch is still `queued`, but under a DIFFERENT claim token — another runner holds it.
+     *
+     * Semantically distinct from both neighbours, which is why it is not folded into either.
+     * Not {@see SETTLED_ELSEWHERE}: nothing is published, so this is no evidence the work is
+     * done. Not {@see NOT_CLAIMED}: the batch is not lying around unclaimed, it is actively
+     * being published by someone else.
+     *
+     * Reached by the sequence `releaseClaim()`'s docblock describes: this runner was merely
+     * slow, the grace period elapsed, `reclaimStaleClaims()` freed the batch, and another
+     * runner claimed it before this runner's own doomed call returned. The release correctly
+     * does nothing — and, the point of the token, spends none of the batch's bounded attempts
+     * on a claim it does not hold.
+     */
+    case CLAIM_LOST = 'claim_lost';
+```
+
+Leave `isSettled()` alone: `CLAIM_LOST` is not settled, so the existing `match` returning false by
+default is already correct. Add a one-line comment there saying so, or the next reader will wonder.
+
+- [ ] **Step 4: Thread the token through the repository**
+
+In `claimNextPublishableBatch()`, generate the token in the same transaction and return the DTO. Replace the
+claim `UPDATE` and the `return $batchId;` inside the candidate loop with:
+
+```php
+                $token = $this->newBatchId(); // gen_random_uuid(); same generator, different purpose
+
+                $claim = $this->db->prepare(
+                    'UPDATE sourcedata_change_requests
+                        SET publication_status  = :queued,
+                            publish_claim_token = :token,
+                            updated_at          = NOW()
+                      WHERE batch_id = :batch_id'
+                );
+                $claim->execute([
+                    'queued'   => ChangePublicationStatus::QUEUED->value,
+                    'token'    => $token,
+                    'batch_id' => $batchId,
+                ]);
+
+                $this->db->commit();
+
+                return new PublishClaim($batchId, $token);
+```
+
+Change the signature to `: ?PublishClaim` and update its docblock's `@return`.
+
+In `releaseClaim()`, take the token and compare it. The observation half is unchanged; the `released` CTE gains
+one predicate, and the `match` gains one arm:
+
+```php
+    public function releaseClaim(string $batchId, string $token): ClaimReleaseOutcome
+    {
+        $stmt = $this->db->prepare(
+            'WITH observed AS (
+                 SELECT publication_status, publish_claim_token
+                   FROM sourcedata_change_requests
+                  WHERE batch_id = :batch_id
+                  LIMIT 1
+             ),
+             released AS (
+                 UPDATE sourcedata_change_requests
+                    SET publication_status  = :none,
+                        publish_claim_token = NULL,
+                        publish_attempts    = publish_attempts + 1,
+                        updated_at          = NOW()
+                  WHERE batch_id = :batch_id
+                    AND publication_status  = :queued
+                    AND publish_claim_token = :token
+                 RETURNING id
+             )
+             SELECT ( SELECT publication_status  FROM observed ) AS observed_status,
+                    ( SELECT publish_claim_token FROM observed ) AS observed_token,
+                    ( SELECT COUNT(*) FROM released )            AS released_rows'
+        );
+        $stmt->execute([
+            'none'     => ChangePublicationStatus::NONE->value,
+            'queued'   => ChangePublicationStatus::QUEUED->value,
+            'token'    => $token,
+            'batch_id' => $batchId,
+        ]);
+
+        /** @var array<string, mixed>|false $row */
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (false === $row) {
+            return ClaimReleaseOutcome::BATCH_MISSING;
+        }
+
+        if (self::requireInt($row['released_rows'] ?? null, 'released_rows') > 0) {
+            return ClaimReleaseOutcome::RELEASED;
+        }
+
+        $observed = $row['observed_status'] ?? null;
+        if (!is_string($observed)) {
+            return ClaimReleaseOutcome::BATCH_MISSING;
+        }
+
+        $observedToken = $row['observed_token'] ?? null;
+
+        // Still queued, but not under OUR token: another runner holds a live claim. Reported
+        // distinctly so the caller neither treats it as published (SETTLED_ELSEWHERE) nor as
+        // unclaimed work (NOT_CLAIMED) — and, critically, so no attempt is spent above.
+        if (
+            ChangePublicationStatus::QUEUED === ChangePublicationStatus::tryFrom($observed)
+            && is_string($observedToken)
+            && $observedToken !== $token
+        ) {
+            return ClaimReleaseOutcome::CLAIM_LOST;
+        }
+
+        return match (ChangePublicationStatus::tryFrom($observed)) {
+            ChangePublicationStatus::OPEN,
+            ChangePublicationStatus::MERGED,
+            ChangePublicationStatus::CLOSED => ClaimReleaseOutcome::SETTLED_ELSEWHERE,
+            default                         => ClaimReleaseOutcome::NOT_CLAIMED,
+        };
+    }
+```
+
+In `recordPublication()`, add `publish_claim_token = NULL,` to the `SET` list. In `reclaimStaleClaims()`, add
+`publish_claim_token = NULL,` to its `SET` list. Both are the same reason: no token may outlive the claim it
+names, or a later stale release could match by accident.
+
+- [ ] **Step 5: Update `PublishRunner` to carry the token**
+
+In `runOnce()`, `$batchId = $this->repository->claimNextPublishableBatch($attempted);` becomes:
+
+```php
+                $claim = $this->repository->claimNextPublishableBatch($attempted);
+```
+
+then `if (null === $claim) { break; }`, `$attempted[] = $claim->batchId;`, `$this->publisher->publish($claim->batchId);`
+and `$outcome = $this->releaseClaimSafely($claim->batchId, $claim->token);`. Every log context key `batch_id`
+becomes `$claim->batchId`.
+
+`releaseClaimSafely()` takes both and forwards both. Add `CLAIM_LOST` to the "everything else is a real failure"
+comment block — it stops the run, because this runner's publish did fail and the runner that actually holds the
+claim carries on regardless.
+
+- [ ] **Step 6: Run the tests**
+
+Run:
+
+```bash
+vendor/bin/phpunit phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
+vendor/bin/phpunit phpunit_tests/Services/SourceData/PublishRunnerTest.php
+```
+
+Expected: PASS. `PublishRunnerTest` may need its fakes updated where they assert on a returned batch id string.
+
+- [ ] **Step 7: Prove the token holds under REAL concurrency**
+
+PHP is single-threaded, so no in-process test can make two claims genuinely concurrent. Phase 2 found four
+concurrency defects and every one needed two real processes — and a test that hand-duplicates the fixed SQL
+instead of calling the real method passes even with the fix reverted.
+
+`SourceDataChangeRequestPublishQueueTest::testTwoRealConcurrentRunnersNeverClaimTheSameBatch()` already races
+two OS processes via `proc_open` against `claimNextPublishableBatch()` itself. It must be updated for the new
+return type and extended to assert on the token:
+
+```php
+/**
+ * Two real processes, one approved batch. Exactly one claim, and — the phase-3 half — the winner's
+ * token is the one on the row, so the loser cannot later release a claim it never held.
+ */
+public function testTwoRealConcurrentRunnersProduceOneClaimAndOneToken(): void
+{
+    $batchId = $this->submitAndApprove('editor-1');
+
+    $results = $this->raceTwoProcesses(<<<'PHP'
+        $claim = $repo->claimNextPublishableBatch();
+        echo json_encode(['batch' => $claim?->batchId, 'token' => $claim?->token]);
+    PHP);
+
+    $claimed = array_values(array_filter($results, static fn (array $r): bool => null !== $r['batch']));
+    self::assertCount(1, $claimed, 'exactly one process may claim the batch');
+    self::assertSame($batchId, $claimed[0]['batch']);
+    self::assertSame($claimed[0]['token'], $this->claimToken($batchId), 'the row carries the winner\'s token');
+
+    // The loser holds no token, so it cannot release the winner's claim even by guessing the batch id.
+    self::assertSame(
+        ClaimReleaseOutcome::CLAIM_LOST,
+        $this->repo->releaseClaim($batchId, '00000000-0000-4000-8000-000000000000')
+    );
+}
+```
+
+Reuse whatever `proc_open` helper that file already has for its existing race test rather than writing a second
+one; if it is inlined in that test, extract it to `raceTwoProcesses()` first, unchanged, as its own commit.
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php --filter Concurrent`
+
+Expected: PASS. Then **verify the test can fail**: temporarily drop `AND publish_claim_token = :token` from
+`releaseClaim()`, re-run, and confirm the last assertion fails. Restore it. A concurrency test that passes with
+the fix reverted is worse than no test, because it is believed.
+
+- [ ] **Step 8: Static analysis and style**
+
+Run: `composer analyse && composer lint`
+
+Expected: clean. PHPStan will flag any caller of the two changed signatures you missed — that is the point of
+running it before committing.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Services/SourceData/PublishClaim.php src/Enum/ClaimReleaseOutcome.php \
+        src/Repositories/SourceDataChangeRequestRepository.php src/Services/SourceData/PublishRunner.php \
+        phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php \
+        phpunit_tests/Services/SourceData/PublishRunnerTest.php
+git commit -m "fix(sourcedata): a claim now identifies whose it is, not merely that one exists"
+```
+
+---
+
+### Task 3: Pin the `closed` decision — no SQL change
+
+**Files:**
+
+- Modify: `src/Repositories/SourceDataChangeRequestRepository.php` (docblock only)
+- Test: `phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: nothing. This task changes no behaviour; it converts an accident into a decision and pins it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php`:
+
+```php
+/**
+ * A batch whose PR was closed unmerged is excluded from the accumulation base — by the REVIEW
+ * axis (phase 3 writes `rejected` alongside `closed`), not by the publication axis.
+ */
+public function testClosedAndRejectedRowIsExcludedFromTheAccumulationBase(): void
+{
+    $path    = 'jsondata/sourcedata/rite/roman/decrees/decrees.json';
+    $batchId = $this->submitDecrees('editor-1', '{"decrees":["A"]}');
+
+    $this->forceStatuses($batchId, review: 'rejected', publication: 'closed');
+
+    self::assertNull($this->repo->findUnpublishedContent($path, 'editor-1'));
+}
+
+/**
+ * The mirror image, and the reason the previous test proves what it claims: a `closed` row that
+ * is still `approved` IS in the base. `closed` means nothing reached the repository, so on the
+ * publication axis it genuinely belongs there. If this ever starts returning null, someone has
+ * "simplified" `publication_status <> 'merged'` into treating `closed` as published — which would
+ * silently drop an editor's un-merged work from their next submission.
+ *
+ * Constructible only by direct SQL: no code path produces closed-without-rejected.
+ */
+public function testClosedButStillApprovedRowRemainsInTheAccumulationBase(): void
+{
+    $path    = 'jsondata/sourcedata/rite/roman/decrees/decrees.json';
+    $batchId = $this->submitDecrees('editor-1', '{"decrees":["A"]}');
+
+    $this->forceStatuses($batchId, review: 'approved', publication: 'closed');
+
+    self::assertSame('{"decrees":["A"]}', $this->repo->findUnpublishedContent($path, 'editor-1'));
+}
+
+/**
+ * `closed` must never become the NOT_SUPERSEDED_BY_PUBLISHED floor. A closed batch published
+ * nothing, so using it as the floor would exclude older rows on the strength of content that
+ * never reached the repository.
+ */
+public function testClosedRowIsNotASupersessionFloor(): void
+{
+    $path = 'jsondata/sourcedata/rite/roman/decrees/decrees.json';
+
+    $older = $this->submitDecrees('editor-1', '{"decrees":["A"]}');
+    $this->repo->approveBatch($older, 'reviewer-1');
+
+    $newer = $this->submitDecrees('editor-1', '{"decrees":["A","B"]}');
+    $this->forceStatuses($newer, review: 'rejected', publication: 'closed');
+
+    // The closed batch is out of the base; the older approved one is still in it, NOT excluded
+    // by a floor the closed batch had no right to set.
+    self::assertSame('{"decrees":["A"]}', $this->repo->findUnpublishedContent($path, 'editor-1'));
+}
+```
+
+Helpers for the same class:
+
+```php
+private function submitDecrees(string $sub, string $content): string
+{
+    return $this->repo->submitBatch(
+        ChangeResource::decrees(),
+        [[
+            'path'      => 'jsondata/sourcedata/rite/roman/decrees/decrees.json',
+            'operation' => ChangeOperation::UPDATE,
+            'content'   => $content,
+        ]],
+        $sub,
+        'Editor',
+        $sub . '@example.test',
+        true
+    )['batch_id'];
+}
+
+/** Both statuses at once, by direct SQL — no code path produces every combination this pins. */
+private function forceStatuses(string $batchId, string $review, string $publication): void
+{
+    $stmt = self::$pdo->prepare(
+        'UPDATE sourcedata_change_requests
+            SET review_status = :r, publication_status = :p
+          WHERE batch_id = :b'
+    );
+    $stmt->execute(['r' => $review, 'p' => $publication, 'b' => $batchId]);
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php --filter Closed`
+
+Expected: **PASS on the first run.** This task asserts existing behaviour is already correct — that is the whole
+finding. If any of the three FAILS, stop: the predicate does not do what the spec concluded it does, and the
+design decision needs revisiting before you write a docblock claiming otherwise.
+
+- [ ] **Step 3: Record the decision in the docblock**
+
+In `src/Repositories/SourceDataChangeRequestRepository.php`, append to `UNPUBLISHED_PREDICATE`'s docblock:
+
+```php
+     * # Why `closed` is admitted here, and what actually excludes it
+     *
+     * `chk_scr_publication_status` also allows `closed`, which phase 3 writes when a pull request
+     * is closed unmerged. This predicate excludes only `merged`, so a `closed` row is ADMITTED by
+     * the publication half — and that is correct, not an oversight. The publication axis answers
+     * "is this row's content in the repository?", and for a pull request closed unmerged the
+     * answer is no.
+     *
+     * What excludes it is the review half: phase 3 writes `review_status = 'rejected'` alongside
+     * `closed`, and a rejected batch is no longer a proposal whatever became of its pull request.
+     * Two axes answering two different questions — the parent design's own reason for keeping them
+     * as two columns rather than one flattened enum.
+     *
+     * Decided in `docs/superpowers/specs/2026-08-30-sourcedata-merge-detection-design.md` and
+     * pinned by `SourceDataChangeRequestRepositoryTest::testClosedAndRejectedRowIsExcludedFromTheAccumulationBase()`
+     * and its deliberate mirror image `…ClosedButStillApprovedRowRemainsInTheAccumulationBase()`.
+     * Do NOT "fix" this by adding `closed` to the exclusion: that would drop an editor's un-merged
+     * work from their next submission on the strength of content that never reached the repository.
+```
+
+And to `NOT_SUPERSEDED_BY_PUBLISHED`'s docblock:
+
+```php
+     * The floor is `publication_status = 'merged'` ALONE, never `IN ('merged','closed')`. A closed
+     * batch published nothing, so letting it set the floor would exclude older rows on the strength
+     * of content that is not in the repository. Pinned by `testClosedRowIsNotASupersessionFloor()`.
+```
+
+- [ ] **Step 4: Re-run and lint**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php && composer lint`
+
+Expected: PASS, clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Repositories/SourceDataChangeRequestRepository.php \
+        phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php
+git commit -m "test(sourcedata): pin the closed-in-accumulation-base decision"
+```
+
+---
+
+### Task 4: `getPullRequest()` and `compareCommits()`
+
+**Files:**
+
+- Create: `src/Services/GitHub/PullRequestState.php`
+- Modify: `src/Services/GitHub/GitHubGitDataClient.php`
+- Test: `phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces:
+  - `final readonly class PullRequestState { public string $state; public bool $merged; public ?string $mergeCommitSha; public string $headSha; }`
+  - `GitHubGitDataClient::getPullRequest(int $number): PullRequestState`
+  - `GitHubGitDataClient::compareCommits(string $base, string $head): string` — returns GitHub's
+    `status`: one of `identical`, `ahead`, `behind`, `diverged`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php`, following that file's existing
+`MockHandler` + `HandlerStack` setup:
+
+```php
+public function testGetPullRequestReadsStateMergedAndShas(): void
+{
+    $client = $this->clientForResponses([
+        new GuzzleResponse(200, [], json_encode([
+            'number'           => 42,
+            'state'            => 'closed',
+            'merged'           => true,
+            'merge_commit_sha' => 'merge-sha',
+            'head'             => ['sha' => 'head-sha'],
+        ], JSON_THROW_ON_ERROR)),
+    ]);
+
+    $pr = $client->getPullRequest(42);
+
+    self::assertSame('closed', $pr->state);
+    self::assertTrue($pr->merged);
+    self::assertSame('merge-sha', $pr->mergeCommitSha);
+    self::assertSame('head-sha', $pr->headSha);
+}
+
+public function testGetPullRequestTreatsA404AsAFailureNotAValue(): void
+{
+    $client = $this->clientForResponses([
+        new GuzzleResponse(404, [], json_encode(['message' => 'Not Found'], JSON_THROW_ON_ERROR)),
+    ]);
+
+    $this->expectException(GitHubApiException::class);
+    $client->getPullRequest(42);
+}
+
+/**
+ * An open pull request has no merge commit. Null, not the empty string, so a caller cannot
+ * accidentally record '' as a merge_commit_sha.
+ */
+public function testGetPullRequestReportsNoMergeCommitWhileOpen(): void
+{
+    $client = $this->clientForResponses([
+        new GuzzleResponse(200, [], json_encode([
+            'number'           => 42,
+            'state'            => 'open',
+            'merged'           => false,
+            'merge_commit_sha' => null,
+            'head'             => ['sha' => 'head-sha'],
+        ], JSON_THROW_ON_ERROR)),
+    ]);
+
+    $pr = $client->getPullRequest(42);
+
+    self::assertFalse($pr->merged);
+    self::assertNull($pr->mergeCommitSha);
+}
+
+public function testCompareCommitsReturnsGithubStatus(): void
+{
+    $client = $this->clientForResponses([
+        new GuzzleResponse(200, [], json_encode(['status' => 'behind'], JSON_THROW_ON_ERROR)),
+    ]);
+
+    self::assertSame('behind', $client->compareCommits('aaa', 'bbb'));
+}
+
+public function testCompareCommitsThrowsWhenGithubReturnsNoStatus(): void
+{
+    $client = $this->clientForResponses([
+        new GuzzleResponse(200, [], json_encode(['files' => []], JSON_THROW_ON_ERROR)),
+    ]);
+
+    $this->expectException(GitHubApiException::class);
+    $client->compareCommits('aaa', 'bbb');
+}
+```
+
+If `clientForResponses()` does not already exist in that test class, add it, mirroring how
+`SourceDataPublisherTest` builds its transport:
+
+```php
+/** @param list<GuzzleResponse> $responses */
+private function clientForResponses(array $responses): GitHubGitDataClient
+{
+    $http = new GuzzleClient(['handler' => HandlerStack::create(new MockHandler($responses))]);
+
+    return new GitHubGitDataClient('Liturgical-Calendar', 'LiturgicalCalendarAPI', $this->auth($http), $http);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php --filter 'PullRequest|Compare'`
+
+Expected: FAIL — `Call to undefined method … ::getPullRequest()`.
+
+- [ ] **Step 3: Add the DTO**
+
+`src/Services/GitHub/PullRequestState.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\GitHub;
+
+/**
+ * The three facts merge detection needs about a rolling pull request, plus the one it needs to
+ * decide WHICH batches the merge actually carried.
+ *
+ * `$headSha` is here because "this batch's pull request merged" is not the same as "this batch
+ * was in the merge": a reviewer clicking Merge concurrently with a publish leaves a commit on the
+ * branch and outside the merge. See
+ * {@see \LiturgicalCalendar\Api\Services\SourceData\MergePollRunner} for what is done with it.
+ */
+final readonly class PullRequestState
+{
+    public function __construct(
+        /** GitHub's `state`: `open` or `closed`. A merged PR is always `closed`. */
+        public string $state,
+        public bool $merged,
+        /** Null while the pull request is open — never the empty string. */
+        public ?string $mergeCommitSha,
+        /** The head commit at the time of this read; at merge time, what was merged. */
+        public string $headSha
+    ) {
+    }
+
+    public function isClosedUnmerged(): bool
+    {
+        return 'closed' === $this->state && false === $this->merged;
+    }
+}
+```
+
+- [ ] **Step 4: Add the two client methods**
+
+Insert after `findOpenPullRequest()` in `src/Services/GitHub/GitHubGitDataClient.php`:
+
+```php
+    /**
+     * Read one pull request's merge state.
+     *
+     * A 404 is a real failure here, not a value. `getRef()` is the only method in this class that
+     * treats one as a value, and it does so because a missing branch is the expected state before
+     * a resource's first publication. A pull request number came out of our own database, written
+     * by our own publisher — if GitHub cannot find it, something is wrong with the repository or
+     * the credential, and reporting "not merged" would hide that forever.
+     *
+     * @throws GitHubApiException If GitHub responds with a non-2xx status, or the payload carries
+     *                            no usable `state` / `head.sha`
+     */
+    public function getPullRequest(int $number): PullRequestState
+    {
+        $response = $this->send('GET', '/pulls/' . $number, null);
+        $decoded  = $this->decodeOrThrow($response);
+
+        $state = $decoded['state'] ?? null;
+        if (!is_string($state) || '' === $state) {
+            throw new GitHubApiException($response->getStatusCode(), 'GitHub returned a pull request with no usable state');
+        }
+
+        $head    = $decoded['head'] ?? null;
+        $headSha = is_array($head) ? ( $head['sha'] ?? null ) : null;
+        if (!is_string($headSha) || '' === $headSha) {
+            throw new GitHubApiException($response->getStatusCode(), 'GitHub returned a pull request with no usable head.sha');
+        }
+
+        $mergeCommitSha = $decoded['merge_commit_sha'] ?? null;
+
+        return new PullRequestState(
+            $state,
+            true === ( $decoded['merged'] ?? false ),
+            is_string($mergeCommitSha) && '' !== $mergeCommitSha ? $mergeCommitSha : null,
+            $headSha
+        );
+    }
+
+    /**
+     * Compare two commits, returning GitHub's `status`: `identical`, `ahead`, `behind` or
+     * `diverged`, read as "$head is <status> $base".
+     *
+     * Merge detection calls this as `compareCommits($batchCommitSha, $mergeCommitSha)` and treats
+     * `ahead` or `identical` as "the merge commit's history contains the batch's commit". Anything
+     * else means it does not, and the batch must NOT be marked merged.
+     *
+     * A missing `status` is an error rather than a default, because every default is wrong here:
+     * assuming contained loses content silently, assuming not-contained republishes work that is
+     * already in the repository. Neither guess is safe, so this refuses to guess.
+     *
+     * @throws GitHubApiException If GitHub responds with a non-2xx status, or returns no `status`
+     */
+    public function compareCommits(string $base, string $head): string
+    {
+        $response = $this->send(
+            'GET',
+            '/compare/' . rawurlencode($base) . '...' . rawurlencode($head),
+            null
+        );
+        $decoded  = $this->decodeOrThrow($response);
+
+        $status = $decoded['status'] ?? null;
+        if (!is_string($status) || '' === $status) {
+            throw new GitHubApiException($response->getStatusCode(), 'GitHub returned a comparison with no usable status');
+        }
+
+        return $status;
+    }
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Services/GitHub/PullRequestState.php src/Services/GitHub/GitHubGitDataClient.php \
+        phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php
+git commit -m "feat(github): read a pull request's merge state and compare two commits"
+```
+
+---
+
+### Task 5: Repository queries for merge detection
+
+**Files:**
+
+- Modify: `src/Repositories/SourceDataChangeRequestRepository.php`
+- Test: `phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php`
+
+**Interfaces:**
+
+- Consumes: `ChangePublicationStatus`, `ChangeReviewStatus`, the columns from Task 1.
+- Produces:
+  - `listOpenPullRequestNumbers(): list<int>` — DISTINCT `pr_number`, oldest first
+  - `countOpenBatchesWithoutPullRequest(): int`
+  - `listOpenBatchesForPullRequest(int $prNumber): list<array{batch_id: string, commit_sha: ?string}>`
+  - `markBatchMerged(string $batchId, string $mergeCommitSha): int`
+  - `markBatchClosedUnmerged(string $batchId, string $reason): int`
+  - `returnBatchToUnpublished(string $batchId): int`
+  - `openBatchStats(): array{open_batches: int, oldest_open_age_seconds: int}`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php`:
+
+```php
+private function publishTo(string $batchId, int $prNumber, string $commitSha): void
+{
+    $claim = $this->repo->claimNextPublishableBatch();
+    self::assertNotNull($claim);
+    self::assertSame($batchId, $claim->batchId);
+    $this->repo->recordPublication($batchId, 'litcal-data/national_calendar/roman/US', $commitSha, $prNumber, 'base');
+}
+
+public function testListOpenPullRequestNumbersDeduplicatesAndOrdersOldestFirst(): void
+{
+    $first  = $this->submitAndApprove('editor-1', 'US');
+    $this->publishTo($first, 11, 'sha-a');
+    $second = $this->submitAndApprove('editor-2', 'US');
+    $this->publishTo($second, 11, 'sha-b');   // same rolling PR
+    $third  = $this->submitAndApprove('editor-3', 'IT');
+    $this->publishTo($third, 22, 'sha-c');
+
+    self::assertSame([11, 22], $this->repo->listOpenPullRequestNumbers());
+}
+
+public function testListOpenBatchesForPullRequestReturnsEveryBatchOnIt(): void
+{
+    $first  = $this->submitAndApprove('editor-1', 'US');
+    $this->publishTo($first, 11, 'sha-a');
+    $second = $this->submitAndApprove('editor-2', 'US');
+    $this->publishTo($second, 11, 'sha-b');
+
+    $rows = $this->repo->listOpenBatchesForPullRequest(11);
+
+    self::assertCount(2, $rows);
+    self::assertSame(
+        ['sha-a', 'sha-b'],
+        array_column($rows, 'commit_sha')
+    );
+}
+
+public function testMarkBatchMergedRecordsTheMergeCommitAndSettledAt(): void
+{
+    $batchId = $this->submitAndApprove('editor-1');
+    $this->publishTo($batchId, 11, 'sha-a');
+
+    self::assertSame(1, $this->repo->markBatchMerged($batchId, 'merge-sha'));
+
+    $row = $this->firstRow($batchId);
+    self::assertSame(ChangePublicationStatus::MERGED->value, $row['publication_status']);
+    self::assertSame('merge-sha', $row['merge_commit_sha']);
+    self::assertNotNull($row['publication_settled_at']);
+    self::assertSame(ChangeReviewStatus::APPROVED->value, $row['review_status'], 'a merge does not re-review');
+}
+
+public function testMarkBatchClosedUnmergedAlsoRejectsAndGivesAReason(): void
+{
+    $batchId = $this->submitAndApprove('editor-1');
+    $this->publishTo($batchId, 11, 'sha-a');
+
+    self::assertSame(1, $this->repo->markBatchClosedUnmerged($batchId, 'Pull request #11 was closed without merging.'));
+
+    $row = $this->firstRow($batchId);
+    self::assertSame(ChangePublicationStatus::CLOSED->value, $row['publication_status']);
+    self::assertSame(ChangeReviewStatus::REJECTED->value, $row['review_status']);
+    self::assertSame('Pull request #11 was closed without merging.', $row['rejected_reason']);
+    self::assertNotNull($row['publication_settled_at']);
+}
+
+/**
+ * Both transitions are guarded on `open`, so two racing pollers produce one transition and one
+ * no-op rather than two writes of possibly-different merge shas.
+ */
+public function testTransitionsAreGuardedOnOpen(): void
+{
+    $batchId = $this->submitAndApprove('editor-1');
+    $this->publishTo($batchId, 11, 'sha-a');
+
+    self::assertSame(1, $this->repo->markBatchMerged($batchId, 'merge-sha'));
+    self::assertSame(0, $this->repo->markBatchMerged($batchId, 'other-sha'), 'second poller must be a no-op');
+    self::assertSame('merge-sha', $this->firstRow($batchId)['merge_commit_sha']);
+}
+
+/**
+ * A batch on a merged PR whose commit was NOT in the merge goes back to claimable, clearing the
+ * attempts it never spent, so the next publish opens a fresh pull request carrying it.
+ */
+public function testReturnBatchToUnpublishedMakesItClaimableAgain(): void
+{
+    $batchId = $this->submitAndApprove('editor-1');
+    $this->publishTo($batchId, 11, 'sha-a');
+
+    self::assertSame(1, $this->repo->returnBatchToUnpublished($batchId));
+
+    $row = $this->firstRow($batchId);
+    self::assertSame(ChangePublicationStatus::NONE->value, $row['publication_status']);
+    self::assertSame(0, (int) $row['publish_attempts']);
+    self::assertSame('sha-a', $row['commit_sha'], 'git identifiers are kept for forensics');
+
+    $claim = $this->repo->claimNextPublishableBatch();
+    self::assertNotNull($claim);
+    self::assertSame($batchId, $claim->batchId);
+}
+
+public function testCountOpenBatchesWithoutPullRequestFindsTheUnpollableOnes(): void
+{
+    $batchId = $this->submitAndApprove('editor-1');
+    $this->publishTo($batchId, 11, 'sha-a');
+    self::assertSame(0, $this->repo->countOpenBatchesWithoutPullRequest());
+
+    self::$pdo->exec("UPDATE sourcedata_change_requests SET pr_number = NULL WHERE batch_id = '{$batchId}'");
+    self::assertSame(1, $this->repo->countOpenBatchesWithoutPullRequest());
+}
+```
+
+Helper for the same class:
+
+```php
+/** @return array<string, mixed> */
+private function firstRow(string $batchId): array
+{
+    $stmt = self::$pdo->prepare('SELECT * FROM sourcedata_change_requests WHERE batch_id = :b LIMIT 1');
+    $stmt->execute(['b' => $batchId]);
+    /** @var array<string, mixed>|false $row */
+    $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+    self::assertNotFalse($row);
+
+    return $row;
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php`
+
+Expected: FAIL — `Call to undefined method … ::listOpenPullRequestNumbers()`.
+
+- [ ] **Step 3: Implement the queries**
+
+Add to `src/Repositories/SourceDataChangeRequestRepository.php`, after `recordPublication()`:
+
+```php
+    /**
+     * The DISTINCT pull request numbers among rows still `open`, oldest first.
+     *
+     * DISTINCT, not one row per batch, because the rolling branch is per RESOURCE: several
+     * batches for one resource are published onto one branch and reuse one open pull request via
+     * `findOpenPullRequest()`. Polling per batch would ask GitHub the same question N times and
+     * get the same answer N times.
+     *
+     * `MIN(created_at)` orders it, so the oldest unresolved pull request is polled first and a
+     * long queue cannot starve it.
+     *
+     * Rows with a NULL `pr_number` are deliberately NOT returned here — they are unpollable — and
+     * are counted separately by {@see countOpenBatchesWithoutPullRequest()} so they cannot be
+     * silently skipped.
+     *
+     * @return list<int>
+     */
+    public function listOpenPullRequestNumbers(): array
+    {
+        $stmt = $this->db->prepare(
+            'SELECT pr_number
+               FROM sourcedata_change_requests
+              WHERE publication_status = :open
+                AND pr_number IS NOT NULL
+              GROUP BY pr_number
+              ORDER BY MIN(created_at) ASC'
+        );
+        $stmt->execute(['open' => ChangePublicationStatus::OPEN->value]);
+
+        /** @var list<int|string> $numbers */
+        $numbers = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+        return array_map(static fn (int|string $n): int => (int) $n, $numbers);
+    }
+
+    /**
+     * How many batches are `open` with no pull request number to poll.
+     *
+     * Never non-zero in practice: `SourceDataPublisher` opens a pull request whenever
+     * `findOpenPullRequest()` returns null, and `openPullRequest()` returns an `int` or throws. So
+     * a non-zero count here is an UNEXPLAINED state — a batch that is stuck forever, since nothing
+     * will ever poll it. Counted rather than filtered out of the poller's query, because a row
+     * quietly excluded from a `WHERE` is exactly as invisible as one stranded `queued`, which is
+     * the defect class this feature keeps rediscovering.
+     */
+    public function countOpenBatchesWithoutPullRequest(): int
+    {
+        $stmt = $this->db->prepare(
+            'SELECT COUNT(DISTINCT batch_id) AS unpollable
+               FROM sourcedata_change_requests
+              WHERE publication_status = :open
+                AND pr_number IS NULL'
+        );
+        $stmt->execute(['open' => ChangePublicationStatus::OPEN->value]);
+
+        /** @var array<string, mixed>|false $row */
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return false === $row ? 0 : self::requireInt($row['unpollable'] ?? null, 'unpollable');
+    }
+
+    /**
+     * Every `open` batch recorded against this pull request, with the commit it was published as.
+     *
+     * One row per BATCH, not per file: `recordPublication()` writes one commit sha across the
+     * whole batch, so `MIN(commit_sha)` over the group is that single value, not an arbitrary
+     * pick. Ordered by `MIN(created_at)` so the caller sees them in publication order.
+     *
+     * @return list<array{batch_id: string, commit_sha: ?string}>
+     */
+    public function listOpenBatchesForPullRequest(int $prNumber): array
+    {
+        $stmt = $this->db->prepare(
+            'SELECT batch_id, MIN(commit_sha) AS commit_sha
+               FROM sourcedata_change_requests
+              WHERE publication_status = :open
+                AND pr_number = :pr
+              GROUP BY batch_id
+              ORDER BY MIN(created_at) ASC'
+        );
+        $stmt->execute(['open' => ChangePublicationStatus::OPEN->value, 'pr' => $prNumber]);
+
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(
+            static fn (array $row): array => [
+                'batch_id'   => self::requireString($row['batch_id'] ?? null, 'batch_id'),
+                'commit_sha' => is_string($row['commit_sha'] ?? null) ? $row['commit_sha'] : null,
+            ],
+            $rows
+        );
+    }
+
+    /**
+     * Record that a batch's content reached the base branch.
+     *
+     * Guarded on `publication_status = 'open'`, unlike {@see markBatchPublicationStatus()} which is
+     * deliberately unconditional. The guard makes two racing pollers produce one transition and one
+     * no-op instead of two writes of possibly-different merge shas — which is why the poller needs
+     * no claim protocol of its own.
+     *
+     * `review_status` is untouched: a merge is not a review, and the batch was already approved.
+     *
+     * @return int Rows transitioned.
+     */
+    public function markBatchMerged(string $batchId, string $mergeCommitSha): int
+    {
+        $stmt = $this->db->prepare(
+            'UPDATE sourcedata_change_requests
+                SET publication_status     = :merged,
+                    merge_commit_sha       = :merge_commit_sha,
+                    publication_settled_at = NOW(),
+                    updated_at             = NOW()
+              WHERE batch_id = :batch_id
+                AND publication_status = :open'
+        );
+        $stmt->execute([
+            'merged'           => ChangePublicationStatus::MERGED->value,
+            'merge_commit_sha' => $mergeCommitSha,
+            'batch_id'         => $batchId,
+            'open'             => ChangePublicationStatus::OPEN->value,
+        ]);
+
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Record that a batch's pull request was closed without merging.
+     *
+     * Writes `review_status = 'rejected'` with it, which is what keeps the batch out of the
+     * accumulation base — see `UNPUBLISHED_PREDICATE`'s docblock, where that pairing is a decision
+     * rather than a coincidence. `rejected_reason` is generated rather than left null so an
+     * editor's history explains why a batch they never withdrew is rejected.
+     *
+     * Nothing needs reverting: the change was never live anywhere.
+     *
+     * @return int Rows transitioned.
+     */
+    public function markBatchClosedUnmerged(string $batchId, string $reason): int
+    {
+        $stmt = $this->db->prepare(
+            'UPDATE sourcedata_change_requests
+                SET publication_status     = :closed,
+                    review_status          = :rejected,
+                    rejected_reason        = :reason,
+                    publication_settled_at = NOW(),
+                    updated_at             = NOW()
+              WHERE batch_id = :batch_id
+                AND publication_status = :open'
+        );
+        $stmt->execute([
+            'closed'   => ChangePublicationStatus::CLOSED->value,
+            'rejected' => ChangeReviewStatus::REJECTED->value,
+            'reason'   => $reason,
+            'batch_id' => $batchId,
+            'open'     => ChangePublicationStatus::OPEN->value,
+        ]);
+
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Put an `open` batch back to claimable, because its pull request merged WITHOUT it.
+     *
+     * Reachable whenever a reviewer merges concurrently with a publish: the batch's commit lands
+     * on the branch, the merge takes the head it had a moment earlier, and the batch is left
+     * pointing at a pull request that closed without carrying it. Marking it `merged` would assert
+     * it reached the repository and make the publisher skip it forever, losing its content
+     * silently — the same failure the age-based ancestor exclusion exists to avoid.
+     *
+     * `publish_attempts` is cleared: the batch spent no attempt, it was simply overtaken. The git
+     * identifiers (`branch`, `commit_sha`, `pr_number`) are deliberately KEPT, so an operator
+     * asking "what happened to this batch" can see which pull request passed it by.
+     *
+     * @return int Rows transitioned.
+     */
+    public function returnBatchToUnpublished(string $batchId): int
+    {
+        $stmt = $this->db->prepare(
+            'UPDATE sourcedata_change_requests
+                SET publication_status  = :none,
+                    publish_attempts    = 0,
+                    publish_claim_token = NULL,
+                    updated_at          = NOW()
+              WHERE batch_id = :batch_id
+                AND publication_status = :open'
+        );
+        $stmt->execute([
+            'none'     => ChangePublicationStatus::NONE->value,
+            'batch_id' => $batchId,
+            'open'     => ChangePublicationStatus::OPEN->value,
+        ]);
+
+        return $stmt->rowCount();
+    }
+
+    /**
+     * How many batches are awaiting a merge decision, and how long the oldest has waited.
+     *
+     * Reported by `GET /health`. An open batch is NOT an error — a pull request awaiting review is
+     * the ordinary state — so the age is what carries the signal: a value that keeps climbing past
+     * any plausible review time means the poller is not running at all.
+     *
+     * @return array{open_batches: int, oldest_open_age_seconds: int}
+     */
+    public function openBatchStats(): array
+    {
+        $stmt = $this->db->prepare(
+            'SELECT COUNT(DISTINCT batch_id) AS open_batches,
+                    COALESCE(EXTRACT(EPOCH FROM (NOW() - MIN(updated_at))), 0) AS oldest_age
+               FROM sourcedata_change_requests
+              WHERE publication_status = :open'
+        );
+        $stmt->execute(['open' => ChangePublicationStatus::OPEN->value]);
+
+        /** @var array<string, mixed>|false $row */
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (false === $row) {
+            return ['open_batches' => 0, 'oldest_open_age_seconds' => 0];
+        }
+
+        return [
+            'open_batches'            => self::requireInt($row['open_batches'] ?? null, 'open_batches'),
+            'oldest_open_age_seconds' => self::requireInt($row['oldest_age'] ?? null, 'oldest_age'),
+        ];
+    }
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php`
+
+Expected: PASS.
+
+- [ ] **Step 5: Static analysis**
+
+Run: `composer analyse && composer lint`
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Repositories/SourceDataChangeRequestRepository.php \
+        phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
+git commit -m "feat(sourcedata): repository queries for merge detection"
+```
+
+---
+
+### Task 6: `MergePollRunner`
+
+**Files:**
+
+- Create: `src/Services/SourceData/MergePollRunResult.php`, `src/Services/SourceData/MergePollRunner.php`
+- Test: `phpunit_tests/Services/SourceData/MergePollRunnerTest.php`
+
+**Interfaces:**
+
+- Consumes: Task 4's `GitHubGitDataClient::getPullRequest()` / `compareCommits()` and `PullRequestState`;
+  Task 5's seven repository methods.
+- Produces:
+  - `final readonly class MergePollRunResult { public int $merged; public int $closed; public int $reset; public int $unpollable; public bool $stoppedOnFailure; }`
+  - `MergePollRunner::__construct(SourceDataChangeRequestRepository $repository, GitHubGitDataClient $client, ?LoggerInterface $logger = null)`
+  - `MergePollRunner::runOnce(int $limit = 50): MergePollRunResult`
+
+`GitHubGitDataClient` is `final`, so tests wire a REAL client to a Guzzle `MockHandler`, exactly as
+`SourceDataPublisherTest` does. Do not add an interface to make it mockable — asserting on the wire is what
+caught phase 2's bugs.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `phpunit_tests/Services/SourceData/MergePollRunnerTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use LiturgicalCalendar\Api\Enum\ChangeOperation;
+use LiturgicalCalendar\Api\Enum\ChangePublicationStatus;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\ChangeResource;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubAppAuth;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
+use LiturgicalCalendar\Api\Services\SourceData\MergePollRunner;
+use LiturgicalCalendar\Tests\Repositories\RepositoryTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+#[CoversClass(MergePollRunner::class)]
+final class MergePollRunnerTest extends RepositoryTestCase
+{
+    private SourceDataChangeRequestRepository $repo;
+
+    /** @var list<\Psr\Http\Message\RequestInterface> */
+    private array $sentRequests = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo         = new SourceDataChangeRequestRepository(self::$pdo);
+        $this->sentRequests = [];
+    }
+
+    // -- Fixtures ------------------------------------------------------------------------------
+
+    private function publishedBatch(string $sub, string $nation, int $prNumber, string $commitSha): string
+    {
+        $batchId = $this->repo->submitBatch(
+            ChangeResource::nationalCalendar(Rite::ROMAN, $nation),
+            [[
+                'path'      => "jsondata/sourcedata/rite/roman/calendars/nations/{$nation}/{$nation}.json",
+                'operation' => ChangeOperation::CREATE,
+                'content'   => '{"litcal":[]}',
+            ]],
+            $sub,
+            'Editor',
+            $sub . '@example.test',
+            true
+        )['batch_id'];
+
+        $this->repo->approveBatch($batchId, 'reviewer-1');
+        $claim = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claim);
+        self::assertSame($batchId, $claim->batchId);
+        $this->repo->recordPublication(
+            $batchId,
+            "litcal-data/national_calendar/roman/{$nation}",
+            $commitSha,
+            $prNumber,
+            'base-sha'
+        );
+
+        return $batchId;
+    }
+
+    /** @param list<GuzzleResponse> $responses */
+    private function runnerFor(array $responses): MergePollRunner
+    {
+        $mock  = new MockHandler($responses);
+        $stack = HandlerStack::create($mock);
+        $stack->push(function (callable $handler): callable {
+            return function ($request, array $options) use ($handler) {
+                $this->sentRequests[] = $request;
+
+                return $handler($request, $options);
+            };
+        });
+        $http = new GuzzleClient(['handler' => $stack]);
+
+        $auth   = new GitHubAppAuth('1', '2', $this->privateKeyPath(), $http, new ArrayAdapter());
+        $client = new GitHubGitDataClient('Liturgical-Calendar', 'LiturgicalCalendarAPI', $auth, $http);
+
+        return new MergePollRunner($this->repo, $client);
+    }
+
+    private static function prJson(string $state, bool $merged, ?string $mergeSha, string $headSha): GuzzleResponse
+    {
+        return new GuzzleResponse(200, [], json_encode([
+            'state'            => $state,
+            'merged'           => $merged,
+            'merge_commit_sha' => $mergeSha,
+            'head'             => ['sha' => $headSha],
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    private function publicationStatus(string $batchId): string
+    {
+        $stmt = self::$pdo->prepare('SELECT publication_status FROM sourcedata_change_requests WHERE batch_id = :b LIMIT 1');
+        $stmt->execute(['b' => $batchId]);
+
+        return (string) $stmt->fetchColumn();
+    }
+
+    // -- Tests ---------------------------------------------------------------------------------
+
+    public function testAnOpenPullRequestChangesNothing(): void
+    {
+        $batchId = $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+
+        $result = $this->runnerFor([
+            new GuzzleResponse(200, [], json_encode(['token' => 'gh_t', 'expires_at' => '2099-01-01T00:00:00Z'], JSON_THROW_ON_ERROR)),
+            self::prJson('open', false, null, 'sha-a'),
+        ])->runOnce();
+
+        self::assertSame(0, $result->merged);
+        self::assertSame(0, $result->closed);
+        self::assertFalse($result->stoppedOnFailure);
+        self::assertSame(ChangePublicationStatus::OPEN->value, $this->publicationStatus($batchId));
+    }
+
+    public function testAMergedPullRequestMarksTheHeadBatchMerged(): void
+    {
+        $batchId = $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+
+        $result = $this->runnerFor([
+            new GuzzleResponse(200, [], json_encode(['token' => 'gh_t', 'expires_at' => '2099-01-01T00:00:00Z'], JSON_THROW_ON_ERROR)),
+            self::prJson('closed', true, 'merge-sha', 'sha-a'),
+        ])->runOnce();
+
+        self::assertSame(1, $result->merged);
+        self::assertSame(ChangePublicationStatus::MERGED->value, $this->publicationStatus($batchId));
+    }
+
+    /**
+     * Two batches, one rolling pull request, ONE GitHub poll. The rolling branch is per resource,
+     * so polling per batch would ask the same question twice.
+     */
+    public function testTwoBatchesOnOnePullRequestCostOnePollAndBothTransition(): void
+    {
+        $first  = $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+        $second = $this->publishedBatch('editor-2', 'US', 11, 'sha-b');
+
+        $result = $this->runnerFor([
+            new GuzzleResponse(200, [], json_encode(['token' => 'gh_t', 'expires_at' => '2099-01-01T00:00:00Z'], JSON_THROW_ON_ERROR)),
+            self::prJson('closed', true, 'merge-sha', 'sha-b'),
+            // one compare, for `sha-a` only — `sha-b` IS the head and needs none
+            new GuzzleResponse(200, [], json_encode(['status' => 'ahead'], JSON_THROW_ON_ERROR)),
+        ])->runOnce();
+
+        self::assertSame(2, $result->merged);
+        self::assertSame(ChangePublicationStatus::MERGED->value, $this->publicationStatus($first));
+        self::assertSame(ChangePublicationStatus::MERGED->value, $this->publicationStatus($second));
+
+        $pullPaths = array_filter(
+            array_map(static fn ($r): string => $r->getUri()->getPath(), $this->sentRequests),
+            static fn (string $p): bool => str_contains($p, '/pulls/')
+        );
+        self::assertCount(1, $pullPaths, 'one pull request, one poll');
+    }
+
+    /**
+     * THE defect this containment check exists for. A reviewer merged concurrently with a publish,
+     * so `sha-late` is on the branch but outside the merge. Marking it merged would make the
+     * publisher skip it forever and lose its content silently.
+     */
+    public function testABatchNotContainedInTheMergeIsResetRatherThanMarkedMerged(): void
+    {
+        $early = $this->publishedBatch('editor-1', 'US', 11, 'sha-early');
+        $late  = $this->publishedBatch('editor-2', 'US', 11, 'sha-late');
+
+        $result = $this->runnerFor([
+            new GuzzleResponse(200, [], json_encode(['token' => 'gh_t', 'expires_at' => '2099-01-01T00:00:00Z'], JSON_THROW_ON_ERROR)),
+            self::prJson('closed', true, 'merge-sha', 'sha-early'),
+            // `sha-late` is not an ancestor of the merge commit
+            new GuzzleResponse(200, [], json_encode(['status' => 'diverged'], JSON_THROW_ON_ERROR)),
+        ])->runOnce();
+
+        self::assertSame(1, $result->merged);
+        self::assertSame(1, $result->reset);
+        self::assertSame(ChangePublicationStatus::MERGED->value, $this->publicationStatus($early));
+        self::assertSame(
+            ChangePublicationStatus::NONE->value,
+            $this->publicationStatus($late),
+            'a batch outside the merge must go back to claimable, never to merged'
+        );
+    }
+
+    public function testAClosedUnmergedPullRequestClosesAndRejects(): void
+    {
+        $batchId = $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+
+        $result = $this->runnerFor([
+            new GuzzleResponse(200, [], json_encode(['token' => 'gh_t', 'expires_at' => '2099-01-01T00:00:00Z'], JSON_THROW_ON_ERROR)),
+            self::prJson('closed', false, null, 'sha-a'),
+        ])->runOnce();
+
+        self::assertSame(1, $result->closed);
+        self::assertSame(ChangePublicationStatus::CLOSED->value, $this->publicationStatus($batchId));
+    }
+
+    /**
+     * A failed compare must NOT be read either way: assuming contained loses content, assuming not
+     * contained republishes work already in the repository. The batch stays `open` for the next tick.
+     */
+    public function testAFailedContainmentCheckLeavesTheBatchOpen(): void
+    {
+        $head  = $this->publishedBatch('editor-1', 'US', 11, 'sha-head');
+        $other = $this->publishedBatch('editor-2', 'US', 11, 'sha-other');
+
+        $result = $this->runnerFor([
+            new GuzzleResponse(200, [], json_encode(['token' => 'gh_t', 'expires_at' => '2099-01-01T00:00:00Z'], JSON_THROW_ON_ERROR)),
+            self::prJson('closed', true, 'merge-sha', 'sha-other'),
+            new GuzzleResponse(500, [], json_encode(['message' => 'boom'], JSON_THROW_ON_ERROR)),
+        ])->runOnce();
+
+        self::assertTrue($result->stoppedOnFailure);
+        self::assertSame(ChangePublicationStatus::OPEN->value, $this->publicationStatus($head));
+    }
+
+    public function testAFailedPollStopsTheRun(): void
+    {
+        $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+        $this->publishedBatch('editor-2', 'IT', 22, 'sha-b');
+
+        $result = $this->runnerFor([
+            new GuzzleResponse(200, [], json_encode(['token' => 'gh_t', 'expires_at' => '2099-01-01T00:00:00Z'], JSON_THROW_ON_ERROR)),
+            new GuzzleResponse(503, [], json_encode(['message' => 'unavailable'], JSON_THROW_ON_ERROR)),
+        ])->runOnce();
+
+        self::assertTrue($result->stoppedOnFailure);
+        self::assertSame(0, $result->merged);
+    }
+
+    public function testUnpollableOpenBatchesAreCountedNotSkipped(): void
+    {
+        $batchId = $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+        self::$pdo->exec("UPDATE sourcedata_change_requests SET pr_number = NULL WHERE batch_id = '{$batchId}'");
+
+        $result = $this->runnerFor([])->runOnce();
+
+        self::assertSame(1, $result->unpollable);
+        self::assertFalse($result->stoppedOnFailure, 'an unexplained row is reported, not an outage');
+    }
+}
+```
+
+`privateKeyPath()` should return a path to a throwaway RSA key. If `GitHubAppAuthTest` already has such a
+fixture helper, reuse it; otherwise generate one into `sys_get_temp_dir()` in `setUp()` with
+`openssl_pkey_new(['private_key_type' => OPENSSL_KEYTYPE_RSA, 'private_key_bits' => 2048])` and
+`openssl_pkey_export_to_file()`, deleting it in `tearDown()`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/SourceData/MergePollRunnerTest.php`
+
+Expected: FAIL — `Class "…\MergePollRunner" not found`.
+
+- [ ] **Step 3: Write `MergePollRunResult`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+/**
+ * What one {@see MergePollRunner::runOnce()} pass did.
+ *
+ * Every count is reported on EVERY run, including runs that stopped early, for the same reason
+ * {@see PublishRunResult} reports `parkedBatches` unconditionally: the runs most likely to leave
+ * work in an odd state are exactly the runs that end before they meant to.
+ */
+final readonly class MergePollRunResult
+{
+    public function __construct(
+        /** Batches transitioned to `merged`. */
+        public int $merged = 0,
+        /** Batches transitioned to `closed` (and `rejected`) because their PR closed unmerged. */
+        public int $closed = 0,
+        /**
+         * Batches returned to `none` because their pull request merged WITHOUT them. Not a
+         * failure — the design's answer to a concurrent merge — but never silent either, since a
+         * non-zero value here means work was overtaken and will be republished.
+         */
+        public int $reset = 0,
+        /**
+         * Batches `open` with a NULL `pr_number`: unpollable, and stuck forever unless an operator
+         * intervenes. Should always be zero; a non-zero value is an unexplained state, reported
+         * rather than filtered out of the query.
+         */
+        public int $unpollable = 0,
+        /** True if the run stopped because a poll or a containment check threw. */
+        public bool $stoppedOnFailure = false
+    ) {
+    }
+}
+```
+
+- [ ] **Step 4: Write `MergePollRunner`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
+use LiturgicalCalendar\Api\Services\GitHub\PullRequestState;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Polls the rolling pull requests that carry published change-request batches and records what
+ * became of them.
+ *
+ * # Polling, not webhooks
+ *
+ * A webhook would need a new public route, HMAC verification, and a second authentication mode on
+ * `/_ops` — real attack surface for a transition nobody is waiting on. A missed webhook is a
+ * silently stuck row; a missed poll is picked up on the next tick.
+ *
+ * # One poll per pull request, not per batch
+ *
+ * The rolling branch is per RESOURCE, and {@see SourceDataPublisher} reuses an already-open pull
+ * request. Two batches for one resource therefore share one `pr_number`, and polling per batch
+ * would ask GitHub the same question twice and answer it twice.
+ *
+ * # Sharing a pull request is not being in the merge
+ *
+ * A reviewer clicking Merge concurrently with a publish separates the two: the publish
+ * fast-forwards the branch to batch C's commit, the merge takes the head it had a moment earlier,
+ * and C is left recorded against a pull request that closed without carrying it.
+ *
+ * Marking C `merged` would ASSERT it reached the repository. The publisher selects approved rows
+ * that are not yet `merged`, so C would never be attempted again and its content would be lost
+ * silently — the same failure mode the age-based ancestor exclusion was chosen to avoid, reached
+ * from the other direction. So containment is verified rather than assumed: a batch whose commit
+ * is the merged head is contained (no extra call, the ordinary case), and any other batch on that
+ * pull request is checked with one `compareCommits()`. A batch that is NOT contained is returned
+ * to `none` and republished under a fresh pull request.
+ *
+ * A containment check that FAILS is read neither way. Assuming contained loses content; assuming
+ * not-contained republishes work already in the repository. Both guesses are wrong, so the run
+ * stops and the batch stays `open` for the next tick.
+ *
+ * # No claim protocol
+ *
+ * Unlike {@see PublishRunner}, this holds nothing and claims nothing. Its writes are `UPDATE`s
+ * guarded on `publication_status = 'open'`, so two racing pollers produce one transition and one
+ * no-op. There is no stranded state to reclaim, which is why there is no grace period, no attempt
+ * bound and no reclaim step here. Do not add one for symmetry.
+ *
+ * # Stop, don't hammer
+ *
+ * A failed poll stops the run rather than moving to the next pull request. If GitHub is down or
+ * the installation credential is stale, every remaining poll fails identically, and retrying
+ * in-process would only exhaust the rate limit faster. The cron interval is what re-attempts.
+ */
+final class MergePollRunner
+{
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly SourceDataChangeRequestRepository $repository,
+        private readonly GitHubGitDataClient $client,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function runOnce(int $limit = 50): MergePollRunResult
+    {
+        $unpollable = $this->unpollableCountSafely();
+
+        try {
+            $prNumbers = $this->repository->listOpenPullRequestNumbers();
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Listing open source-data pull requests failed; stopping this run rather than '
+                    . 'polling against an unhealthy database.',
+                ['exception' => $e::class, 'message' => $e->getMessage()]
+            );
+
+            return new MergePollRunResult(unpollable: $unpollable, stoppedOnFailure: true);
+        }
+
+        $merged = 0;
+        $closed = 0;
+        $reset  = 0;
+
+        foreach (array_slice($prNumbers, 0, $limit) as $prNumber) {
+            try {
+                $tally = $this->pollOne($prNumber);
+            } catch (\Throwable $e) {
+                $this->logger->error(
+                    'Polling a source-data pull request failed; stopping this run rather than '
+                        . 'hammering a failing API with the rest of the queue.',
+                    ['pr_number' => $prNumber, 'exception' => $e::class, 'message' => $e->getMessage()]
+                );
+
+                return new MergePollRunResult($merged, $closed, $reset, $unpollable, true);
+            }
+
+            $merged += $tally['merged'];
+            $closed += $tally['closed'];
+            $reset  += $tally['reset'];
+        }
+
+        return new MergePollRunResult($merged, $closed, $reset, $unpollable);
+    }
+
+    /**
+     * @return array{merged: int, closed: int, reset: int}
+     */
+    private function pollOne(int $prNumber): array
+    {
+        $pr     = $this->client->getPullRequest($prNumber);
+        $tally  = ['merged' => 0, 'closed' => 0, 'reset' => 0];
+        $states = $this->repository->listOpenBatchesForPullRequest($prNumber);
+
+        if ('open' === $pr->state) {
+            return $tally;
+        }
+
+        if ($pr->isClosedUnmerged()) {
+            foreach ($states as $batch) {
+                $reason = sprintf('Pull request #%d was closed without merging.', $prNumber);
+                if ($this->repository->markBatchClosedUnmerged($batch['batch_id'], $reason) > 0) {
+                    $tally['closed']++;
+                    $this->logger->info(
+                        'Source-data change request batch closed unmerged.',
+                        ['batch_id' => $batch['batch_id'], 'pr_number' => $prNumber]
+                    );
+                }
+            }
+
+            return $tally;
+        }
+
+        // Merged. `mergeCommitSha` is non-null for a merged pull request; a merged PR without one
+        // is GitHub contradicting itself, and guessing a sha is worse than stopping.
+        $mergeCommitSha = $pr->mergeCommitSha;
+        if (null === $mergeCommitSha) {
+            throw new \RuntimeException(sprintf('Pull request #%d reports merged but carries no merge_commit_sha', $prNumber));
+        }
+
+        foreach ($states as $batch) {
+            if ($this->isContained($batch['commit_sha'], $pr, $mergeCommitSha)) {
+                if ($this->repository->markBatchMerged($batch['batch_id'], $mergeCommitSha) > 0) {
+                    $tally['merged']++;
+                    $this->logger->info(
+                        'Source-data change request batch merged.',
+                        ['batch_id' => $batch['batch_id'], 'pr_number' => $prNumber, 'merge_commit_sha' => $mergeCommitSha]
+                    );
+                }
+                continue;
+            }
+
+            if ($this->repository->returnBatchToUnpublished($batch['batch_id']) > 0) {
+                $tally['reset']++;
+                $this->logger->warning(
+                    'A pull request merged WITHOUT one of the batches recorded against it — most '
+                        . 'likely a review that landed concurrently with a publish. The batch is '
+                        . 'claimable again and the next publish opens a fresh pull request carrying '
+                        . 'it; it is deliberately NOT marked merged, which would assert it reached '
+                        . 'the repository and lose its content silently.',
+                    [
+                        'batch_id'         => $batch['batch_id'],
+                        'pr_number'        => $prNumber,
+                        'batch_commit_sha' => $batch['commit_sha'],
+                        'merge_commit_sha' => $mergeCommitSha,
+                    ]
+                );
+            }
+        }
+
+        return $tally;
+    }
+
+    /**
+     * Is this batch's commit inside the merged pull request's history?
+     *
+     * Equality with the merged head is decided locally and costs nothing — the ordinary case, since
+     * most pull requests carry one batch. Anything else costs one `compareCommits()`, read as
+     * "$head is <status> $base": `ahead` or `identical` means the merge commit's history contains
+     * the batch's commit.
+     *
+     * A null `commit_sha` on an `open` row is unexplained (the publisher writes one for every row
+     * it records), so it is read conservatively as NOT contained rather than optimistically.
+     */
+    private function isContained(?string $batchCommitSha, PullRequestState $pr, string $mergeCommitSha): bool
+    {
+        if (null === $batchCommitSha || '' === $batchCommitSha) {
+            return false;
+        }
+
+        if ($batchCommitSha === $pr->headSha) {
+            return true;
+        }
+
+        $status = $this->client->compareCommits($batchCommitSha, $mergeCommitSha);
+
+        return in_array($status, ['ahead', 'identical'], true);
+    }
+
+    /**
+     * Wrapped for the same reason every DB call in {@see PublishRunner} is: reporting how much work
+     * is in an odd state must never be the thing that turns a completed run into a raw fatal.
+     */
+    private function unpollableCountSafely(): int
+    {
+        try {
+            $unpollable = $this->repository->countOpenBatchesWithoutPullRequest();
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Counting unpollable open source-data batches failed; this run reports 0, which may '
+                    . 'understate what is actually stuck.',
+                ['exception' => $e::class, 'message' => $e->getMessage()]
+            );
+
+            return 0;
+        }
+
+        if ($unpollable > 0) {
+            $this->logger->warning(
+                'Source-data change request batches are `open` with no pull request number, so '
+                    . 'nothing will ever poll them. The publisher always records one, so this is an '
+                    . 'unexplained state and needs an operator.',
+                ['unpollable_batches' => $unpollable]
+            );
+        }
+
+        return $unpollable;
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/SourceData/MergePollRunnerTest.php`
+
+Expected: PASS.
+
+- [ ] **Step 6: Static analysis and style**
+
+Run: `composer analyse && composer lint`
+
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Services/SourceData/MergePollRunner.php src/Services/SourceData/MergePollRunResult.php \
+        phpunit_tests/Services/SourceData/MergePollRunnerTest.php
+git commit -m "feat(sourcedata): merge detection, with containment verified rather than assumed"
+```
+
+---
+
+### Task 7: `deletes_resource` — the signal the purge needs
+
+**Files:**
+
+- Modify: `src/Services/SourceData/SourceDataWriter.php`, `src/Services/SourceData/DiskSourceDataWriter.php`,
+  `src/Services/SourceData/ChangeRequestSourceDataWriter.php`,
+  `src/Handlers/Concerns/WritesSourceData.php`, `src/Handlers/RegionalDataHandler.php`,
+  `src/Handlers/TestsHandler.php`
+- Test: `phpunit_tests/Handlers/RegionalDataChangeRequestTest.php`,
+  `phpunit_tests/Handlers/TestsChangeRequestTest.php`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `SourceDataWriter::commit(ChangeResource $resource, bool $deletesResource = false): array`, and the
+  `metadata` key `deletes_resource` (bool) on every row of a batch that removes a whole resource. Task 8 reads it.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `phpunit_tests/Handlers/RegionalDataChangeRequestTest.php`:
+
+```php
+/**
+ * The signal Task 8's OpenFGA purge keys on. It must be set ONLY when the resource itself is
+ * removed — see the sibling test below for the case that makes `operation = 'delete'` unusable.
+ */
+public function testDeletingACalendarFlagsTheBatchAsAResourceDeletion(): void
+{
+    $batchId = $this->deleteNationalCalendarAsQueuedRequest('US');
+
+    foreach ($this->repo->getBatch($batchId) as $row) {
+        self::assertTrue(
+            $row['metadata']['deletes_resource'] ?? false,
+            'every row of a resource-deletion batch carries the flag'
+        );
+    }
+}
+
+/**
+ * THE false positive. Dropping a locale from `metadata.locales` stages a DELETE for that i18n
+ * file on a calendar that still exists. If this batch were flagged, merging it would revoke every
+ * editor and viewer on a live calendar because a translator removed one language.
+ */
+public function testRemovingALocaleStagesADeleteButIsNotAResourceDeletion(): void
+{
+    $batchId = $this->updateNationalCalendarDroppingALocale('US');
+    $rows    = $this->repo->getBatch($batchId);
+
+    self::assertContains(
+        ChangeOperation::DELETE->value,
+        array_column($rows, 'operation'),
+        'the fixture must actually stage a delete, or this test proves nothing'
+    );
+
+    foreach ($rows as $row) {
+        self::assertFalse(
+            $row['metadata']['deletes_resource'] ?? false,
+            'a locale removal is an update, not a resource deletion'
+        );
+    }
+}
+```
+
+In `phpunit_tests/Handlers/TestsChangeRequestTest.php`, the analogue:
+
+```php
+public function testDeletingATestDefinitionFlagsTheBatchAsAResourceDeletion(): void
+{
+    $batchId = $this->deleteTestAsQueuedRequest('MyTest');
+
+    foreach ($this->repo->getBatch($batchId) as $row) {
+        self::assertTrue($row['metadata']['deletes_resource'] ?? false);
+    }
+}
+```
+
+Build `deleteNationalCalendarAsQueuedRequest()`, `updateNationalCalendarDroppingALocale()` and
+`deleteTestAsQueuedRequest()` on the existing fixtures in those files — they already drive the handlers in
+queue mode; these just name the three shapes the assertions need.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+vendor/bin/phpunit phpunit_tests/Handlers/RegionalDataChangeRequestTest.php --filter ResourceDeletion
+vendor/bin/phpunit phpunit_tests/Handlers/TestsChangeRequestTest.php --filter ResourceDeletion
+```
+
+Expected: FAIL on the two `assertTrue` cases (`metadata.deletes_resource` is absent). The locale case
+should already PASS — it is the guard rail, and it must keep passing after Step 3.
+
+- [ ] **Step 3: Widen the writer seam**
+
+In `src/Services/SourceData/SourceDataWriter.php`:
+
+```php
+    /**
+     * @param bool $deletesResource True only when this request removes the RESOURCE, not merely
+     *        some of its files. Set by the handler that knows, at the moment it knows.
+     *
+     *        `operation = ChangeOperation::DELETE` cannot answer this and must never be used to:
+     *        `RegionalDataHandler::writeI18nFiles()` stages a DELETE for every locale file dropped
+     *        from `metadata.locales`, on a calendar that still exists. Keying the OpenFGA purge on
+     *        the operation would revoke every editor on a live calendar because a translator
+     *        removed one language.
+     *
+     * @return array<string, mixed> Always carries a `disposition` key.
+     */
+    public function commit(ChangeResource $resource, bool $deletesResource = false): array;
+```
+
+In `DiskSourceDataWriter::commit()`, accept and ignore it:
+
+```php
+    public function commit(ChangeResource $resource, bool $deletesResource = false): array
+    {
+        // Ignored deliberately. Disk mode purges inline, in the handler, gated on the write having
+        // landed — there is no later moment at which to act on this, because there is no later.
+```
+
+In `ChangeRequestSourceDataWriter::commit()`, change the signature the same way and widen the metadata:
+
+```php
+            $metadata = ['authorizing_relation' => 'admin'];
+            if ($deletesResource) {
+                // Read at merge time by MergePollRunner, which is the only moment that knows the
+                // deletion actually happened. Written here because this is the only moment that
+                // knows it was a resource deletion at all.
+                $metadata['deletes_resource'] = true;
+            }
+
+            $submission = $this->repository->submitBatch(
+                $resource,
+                $this->staged,
+                $sub,
+                $name,
+                $email,
+                $emailVerified,
+                $metadata
+            );
+```
+
+In `WritesSourceData::commitStagedFiles()`:
+
+```php
+    protected function commitStagedFiles(ChangeResource $resource, bool $deletesResource = false): array
+    {
+        return $this->sourceDataWriter()->commit($resource, $deletesResource);
+    }
+```
+
+- [ ] **Step 4: Pass `true` from the two deletion call sites, and only those**
+
+`src/Handlers/RegionalDataHandler.php`, in `deleteCalendar()` — the call that follows the `stageFile(…DELETE…)`
+at lines 1063 and 1076:
+
+```php
+        $changeRequest = $this->commitStagedFiles($this->changeResourceForRequest(), deletesResource: true);
+```
+
+`src/Handlers/TestsHandler.php:270`:
+
+```php
+        $changeRequest = $this->commitStagedFiles($this->changeResourceForTest($scope), deletesResource: true);
+```
+
+Leave `TestsHandler.php:372` and `:598` (create/update) and every `RegionalDataHandler` write path alone —
+including the one at line 1262 that stages locale deletions. Named arguments here, not positional: a bare
+`true` at a call site reads as nothing at all, and this argument's whole job is to be unmistakable.
+
+- [ ] **Step 5: Run the tests**
+
+Run:
+
+```bash
+vendor/bin/phpunit phpunit_tests/Handlers/RegionalDataChangeRequestTest.php
+vendor/bin/phpunit phpunit_tests/Handlers/TestsChangeRequestTest.php
+vendor/bin/phpunit phpunit_tests/Services/SourceData/DiskSourceDataWriterTest.php
+vendor/bin/phpunit phpunit_tests/Handlers/Concerns/WritesSourceDataTest.php
+```
+
+Expected: PASS, including the locale case that must not regress.
+
+- [ ] **Step 6: Static analysis and style**
+
+Run: `composer analyse && composer lint`
+
+Expected: clean. PHPStan flags any `SourceDataWriter` implementation whose signature you missed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Services/SourceData/SourceDataWriter.php src/Services/SourceData/DiskSourceDataWriter.php \
+        src/Services/SourceData/ChangeRequestSourceDataWriter.php src/Handlers/Concerns/WritesSourceData.php \
+        src/Handlers/RegionalDataHandler.php src/Handlers/TestsHandler.php \
+        phpunit_tests/Handlers/RegionalDataChangeRequestTest.php phpunit_tests/Handlers/TestsChangeRequestTest.php
+git commit -m "feat(sourcedata): flag a batch that deletes a resource, not merely one of its files"
+```
+
+---
+
+### Task 8: OpenFGA purge and audit trail on a merged deletion
+
+**Files:**
+
+- Modify: `src/Services/SourceData/MergePollRunner.php`
+- Test: `phpunit_tests/Services/SourceData/MergePollRunnerTest.php`,
+  `phpunit_tests/Services/SourceData/RecordingTuplePurgeService.php` (create)
+
+**Interfaces:**
+
+- Consumes: Task 7's `metadata.deletes_resource`; `ResourceTuplePurgeServiceInterface::purgeForObject(string): int`;
+  `AuditLogRepository::log(?string $userId, string $action, string $resourceType, ?string $resourceId, ?array $details)`.
+- Produces: `MergePollRunner::__construct(SourceDataChangeRequestRepository $repository, GitHubGitDataClient $client,
+  ?ResourceTuplePurgeServiceInterface $purge = null, ?AuditLogRepository $auditLog = null, ?LoggerInterface $logger = null)`.
+
+Both new dependencies are optional and nullable, matching how `ResolvesOutboxTooling` treats the purge service:
+a deployment without OpenFGA must still detect merges.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `phpunit_tests/Services/SourceData/RecordingTuplePurgeService.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Services\ResourceTuplePurgeServiceInterface;
+
+/**
+ * Records which FGA objects were purged, so a test can assert on the exact object string — the
+ * thing that goes wrong here is a double-qualified id (`roman/roman/US`), and only the string
+ * shows that.
+ */
+final class RecordingTuplePurgeService implements ResourceTuplePurgeServiceInterface
+{
+    /** @var list<string> */
+    public array $purged = [];
+
+    public function __construct(private readonly ?\Throwable $throws = null)
+    {
+    }
+
+    public function purgeForObject(string $fgaObject): int
+    {
+        $this->purged[] = $fgaObject;
+
+        if (null !== $this->throws) {
+            throw $this->throws;
+        }
+
+        return 1;
+    }
+}
+```
+
+Append to `MergePollRunnerTest`:
+
+```php
+private function deletionBatch(string $sub, string $nation, int $prNumber, string $commitSha): string
+{
+    $batchId = $this->repo->submitBatch(
+        ChangeResource::nationalCalendar(Rite::ROMAN, $nation),
+        [[
+            'path'      => "jsondata/sourcedata/rite/roman/calendars/nations/{$nation}/{$nation}.json",
+            'operation' => ChangeOperation::DELETE,
+            'content'   => null,
+        ]],
+        $sub,
+        'Editor',
+        $sub . '@example.test',
+        true,
+        ['authorizing_relation' => 'admin', 'deletes_resource' => true]
+    )['batch_id'];
+
+    $this->repo->approveBatch($batchId, 'reviewer-1');
+    $claim = $this->repo->claimNextPublishableBatch();
+    self::assertNotNull($claim);
+    $this->repo->recordPublication($batchId, "litcal-data/national_calendar/roman/{$nation}", $commitSha, $prNumber, 'base');
+
+    return $batchId;
+}
+
+public function testAMergedResourceDeletionPurgesOperationalTuples(): void
+{
+    $this->deletionBatch('editor-1', 'US', 11, 'sha-a');
+    $purge = new RecordingTuplePurgeService();
+
+    $this->runnerFor([
+        new GuzzleResponse(200, [], json_encode(['token' => 'gh_t', 'expires_at' => '2099-01-01T00:00:00Z'], JSON_THROW_ON_ERROR)),
+        self::prJson('closed', true, 'merge-sha', 'sha-a'),
+    ], $purge)->runOnce();
+
+    self::assertSame(['national_calendar:roman/US'], $purge->purged);
+}
+
+/**
+ * THE false positive, at the level that matters. A batch that stages a DELETE for an i18n locale
+ * file but does NOT delete the calendar must purge nothing when it merges — otherwise removing a
+ * translation revokes every editor on a live calendar.
+ */
+public function testAMergedLocaleRemovalPurgesNothing(): void
+{
+    $batchId = $this->repo->submitBatch(
+        ChangeResource::nationalCalendar(Rite::ROMAN, 'US'),
+        [
+            [
+                'path'      => 'jsondata/sourcedata/rite/roman/calendars/nations/US/US.json',
+                'operation' => ChangeOperation::UPDATE,
+                'content'   => '{"litcal":[]}',
+            ],
+            [
+                'path'      => 'jsondata/sourcedata/rite/roman/calendars/nations/US/i18n/fr.json',
+                'operation' => ChangeOperation::DELETE,
+                'content'   => null,
+            ],
+        ],
+        'editor-1',
+        'Editor',
+        'editor-1@example.test',
+        true,
+        ['authorizing_relation' => 'admin']
+    )['batch_id'];
+
+    $this->repo->approveBatch($batchId, 'reviewer-1');
+    $claim = $this->repo->claimNextPublishableBatch();
+    self::assertNotNull($claim);
+    $this->repo->recordPublication($batchId, 'litcal-data/national_calendar/roman/US', 'sha-a', 11, 'base');
+
+    $purge = new RecordingTuplePurgeService();
+
+    $this->runnerFor([
+        new GuzzleResponse(200, [], json_encode(['token' => 'gh_t', 'expires_at' => '2099-01-01T00:00:00Z'], JSON_THROW_ON_ERROR)),
+        self::prJson('closed', true, 'merge-sha', 'sha-a'),
+    ], $purge)->runOnce();
+
+    self::assertSame([], $purge->purged, 'a locale removal is not a resource deletion');
+}
+
+public function testAClosedUnmergedDeletionPurgesNothing(): void
+{
+    $this->deletionBatch('editor-1', 'US', 11, 'sha-a');
+    $purge = new RecordingTuplePurgeService();
+
+    $this->runnerFor([
+        new GuzzleResponse(200, [], json_encode(['token' => 'gh_t', 'expires_at' => '2099-01-01T00:00:00Z'], JSON_THROW_ON_ERROR)),
+        self::prJson('closed', false, null, 'sha-a'),
+    ], $purge)->runOnce();
+
+    self::assertSame([], $purge->purged, 'a deletion that never merged deleted nothing');
+}
+
+/**
+ * The transition is a fact about the repository. A purge failure must not un-record it — the
+ * reconciler sweep is what cleans up, exactly as in disk mode.
+ */
+public function testAFailingPurgeDoesNotUndoTheMerge(): void
+{
+    $batchId = $this->deletionBatch('editor-1', 'US', 11, 'sha-a');
+    $purge   = new RecordingTuplePurgeService(new \RuntimeException('OpenFGA unreachable'));
+
+    $result = $this->runnerFor([
+        new GuzzleResponse(200, [], json_encode(['token' => 'gh_t', 'expires_at' => '2099-01-01T00:00:00Z'], JSON_THROW_ON_ERROR)),
+        self::prJson('closed', true, 'merge-sha', 'sha-a'),
+    ], $purge)->runOnce();
+
+    self::assertSame(1, $result->merged);
+    self::assertFalse($result->stoppedOnFailure);
+    self::assertSame(ChangePublicationStatus::MERGED->value, $this->publicationStatus($batchId));
+}
+```
+
+Change `runnerFor()` to take an optional purge service and pass it through:
+
+```php
+    /** @param list<GuzzleResponse> $responses */
+    private function runnerFor(array $responses, ?RecordingTuplePurgeService $purge = null): MergePollRunner
+    {
+        // … existing transport wiring …
+        return new MergePollRunner($this->repo, $client, $purge);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/SourceData/MergePollRunnerTest.php --filter 'Purge|purges'`
+
+Expected: FAIL — `MergePollRunner::__construct()` takes no third argument.
+
+- [ ] **Step 3: Wire the purge and the audit entry**
+
+Add the two optional constructor parameters:
+
+```php
+    public function __construct(
+        private readonly SourceDataChangeRequestRepository $repository,
+        private readonly GitHubGitDataClient $client,
+        /**
+         * Null on a deployment without OpenFGA. Merge detection must still work there — the whole
+         * point of the write-mode seam is that the stack is optional — so a null purge service is
+         * a quiet no-op, not a failure.
+         */
+        private readonly ?ResourceTuplePurgeServiceInterface $purge = null,
+        private readonly ?AuditLogRepository $auditLog = null,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+```
+
+In `pollOne()`, after a successful `markBatchMerged()` (inside the `if (… > 0)` block, after `$tally['merged']++`):
+
+```php
+                    $this->audit('change_request.merged', $batch['batch_id'], ['pr_number' => $prNumber, 'merge_commit_sha' => $mergeCommitSha]);
+                    $this->purgeIfResourceDeletion($batch['batch_id']);
+```
+
+and after a successful `markBatchClosedUnmerged()`:
+
+```php
+                    $this->audit('change_request.closed_unmerged', $batch['batch_id'], ['pr_number' => $prNumber]);
+```
+
+Add the two helpers:
+
+```php
+    /**
+     * Purge a deleted resource's operational OpenFGA tuples, now that the deletion is real.
+     *
+     * The trigger is `metadata.deletes_resource`, NOT `operation = 'delete'`. The operation cannot
+     * answer this: `RegionalDataHandler::writeI18nFiles()` stages a DELETE for every locale file
+     * dropped from `metadata.locales`, on a calendar that still exists, so keying on it would
+     * revoke every editor on a live calendar because a translator removed a language.
+     *
+     * The object string is rebuilt from the row's own `resource_type` and `resource_id`, which are
+     * already rite-qualified. Do NOT reconstruct a `ChangeResource` here: its factories RE-qualify
+     * a bare id, so `roman/US` would become `roman/roman/US` and fail closed for the wrong reason.
+     *
+     * `admin` tuples survive — that is `ResourceTuplePurgeService`'s own contract — so ownership
+     * outlives a deletion and a recreated resource id belongs to the same person.
+     *
+     * Best-effort, and deliberately so: the batch is already `merged`, which is a fact about the
+     * repository, and a reachable OpenFGA is not a precondition for recording it. A failure logs
+     * and leaves the tuples for `ResourceTuplePurgeReconciler`'s sweep, exactly as the disk-mode
+     * path does.
+     */
+    private function purgeIfResourceDeletion(string $batchId): void
+    {
+        if (null === $this->purge) {
+            return;
+        }
+
+        try {
+            $rows = $this->repository->getBatch($batchId);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Could not read a merged batch to decide whether it deleted a resource; any '
+                    . 'operational tuples it orphaned stay live until the reconciler sweep.',
+                ['batch_id' => $batchId, 'exception' => $e::class, 'message' => $e->getMessage()]
+            );
+
+            return;
+        }
+
+        $first = $rows[0] ?? null;
+        if (null === $first) {
+            return;
+        }
+
+        $metadata = is_array($first['metadata'] ?? null) ? $first['metadata'] : [];
+        if (true !== ( $metadata['deletes_resource'] ?? false )) {
+            return;
+        }
+
+        $resourceType = $first['resource_type'] ?? null;
+        $resourceId   = $first['resource_id'] ?? null;
+        if (!is_string($resourceType) || !is_string($resourceId)) {
+            return;
+        }
+
+        $fgaObject = $resourceType . ':' . $resourceId;
+
+        try {
+            $purged = $this->purge->purgeForObject($fgaObject);
+            $this->logger->info(
+                'Purged operational tuples for a resource whose deletion has merged.',
+                ['batch_id' => $batchId, 'object' => $fgaObject, 'tuples' => $purged]
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Purging operational tuples for a merged resource deletion failed; the merge stands '
+                    . 'and the reconciler sweep will retry. Until it does, the deleted resource\'s '
+                    . 'former editors retain access to an object whose files are gone.',
+                ['batch_id' => $batchId, 'object' => $fgaObject, 'exception' => $e::class, 'message' => $e->getMessage()]
+            );
+        }
+    }
+
+    /**
+     * Best-effort audit entry. A logging failure must never turn a recorded transition into a
+     * failed run — same rule, and same reasoning, as `ChangeRequestAdminHandler::audit()`.
+     *
+     * The actor is null: nobody at this deployment performed the merge. The reviewer who clicked
+     * Merge did so on GitHub, and attributing it to the approving admin would be a fabrication.
+     *
+     * @param array<string, mixed> $details
+     */
+    private function audit(string $action, string $batchId, array $details): void
+    {
+        if (null === $this->auditLog) {
+            return;
+        }
+
+        try {
+            $this->auditLog->log(null, $action, 'sourcedata_change_request', $batchId, $details);
+        } catch (\Throwable) {
+            // Deliberately swallowed — see method docblock.
+        }
+    }
+```
+
+Add the imports: `LiturgicalCalendar\Api\Repositories\AuditLogRepository` and
+`LiturgicalCalendar\Api\Services\ResourceTuplePurgeServiceInterface`.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/SourceData/MergePollRunnerTest.php`
+
+Expected: PASS, all cases including the ones from Task 6.
+
+- [ ] **Step 5: Static analysis and style**
+
+Run: `composer analyse && composer lint`
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Services/SourceData/MergePollRunner.php \
+        phpunit_tests/Services/SourceData/MergePollRunnerTest.php \
+        phpunit_tests/Services/SourceData/RecordingTuplePurgeService.php
+git commit -m "feat(sourcedata): purge a deleted resource's tuples once its deletion has merged"
+```
+
+---
+
+### Task 9: Change-request notifications in the inbox
+
+**Files:**
+
+- Modify: `src/Repositories/UserNotificationRepository.php`, `src/Handlers/Auth/NotificationsHandler.php` (docblock)
+- Test: `phpunit_tests/Repositories/UserNotificationRepositoryTest.php` (create if absent)
+
+**Interfaces:**
+
+- Consumes: `publication_settled_at` from Task 1; the transitions from Task 5.
+- Produces: `fetchInbox()` items may now carry `type: 'change_request_published'` with keys
+  `batch_id`, `resource_type`, `resource_id`, `publication_status`, `pr_number`, `settled_at`, `unread`.
+  `total` and `unread_count` span both sources.
+
+- [ ] **Step 1: Write the failing tests**
+
+```php
+public function testInboxCarriesSettledChangeRequests(): void
+{
+    $batchId = $this->settledBatch('user-1', 'merged', '-1 hour');
+
+    $inbox = $this->repo->fetchInbox('user-1');
+
+    self::assertSame(1, $inbox['total']);
+    self::assertSame('change_request_published', $inbox['items'][0]['type']);
+    self::assertSame($batchId, $inbox['items'][0]['batch_id']);
+    self::assertSame('merged', $inbox['items'][0]['publication_status']);
+    self::assertTrue($inbox['items'][0]['unread']);
+}
+
+public function testAnUnsettledBatchIsNotNews(): void
+{
+    $this->openBatch('user-1');
+
+    self::assertSame(0, $this->repo->fetchInbox('user-1')['total']);
+}
+
+public function testOneItemPerBatchNotPerFile(): void
+{
+    $this->settledBatch('user-1', 'merged', '-1 hour', files: 3);
+
+    self::assertCount(1, $this->repo->fetchInbox('user-1')['items']);
+}
+
+public function testTheTwoSourcesInterleaveByTimestampAndShareTheTotals(): void
+{
+    $this->reviewedAccessRequest('user-1', '-2 hours');
+    $this->settledBatch('user-1', 'merged', '-1 hour');
+    $this->reviewedAccessRequest('user-1', '-3 hours');
+
+    $inbox = $this->repo->fetchInbox('user-1');
+
+    self::assertSame(3, $inbox['total']);
+    self::assertSame(3, $inbox['unread_count']);
+    self::assertSame(
+        ['change_request_published', 'access_request_reviewed', 'access_request_reviewed'],
+        array_column($inbox['items'], 'type'),
+        'newest first, across both sources'
+    );
+}
+
+public function testTheSeenBookmarkMarksChangeRequestsRead(): void
+{
+    $this->settledBatch('user-1', 'merged', '-2 hours');
+    $this->repo->markSeen('user-1');
+    $this->settledBatch('user-1', 'closed', '+0 seconds');
+
+    $inbox = $this->repo->fetchInbox('user-1');
+
+    self::assertSame(2, $inbox['total']);
+    self::assertSame(1, $inbox['unread_count']);
+}
+
+public function testAnotherUsersBatchIsInvisible(): void
+{
+    $this->settledBatch('user-2', 'merged', '-1 hour');
+
+    self::assertSame(0, $this->repo->fetchInbox('user-1')['total']);
+}
+```
+
+Fixtures: `settledBatch()` inserts a batch's rows directly with `submitted_by_sub`, a `publication_status`, and
+`publication_settled_at = NOW() + interval`; `openBatch()` leaves `publication_settled_at` NULL;
+`reviewedAccessRequest()` inserts an `access_requests` row with a `reviewed_at`. Direct SQL is right here —
+driving the whole publish path to produce one inbox row would test the publisher, not the inbox.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/UserNotificationRepositoryTest.php`
+
+Expected: FAIL — `total` is 0; change-request rows are not read at all.
+
+- [ ] **Step 3: Implement the second source and the PHP-side merge**
+
+In `src/Repositories/UserNotificationRepository.php`, split the existing body of `fetchInbox()` into a private
+`accessRequestItems()` and add a sibling, then merge. Keep the existing 50-row clamp.
+
+```php
+    /**
+     * The user's inbox: reviewed access requests AND settled source-data change requests.
+     *
+     * # Why two queries and a PHP merge, rather than one UNION
+     *
+     * The two sources have genuinely different shapes, and `total` / `unread_count` are window
+     * counts over the FULL filtered set rather than over the returned page — so a UNION would need
+     * `COUNT(*) OVER ()` spanning both halves, over rows whose columns do not line up. That is one
+     * query that is hard to read and harder to prove right. Two straightforward queries plus a
+     * `usort` are verifiable by inspection, and each source is already capped at 50 rows, so the
+     * merge is bounded.
+     *
+     * # Why `publication_settled_at` and not `updated_at`
+     *
+     * `updated_at` moves on every claim, release, reclaim and record, so it answers "when was this
+     * row last touched", not "when did this become news". `publication_settled_at` is written once,
+     * by the transition to `merged` or `closed`.
+     *
+     * # One item per batch
+     *
+     * An editor who changed a calendar and its fourteen i18n files proposed ONE thing. `DISTINCT ON
+     * (batch_id)` collapses the rows the way the reviewer already sees them.
+     */
+```
+
+The change-request half:
+
+```php
+    /**
+     * @return list<array{type: string, batch_id: string, resource_type: string, resource_id: string,
+     *                    publication_status: string, pr_number: ?int, settled_at: string, unread: bool}>
+     */
+    private function changeRequestItems(string $userId, string $lastSeen, int $limit): array
+    {
+        $sql = <<<'SQL'
+            SELECT DISTINCT ON (batch_id)
+                batch_id,
+                resource_type,
+                resource_id,
+                publication_status,
+                pr_number,
+                publication_settled_at,
+                (publication_settled_at > :last_seen::timestamptz) AS unread
+            FROM sourcedata_change_requests
+            WHERE submitted_by_sub = :uid
+              AND publication_settled_at IS NOT NULL
+            ORDER BY batch_id, publication_settled_at DESC
+        SQL;
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindValue(':uid', $userId);
+        $stmt->bindValue(':last_seen', $lastSeen);
+        $stmt->execute();
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        $items = array_map(
+            function (array $row): array {
+                $prNumber = $row['pr_number'] ?? null;
+
+                return [
+                    'type'               => 'change_request_published',
+                    'batch_id'           => $this->toString($row['batch_id']),
+                    'resource_type'      => $this->toString($row['resource_type']),
+                    'resource_id'        => $this->toString($row['resource_id']),
+                    'publication_status' => $this->toString($row['publication_status']),
+                    'pr_number'          => null === $prNumber ? null : (int) $prNumber,
+                    'settled_at'         => $this->iso8601($this->toString($row['publication_settled_at'])),
+                    'unread'             => in_array($row['unread'], [true, 't', 'true', '1', 1], true),
+                ];
+            },
+            $rows
+        );
+
+        // DISTINCT ON forces ORDER BY batch_id first, so the newest-first ordering the inbox needs
+        // has to be re-applied here rather than left to SQL.
+        usort($items, static fn (array $a, array $b): int => strcmp($b['settled_at'], $a['settled_at']));
+
+        return array_slice($items, 0, $limit);
+    }
+```
+
+Then in `fetchInbox()`, after computing `$lastSeen` / `$lastSeenIso`:
+
+```php
+        $accessItems = $this->accessRequestItems($userId, $lastSeen, $limit);
+        $changeItems = $this->changeRequestItems($userId, $lastSeen, $limit);
+
+        /** @var list<array<string, mixed>> $items */
+        $items = array_merge($accessItems['items'], $changeItems);
+        usort(
+            $items,
+            static fn (array $a, array $b): int => strcmp(
+                (string) ( $b['settled_at'] ?? $b['reviewed_at'] ?? '' ),
+                (string) ( $a['settled_at'] ?? $a['reviewed_at'] ?? '' )
+            )
+        );
+
+        // total and unread_count span the FULL filtered set of both sources, not the merged page —
+        // consistent with what the access-request half already promised on its own.
+        $total       = $accessItems['total'] + count($changeItems);
+        $unreadCount = $accessItems['unread_count'] + count(array_filter(
+            $changeItems,
+            static fn (array $item): bool => true === $item['unread']
+        ));
+
+        return [
+            'items'        => array_slice($items, 0, $limit),
+            'total'        => $total,
+            'unread_count' => $unreadCount,
+            'last_seen_at' => $lastSeenIso,
+        ];
+```
+
+Update `NotificationsHandler`'s docblock and the `@return` shape on `fetchInbox()` to say `items` is a
+DISCRIMINATED list and clients must switch on `type` — the two shapes do not share keys beyond `type` and
+`unread`.
+
+- [ ] **Step 4: Run the tests**
+
+Run:
+
+```bash
+vendor/bin/phpunit phpunit_tests/Repositories/UserNotificationRepositoryTest.php
+vendor/bin/phpunit --filter Notifications
+```
+
+Expected: PASS, and no regression in the existing access-request notification tests.
+
+- [ ] **Step 5: Static analysis and style**
+
+Run: `composer analyse && composer lint`
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Repositories/UserNotificationRepository.php src/Handlers/Auth/NotificationsHandler.php \
+        phpunit_tests/Repositories/UserNotificationRepositoryTest.php
+git commit -m "feat(notifications): tell a submitter when their change request merges or closes"
+```
+
+---
+
+### Task 10: `SourceDataPublishNotifier` and the two `XADD` sites
+
+**Files:**
+
+- Create: `src/Services/SourceData/SourceDataPublishNotifier.php`
+- Modify: `src/Handlers/Admin/ChangeRequestAdminHandler.php`,
+  `src/Services/SourceData/ChangeRequestSourceDataWriter.php`
+- Test: `phpunit_tests/Services/SourceData/SourceDataPublishNotifierTest.php` (create),
+  `phpunit_tests/Handlers/ChangeRequestAdminHandlerTest.php`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: `SourceDataPublishNotifier::__construct(?\Redis $redis, string $streamName, ?LoggerInterface $logger = null)`
+  and `notify(string $batchId): void`. Task 12's consumer reads the `batch_id` field it writes.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `phpunit_tests/Services/SourceData/SourceDataPublishNotifierTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SourceDataPublishNotifier::class)]
+final class SourceDataPublishNotifierTest extends TestCase
+{
+    public function testANullRedisIsAQuietNoOp(): void
+    {
+        // A self-hoster running cron only has no Redis. This must not throw and must not log.
+        $handler  = new TestHandler();
+        $notifier = new SourceDataPublishNotifier(null, 'litcal:publish-stream', new Logger('t', [$handler]));
+
+        $notifier->notify('batch-1');
+
+        self::assertSame([], $handler->getRecords());
+    }
+
+    public function testItXaddsTheBatchId(): void
+    {
+        if (!extension_loaded('redis')) {
+            self::markTestSkipped('ext-redis is required for this test');
+        }
+
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('xAdd')
+            ->with('litcal:publish-stream', '*', ['batch_id' => 'batch-1'])
+            ->willReturn('1-0');
+
+        ( new SourceDataPublishNotifier($redis, 'litcal:publish-stream') )->notify('batch-1');
+    }
+
+    /**
+     * The whole contract: the batch is already durable in Postgres and cron is the backstop, so a
+     * Redis failure costs latency and never correctness. It must never propagate into the approval
+     * the caller has already committed.
+     */
+    public function testARedisFailureIsLoggedAndSwallowed(): void
+    {
+        if (!extension_loaded('redis')) {
+            self::markTestSkipped('ext-redis is required for this test');
+        }
+
+        $redis = $this->createMock(\Redis::class);
+        $redis->method('xAdd')->willThrowException(new \RedisException('connection refused'));
+
+        $handler = new TestHandler();
+        ( new SourceDataPublishNotifier($redis, 'litcal:publish-stream', new Logger('t', [$handler])) )
+            ->notify('batch-1');
+
+        self::assertTrue($handler->hasWarningThatContains('sourcedata.redis.notify_failed'));
+    }
+}
+```
+
+Append to `phpunit_tests/Handlers/ChangeRequestAdminHandlerTest.php`:
+
+```php
+public function testApproveNotifiesTheStreamAfterTheStatusUpdate(): void
+{
+    $batchId  = $this->submittedBatch('editor-1');
+    $notifier = new RecordingPublishNotifier();
+
+    $this->handlerFor('approve', $batchId, $notifier)->handle($this->adminRequest());
+
+    self::assertSame([$batchId], $notifier->notified);
+}
+
+public function testRejectDoesNotNotifyTheStream(): void
+{
+    $batchId  = $this->submittedBatch('editor-1');
+    $notifier = new RecordingPublishNotifier();
+
+    $this->handlerFor('reject', $batchId, $notifier)->handle($this->adminRequest());
+
+    self::assertSame([], $notifier->notified, 'a rejected batch is never publishable');
+}
+
+/**
+ * A batch approved on the auto-approval path never passes through this handler at all, and it is
+ * the COMMON path — an admin editing a resource they administer. Missing it would leave the most
+ * frequent approval waiting for cron.
+ */
+public function testAutoApprovalOnTheWritePathAlsoNotifies(): void
+{
+    $notifier = new RecordingPublishNotifier();
+    $writer   = $this->changeRequestWriterForAdmin($notifier);
+
+    $writer->stage('/abs/jsondata/sourcedata/rite/roman/calendars/nations/US/US.json', ChangeOperation::UPDATE, '{}');
+    $result = $writer->commit(ChangeResource::nationalCalendar(Rite::ROMAN, 'US'));
+
+    self::assertSame('approved', $result['disposition']);
+    self::assertSame([$result['change_request']['batch_id']], $notifier->notified);
+}
+```
+
+with a tiny recorder alongside the other test doubles:
+
+```php
+final class RecordingPublishNotifier extends SourceDataPublishNotifier
+{
+    /** @var list<string> */
+    public array $notified = [];
+
+    public function __construct()
+    {
+        parent::__construct(null, 'litcal:publish-stream');
+    }
+
+    public function notify(string $batchId): void
+    {
+        $this->notified[] = $batchId;
+    }
+}
+```
+
+`SourceDataPublishNotifier` must therefore **not** be `final`, and `notify()` must not be `private`. That is a
+deliberate exception to this codebase's default: unlike `SourceDataPublisher`, whose `final` protects the
+author/committer split, nothing here is worth protecting from a subclass, and the alternative is another
+interface for a class with one method and no logic.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+vendor/bin/phpunit phpunit_tests/Services/SourceData/SourceDataPublishNotifierTest.php
+vendor/bin/phpunit phpunit_tests/Handlers/ChangeRequestAdminHandlerTest.php --filter Notif
+```
+
+Expected: FAIL — `Class "…\SourceDataPublishNotifier" not found`.
+
+- [ ] **Step 3: Write the notifier**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Best-effort `XADD` announcing that a batch has become publishable.
+ *
+ * Mirrors {@see \LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier}, and for the same reason:
+ * the row is already durable in Postgres and cron is the backstop, so this is an accelerator over
+ * a durable queue, never the queue itself. It therefore NEVER throws to the caller — a Redis
+ * outage must not fail an approval that has already committed. Losing the message costs latency
+ * and nothing else.
+ *
+ * The message is a HINT, not a work item: the consumer ignores the batch id except for logging and
+ * claims from Postgres exactly as cron does. That is what makes a lost, duplicated or out-of-order
+ * message harmless.
+ *
+ * Pass a null `\Redis` to disable — the ordinary state for a self-hoster, since `REDIS_SOCKET` /
+ * `REDIS_HOST` are commented out in `.env.example`.
+ *
+ * Not `final`, unlike most of this namespace: it has one method and no invariant worth protecting,
+ * and tests substitute a recording subclass rather than justify an interface for it.
+ */
+class SourceDataPublishNotifier
+{
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly ?\Redis $redis,
+        private readonly string $streamName,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function notify(string $batchId): void
+    {
+        if (null === $this->redis) {
+            return;
+        }
+
+        try {
+            $this->redis->xAdd($this->streamName, '*', ['batch_id' => $batchId]);
+        } catch (\RedisException $e) {
+            $this->logger->warning('sourcedata.redis.notify_failed', [
+                'batch_id' => $batchId,
+                'error'    => $e->getMessage(),
+            ]);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Call it from both approval sites**
+
+`ChangeRequestAdminHandler`: add a nullable `?SourceDataPublishNotifier $publishNotifier = null` constructor
+parameter (tests inject; production resolves lazily like `getRepository()` does), and in `approve()`, AFTER the
+`ConflictException` guard:
+
+```php
+        $this->audit('change_request.approve', $sub, $batchId, $firstRow, []);
+
+        // AFTER the status UPDATE has committed, never before: a consumer that wakes on this
+        // message claims from Postgres, so announcing an approval the database has not recorded
+        // would send it looking for work that is not yet there. Same ordering constraint the
+        // OpenFGA outbox already documents.
+        $this->publishNotifier()->notify($batchId);
+```
+
+`ChangeRequestSourceDataWriter`: add a nullable `?SourceDataPublishNotifier $publishNotifier = null`
+constructor parameter and, in `commit()`:
+
+```php
+        $autoApproved = $this->review->administers($resource, $sub);
+        if ($autoApproved) {
+            $this->repository->approveBatch($batchId, $sub);
+            // The auto-approval path is the COMMON one — an admin editing a resource they
+            // administer — and it never reaches ChangeRequestAdminHandler. Announcing only there
+            // would leave the most frequent approval waiting for the cron backstop.
+            $this->publishNotifier?->notify($batchId);
+        }
+```
+
+Wire the notifier into `WritesSourceData::sourceDataWriter()`'s `ChangeRequestSourceDataWriter` construction,
+resolving `\Redis` the same way `ResolvesOutboxTooling` already does (null when `ext-redis` is missing or no
+`REDIS_SOCKET` / `REDIS_HOST` is configured). Stream name from `REDIS_SOURCEDATA_PUBLISH_STREAM`, defaulting to
+`litcal:sourcedata-publish-stream`.
+
+- [ ] **Step 5: Run the tests**
+
+Run:
+
+```bash
+vendor/bin/phpunit phpunit_tests/Services/SourceData/SourceDataPublishNotifierTest.php
+vendor/bin/phpunit phpunit_tests/Handlers/ChangeRequestAdminHandlerTest.php
+vendor/bin/phpunit phpunit_tests/Handlers/Concerns/WritesSourceDataTest.php
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Static analysis and style**
+
+Run: `composer analyse && composer lint`
+
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Services/SourceData/SourceDataPublishNotifier.php \
+        src/Services/SourceData/ChangeRequestSourceDataWriter.php \
+        src/Handlers/Admin/ChangeRequestAdminHandler.php src/Handlers/Concerns/WritesSourceData.php \
+        phpunit_tests/Services/SourceData/SourceDataPublishNotifierTest.php \
+        phpunit_tests/Handlers/ChangeRequestAdminHandlerTest.php
+git commit -m "feat(sourcedata): announce an approved batch on a Redis stream, best-effort"
+```
+
+---
+
+### Task 11: Widen the stream seam to string payloads
+
+**Files:**
+
+- Modify: `src/Services/Outbox/StreamConsumerInterface.php`, `src/Services/Outbox/RedisStreamConsumer.php`,
+  `src/Services/Outbox/ConsumerLoop.php`
+- Test: `phpunit_tests/Services/Outbox/RedisStreamConsumerTest.php`,
+  `phpunit_tests/Services/Outbox/ConsumerLoopTest.php`
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces:
+  - `StreamConsumerInterface::readOnce(int $blockMs, callable $process): void` where `$process` is
+    `callable(string): void`
+  - `RedisStreamConsumer::__construct(\Redis $redis, string $streamName, string $groupName, string $consumerName,
+    ?LoggerInterface $logger = null, string $payloadField = 'row_id')`
+  - `ConsumerLoop` now owns the `(int)` cast and the `<= 0` bad-id guard.
+
+This touches the OpenFGA consumer, which is live. Its existing tests are the safety net — run the whole
+`phpunit_tests/Services/Outbox/` directory before and after.
+
+- [ ] **Step 1: Capture the current behaviour**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/`
+
+Expected: PASS. Note the count; it must not drop.
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `phpunit_tests/Services/Outbox/RedisStreamConsumerTest.php`:
+
+```php
+public function testItPassesTheRawPayloadValueThroughAsAString(): void
+{
+    $redis = $this->redisReturningMessages(['1-0' => ['row_id' => '42']]);
+    $seen  = [];
+
+    ( new RedisStreamConsumer($redis, 'stream', 'group', 'consumer') )
+        ->readOnce(0, function (string $id) use (&$seen): void {
+            $seen[] = $id;
+        });
+
+    self::assertSame(['42'], $seen, 'the consumer no longer decides what a valid id looks like');
+}
+
+public function testItReadsAConfigurablePayloadField(): void
+{
+    $redis = $this->redisReturningMessages(['1-0' => ['batch_id' => 'b7f3-uuid']]);
+    $seen  = [];
+
+    ( new RedisStreamConsumer($redis, 'stream', 'group', 'consumer', null, 'batch_id') )
+        ->readOnce(0, function (string $id) use (&$seen): void {
+            $seen[] = $id;
+        });
+
+    self::assertSame(['b7f3-uuid'], $seen);
+}
+
+/**
+ * A message missing the payload field entirely is unprocessable by anyone, so it is still ACKed
+ * here rather than left to redeliver forever. What moved to the caller is deciding whether a
+ * PRESENT value is valid.
+ */
+public function testAMessageMissingThePayloadFieldIsAckedAndSkipped(): void
+{
+    $redis = $this->redisReturningMessages(['1-0' => ['unrelated' => 'x']]);
+    $redis->expects(self::once())->method('xAck')->with('stream', 'group', ['1-0']);
+    $called = false;
+
+    ( new RedisStreamConsumer($redis, 'stream', 'group', 'consumer') )
+        ->readOnce(0, function (string $id) use (&$called): void {
+            $called = true;
+        });
+
+    self::assertFalse($called);
+}
+```
+
+Append to `phpunit_tests/Services/Outbox/ConsumerLoopTest.php`:
+
+```php
+/**
+ * The `<= 0` guard moved here with the cast. The outbox's unit of work is an integer row id, and
+ * this is now the only layer that knows that.
+ */
+public function testANonNumericOrNonPositiveIdIsNotProcessed(): void
+{
+    $consumer  = new FakeStreamConsumer(['0', '-1', 'not-a-number', '7']);
+    $processor = new RecordingOutboxProcessor();
+
+    ( new ConsumerLoop($consumer, $processor) )->tick();
+
+    self::assertSame([7], $processor->processed);
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/`
+
+Expected: FAIL on the new cases — the payload field is hardcoded and the value arrives as `int`.
+
+- [ ] **Step 4: Widen the interface**
+
+```php
+interface StreamConsumerInterface
+{
+    public function ensureGroup(): void;
+
+    /**
+     * Read one message (or batch) and invoke `$process` with the payload field's RAW STRING value.
+     *
+     * String, not int, because the two streams that use this carry different id types: the OpenFGA
+     * outbox's unit of work is an integer row id, while the source-data publisher's is a batch id,
+     * which is a UUID. Validating and narrowing the value is the caller's job — this layer no
+     * longer knows what a valid id looks like.
+     *
+     * @param callable(string): void $process
+     */
+    public function readOnce(int $blockMs, callable $process): void;
+}
+```
+
+- [ ] **Step 5: Generalise `RedisStreamConsumer`**
+
+Add the constructor parameter:
+
+```php
+        ?LoggerInterface $logger = null,
+        /**
+         * Which message field carries the id. `row_id` for the OpenFGA outbox, `batch_id` for the
+         * source-data publish stream.
+         */
+        private readonly string $payloadField = 'row_id',
+```
+
+In both `readOnce()` and `claimStale()`, replace the `$rowId = isset($payload['row_id']) ? (int) $payload['row_id'] : 0;`
+pattern and its `<= 0` test with:
+
+```php
+            $id = $payload[$this->payloadField] ?? null;
+            if (!is_string($id) || '' === $id) {
+                // Unprocessable by ANY caller — there is no id at all — so ACK it rather than let
+                // it redeliver forever. Deciding whether a PRESENT id is valid belongs to the
+                // caller, which is the only layer that knows what shape it should be.
+                $this->logger->warning('outbox.consumer.bad_message', ['msg_id' => $msgId, 'payload' => $payload]);
+                $ackIds[] = $msgId;
+                continue;
+            }
+
+            try {
+                $process($id);
+                $ackIds[] = $msgId;
+            } catch (\Throwable $e) {
+                // Leave the message in the PEL; XCLAIM on the next pass picks it up.
+                $this->logger->error('outbox.consumer.process_failed', [
+                    'msg_id' => $msgId,
+                    'id'     => $id,
+                    'error'  => $e->getMessage(),
+                ]);
+            }
+```
+
+Keep `claimStale()`'s existing "log the XCLAIM at warning" behaviour, adjusting its context key from `row_id`
+to `id` for the same reason.
+
+- [ ] **Step 6: Move the cast and the guard into `ConsumerLoop`**
+
+```php
+        $this->consumer->readOnce(
+            $this->blockMs,
+            function (string $id): void {
+                // The stream layer hands over a raw string, because the publish stream on the other
+                // side of the same interface carries UUIDs. The outbox's unit of work is an integer
+                // row id, so narrowing it — and rejecting anything that is not a positive integer —
+                // is this layer's job now.
+                if (!ctype_digit($id) || (int) $id <= 0) {
+                    return;
+                }
+
+                $rowId       = (int) $id;
+                $disposition = $this->processor->processOne($rowId);
+                if ($disposition === OutboxDisposition::BENIGN_SUCCESS && $this->cascade !== null) {
+                    try {
+                        $this->cascade->evaluate($rowId);
+                    } catch (\Throwable) {
+                        // Never fail the consumer over a cascade decision — the row is already in
+                        // succeeded state and a future sibling success (or admin re-revoke) will
+                        // trigger evaluate() again.
+                    }
+                }
+            },
+        );
+```
+
+- [ ] **Step 7: Run the whole Outbox suite**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/`
+
+Expected: PASS, with at least the count from Step 1 plus the new cases. A DROP in passing tests means a
+regression in the live OpenFGA consumer — stop and fix it before moving on.
+
+- [ ] **Step 8: Static analysis and style**
+
+Run: `composer analyse && composer lint`
+
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Services/Outbox/StreamConsumerInterface.php src/Services/Outbox/RedisStreamConsumer.php \
+        src/Services/Outbox/ConsumerLoop.php phpunit_tests/Services/Outbox/
+git commit -m "refactor(outbox): the stream seam carries a raw id, not an outbox row id"
+```
+
+---
+
+### Task 12: `PublishConsumerLoop`
+
+**Files:**
+
+- Create: `src/Services/SourceData/PublishConsumerLoop.php`
+- Test: `phpunit_tests/Services/SourceData/PublishConsumerLoopTest.php`
+
+**Interfaces:**
+
+- Consumes: Task 11's `StreamConsumerInterface`; `PublishRunner`; Task 6/8's `MergePollRunner`.
+- Produces: `PublishConsumerLoop::__construct(StreamConsumerInterface $consumer, PublishRunner $publisher,
+  ?MergePollRunner $mergePoller = null, int $blockMs = 5000, int $mergePollIntervalSeconds = 60,
+  ?LoggerInterface $logger = null)`, with `tick(): void` and `run(): never`.
+
+`ConsumerLoop` is not reused: it is constructor-typed to `OutboxProcessorInterface`. This is its sibling, with
+the same `tick()` / `run()` split so the loop body stays unit-testable and `run()` stays out of coverage.
+
+- [ ] **Step 1: Write the failing tests**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Services\Outbox\StreamConsumerInterface;
+use LiturgicalCalendar\Api\Services\SourceData\PublishConsumerLoop;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A stream consumer that replays a fixed script of messages, one `readOnce()` at a time. An empty
+ * array for a tick means "blocked and nothing arrived" — the idle tick.
+ */
+final class ScriptedStreamConsumer implements StreamConsumerInterface
+{
+    public int $ensureGroupCalls = 0;
+
+    /** @param list<list<string>> $script */
+    public function __construct(private array $script)
+    {
+    }
+
+    public function ensureGroup(): void
+    {
+        $this->ensureGroupCalls++;
+    }
+
+    public function readOnce(int $blockMs, callable $process): void
+    {
+        foreach (array_shift($this->script) ?? [] as $id) {
+            $process($id);
+        }
+    }
+}
+
+#[CoversClass(PublishConsumerLoop::class)]
+final class PublishConsumerLoopTest extends TestCase
+{
+    public function testAMessageTriggersAPublishRun(): void
+    {
+        $publisher = $this->spyPublishRunner();
+        $loop      = new PublishConsumerLoop(new ScriptedStreamConsumer([['batch-1']]), $publisher);
+
+        $loop->tick();
+
+        self::assertSame(1, $publisher->runs);
+    }
+
+    /**
+     * The message is a HINT, never a work item. The consumer must claim from Postgres, so the batch
+     * id it was handed is never passed to the publisher — a duplicated or out-of-order message then
+     * costs at most one claim against an empty queue.
+     */
+    public function testTheBatchIdIsNeverHandedToThePublisher(): void
+    {
+        $publisher = $this->spyPublishRunner();
+        $loop      = new PublishConsumerLoop(new ScriptedStreamConsumer([['batch-1']]), $publisher);
+
+        $loop->tick();
+
+        self::assertSame([], $publisher->batchIdsReceived);
+    }
+
+    public function testEnsureGroupRunsOnceAcrossManyTicks(): void
+    {
+        $consumer = new ScriptedStreamConsumer([[], [], []]);
+        $loop     = new PublishConsumerLoop($consumer, $this->spyPublishRunner());
+
+        $loop->tick();
+        $loop->tick();
+        $loop->tick();
+
+        self::assertSame(1, $consumer->ensureGroupCalls);
+    }
+
+    /**
+     * `blockMs` is 5000, so an unrated idle tick would poll GitHub 720 times an hour to watch for a
+     * transition nobody is waiting on.
+     */
+    public function testTheIdleMergePollIsRateLimited(): void
+    {
+        $poller = $this->spyMergePollRunner();
+        $loop   = new PublishConsumerLoop(
+            new ScriptedStreamConsumer([[], [], []]),
+            $this->spyPublishRunner(),
+            $poller,
+            blockMs: 0,
+            mergePollIntervalSeconds: 3600
+        );
+
+        $loop->tick();
+        $loop->tick();
+        $loop->tick();
+
+        self::assertSame(1, $poller->runs, 'three idle ticks, one poll');
+    }
+
+    public function testAMergePollFailureDoesNotKillTheConsumer(): void
+    {
+        $poller = $this->spyMergePollRunner(new \RuntimeException('GitHub down'));
+        $loop   = new PublishConsumerLoop(new ScriptedStreamConsumer([[]]), $this->spyPublishRunner(), $poller);
+
+        $loop->tick();
+
+        self::assertTrue(true, 'tick() returned rather than propagating');
+    }
+
+    public function testAPublishRunFailureDoesNotKillTheConsumer(): void
+    {
+        $publisher = $this->spyPublishRunner(new \RuntimeException('database down'));
+        $loop      = new PublishConsumerLoop(new ScriptedStreamConsumer([['batch-1']]), $publisher);
+
+        $loop->tick();
+
+        self::assertTrue(true, 'tick() returned rather than propagating');
+    }
+}
+```
+
+`spyPublishRunner()` / `spyMergePollRunner()` return subclasses of `PublishRunner` / `MergePollRunner` that
+count `runOnce()` calls, record any batch id they are handed, and optionally throw. Neither class is `final`,
+so subclassing works; if either has been made `final` by the time you get here, extract a one-method interface
+rather than weakening the class.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/SourceData/PublishConsumerLoopTest.php`
+
+Expected: FAIL — `Class "…\PublishConsumerLoop" not found`.
+
+- [ ] **Step 3: Write the loop**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+use LiturgicalCalendar\Api\Services\Outbox\StreamConsumerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Long-lived consumer for the source-data publish stream.
+ *
+ * # The message is a hint, not a work item
+ *
+ * A message says WHEN to look; Postgres says WHAT is claimable and by whom. So the batch id is
+ * used only for logging and {@see PublishRunner::runOnce()} does the ordinary claim, exactly as
+ * cron does. Three consequences, all of them the point:
+ *
+ * - A lost `XADD` costs latency, never correctness — the cron backstop finds the batch.
+ * - A duplicate or out-of-order message costs one wasted claim against an empty queue.
+ * - This class inherits every guarantee phase 2 built (the claim protocol, bounded attempts,
+ *   parking, stop-don't-hammer) without reimplementing any of it.
+ *
+ * # Nothing here may kill the consumer
+ *
+ * `PublishRunner` and `MergePollRunner` already catch everything they can and report it in their
+ * result objects, so an exception reaching this loop is unexpected by construction — which is
+ * exactly why it must be caught rather than allowed to end a process that is meant to stay up.
+ * systemd would restart it, but a crash loop against a failing database is the hammering both
+ * runners exist to avoid.
+ *
+ * # The idle tick, and why it is rate-limited
+ *
+ * Merge detection has no event to wake on: nothing at this deployment knows a reviewer clicked
+ * Merge. It runs on the idle tick instead — a `readOnce()` that blocked and returned nothing. With
+ * `blockMs` at 5000 that is every five seconds, or 720 GitHub polls an hour for a transition nobody
+ * is waiting on, so it is rate-limited to `$mergePollIntervalSeconds`. Cron polls it too; this
+ * only shortens the wait.
+ *
+ * Not a reuse of {@see \LiturgicalCalendar\Api\Services\Outbox\ConsumerLoop}, which is
+ * constructor-typed to `OutboxProcessorInterface`. Its sibling, sharing the `tick()` / `run()`
+ * split that keeps the loop body unit-testable.
+ */
+final class PublishConsumerLoop
+{
+    private bool $groupEnsured = false;
+
+    private ?int $lastMergePollAt = null;
+
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly StreamConsumerInterface $consumer,
+        private readonly PublishRunner $publisher,
+        /** Null disables the idle poll; the cron entry point still runs it. */
+        private readonly ?MergePollRunner $mergePoller = null,
+        private readonly int $blockMs = 5000,
+        private readonly int $mergePollIntervalSeconds = 60,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function tick(): void
+    {
+        if (!$this->groupEnsured) {
+            $this->consumer->ensureGroup();
+            $this->groupEnsured = true;
+        }
+
+        $woken = false;
+
+        $this->consumer->readOnce(
+            $this->blockMs,
+            function (string $batchId) use (&$woken): void {
+                $woken = true;
+                $this->logger->info(
+                    'Woken by an approved source-data batch; claiming from the database.',
+                    ['batch_id' => $batchId]
+                );
+
+                try {
+                    $result = $this->publisher->runOnce();
+                    $this->logger->info('Stream-driven publish run finished.', [
+                        'published'          => $result->published,
+                        'stopped_on_failure' => $result->stoppedOnFailure,
+                        'parked'             => $result->parkedBatches,
+                    ]);
+                } catch (\Throwable $e) {
+                    // PublishRunner catches everything it can, so reaching here is unexpected —
+                    // which is why it must not end the process. See the class docblock.
+                    $this->logger->error('Stream-driven publish run threw; the consumer stays up.', [
+                        'batch_id'  => $batchId,
+                        'exception' => $e::class,
+                        'message'   => $e->getMessage(),
+                    ]);
+                }
+            },
+        );
+
+        if (!$woken) {
+            $this->pollMergesIfDue();
+        }
+    }
+
+    private function pollMergesIfDue(): void
+    {
+        if (null === $this->mergePoller) {
+            return;
+        }
+
+        $now = time();
+        if (null !== $this->lastMergePollAt && ( $now - $this->lastMergePollAt ) < $this->mergePollIntervalSeconds) {
+            return;
+        }
+        $this->lastMergePollAt = $now;
+
+        try {
+            $result = $this->mergePoller->runOnce();
+            if ($result->merged > 0 || $result->closed > 0 || $result->reset > 0) {
+                $this->logger->info('Idle-tick merge poll settled some batches.', [
+                    'merged' => $result->merged,
+                    'closed' => $result->closed,
+                    'reset'  => $result->reset,
+                ]);
+            }
+        } catch (\Throwable $e) {
+            $this->logger->error('Idle-tick merge poll threw; the consumer stays up.', [
+                'exception' => $e::class,
+                'message'   => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Forever. systemd restarts on crash.
+     *
+     * @codeCoverageIgnore
+     */
+    public function run(): never
+    {
+        while (true) {
+            $this->tick();
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/SourceData/PublishConsumerLoopTest.php`
+
+Expected: PASS.
+
+- [ ] **Step 5: Static analysis and style**
+
+Run: `composer analyse && composer lint`
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Services/SourceData/PublishConsumerLoop.php \
+        phpunit_tests/Services/SourceData/PublishConsumerLoopTest.php
+git commit -m "feat(sourcedata): a stream consumer that wakes the publisher, with an idle merge poll"
+```
+
+---
+
+### Task 13: One factory, three entry points
+
+**Files:**
+
+- Create: `src/Services/SourceData/SourceDataPublisherFactory.php`, `scripts/poll-sourcedata-merges.php`,
+  `bin/publish-sourcedata-consumer`
+- Modify: `scripts/publish-sourcedata.php`
+- Test: `phpunit_tests/Services/SourceData/SourceDataPublisherFactoryTest.php` (create),
+  `phpunit_tests/Services/SourceData/PublishSourceDataScriptTest.php`,
+  `phpunit_tests/Services/SourceData/PollSourceDataMergesScriptTest.php` (create)
+
+**Interfaces:**
+
+- Consumes: everything above.
+- Produces: `SourceDataPublisherFactory` with
+  `logger(string $channel): LoggerInterface`, `repository(): SourceDataChangeRequestRepository`,
+  `publishRunner(LoggerInterface $logger): PublishRunner`, `mergePollRunner(LoggerInterface $logger): MergePollRunner`,
+  and `publishNotifier(): SourceDataPublishNotifier`.
+
+**Why this exists.** Phase 2's most expensive defect was a script CONSTRUCTING what every test INJECTED: the
+cron entry took `LoggerFactory::create()`'s default processors, which throw on non-request context, so every log
+line the runner wrote would have thrown in production — including the ones inside its catch blocks, before
+`releaseClaim()` ran. Every test passed; no test crossed that seam. Phase 3 adds two more entry points to the
+same wiring. Moving it into `src/` also brings it under `composer analyse`, which scans `paths: [src]` only.
+
+- [ ] **Step 1: Write the failing tests**
+
+`phpunit_tests/Services/SourceData/SourceDataPublisherFactoryTest.php`:
+
+```php
+/**
+ * The defect this factory exists to prevent, pinned directly. LoggerFactory's default attaches
+ * RequestResponseProcessor, which THROWS on any record whose context lacks type => request|response
+ * — and the runners log batch ids. If this ever regresses, every log call in production throws,
+ * including the ones inside the catch blocks, stranding the batch.
+ */
+public function testTheLoggerDoesNotThrowOnARunnerShapedRecord(): void
+{
+    $logger = ( new SourceDataPublisherFactory() )->logger('publish-sourcedata-test');
+
+    $logger->info('a runner-shaped record', ['batch_id' => 'batch-1', 'exception' => 'RuntimeException']);
+
+    self::assertTrue(true, 'no exception was thrown');
+}
+
+public function testMergePollRunnerIsBuiltWhenTheGithubAppIsConfigured(): void
+{
+    $this->withGithubAppEnv(function (): void {
+        $factory = new SourceDataPublisherFactory();
+        self::assertInstanceOf(
+            MergePollRunner::class,
+            $factory->mergePollRunner($factory->logger('poll-sourcedata-merges-test'))
+        );
+    });
+}
+
+/**
+ * GITHUB_REPOSITORY is a GitHub Actions built-in injected into every job as owner/repo. Clearing
+ * only $_ENV leaves getenv() serving it, which passes locally and fails CI — every time.
+ */
+public function testAMalformedRepositoryIsRejectedRatherThanFatal(): void
+{
+    $this->withGithubAppEnv(function (): void {
+        $_ENV['GITHUB_REPOSITORY'] = 'https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI';
+        putenv('GITHUB_REPOSITORY=https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI');
+
+        $factory = new SourceDataPublisherFactory();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $factory->mergePollRunner($factory->logger('poll-sourcedata-merges-test'));
+    });
+}
+
+public function testPublishNotifierIsANoOpWithoutRedisConfiguration(): void
+{
+    unset($_ENV['REDIS_SOCKET'], $_ENV['REDIS_HOST']);
+    putenv('REDIS_SOCKET');
+    putenv('REDIS_HOST');
+
+    // Must not throw, must not connect.
+    ( new SourceDataPublisherFactory() )->publishNotifier()->notify('batch-1');
+
+    self::assertTrue(true);
+}
+```
+
+`withGithubAppEnv()` sets `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY_PATH` and
+`GITHUB_REPOSITORY` in **both** `$_ENV` and `putenv()`, runs the closure, and restores both in a `finally`.
+
+`phpunit_tests/Services/SourceData/PollSourceDataMergesScriptTest.php` mirrors `PublishSourceDataScriptTest`:
+run the real script with `proc_open`, assert on its exit code and its summary line.
+
+```php
+public function testItExitsOneAndSaysWhyWhenTheGithubAppIsUnconfigured(): void
+{
+    [$stdout, $stderr, $exit] = $this->runScript([], env: ['GITHUB_REPOSITORY' => '']);
+
+    self::assertSame(1, $exit);
+    self::assertStringContainsString('not configured', $stderr);
+}
+
+public function testItReportsASummaryLine(): void
+{
+    [$stdout, , $exit] = $this->runScript([], env: $this->configuredGithubEnv());
+
+    self::assertMatchesRegularExpression(
+        '/^poll-sourcedata-merges merged=\d+ closed=\d+ reset=\d+ unpollable=\d+ stopped_on_failure=(true|false)$/m',
+        $stdout
+    );
+    self::assertContains($exit, [0, 1]);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+vendor/bin/phpunit phpunit_tests/Services/SourceData/SourceDataPublisherFactoryTest.php
+vendor/bin/phpunit phpunit_tests/Services/SourceData/PollSourceDataMergesScriptTest.php
+```
+
+Expected: FAIL — the factory class and the script do not exist.
+
+- [ ] **Step 3: Write the factory**
+
+Move the wiring currently inline in `scripts/publish-sourcedata.php` into
+`src/Services/SourceData/SourceDataPublisherFactory.php` verbatim, preserving every comment that explains WHY —
+the `includeProcessors: false` argument, the umask window around the token cache, the explicit Guzzle timeouts
+and their relationship to `PublishRunner::DEFAULT_GRACE_SECONDS`. Those comments are the record of what went
+wrong; do not summarise them away in the move.
+
+```php
+    /**
+     * `includeProcessors: false` — the sixth argument, and load-bearing rather than cosmetic.
+     * LoggerFactory's default attaches RequestResponseProcessor, which THROWS a RuntimeException for
+     * any record whose context does not carry type => request|response. The runners log batch ids,
+     * so with the default every log call they make — including the ones inside their catch blocks —
+     * would throw from inside the failure handling, before releaseClaim() ever ran, stranding the
+     * batch and killing the process.
+     */
+    public function logger(string $channel): LoggerInterface
+    {
+        return LoggerFactory::create($channel, null, 30, false, true, false);
+    }
+```
+
+`publishNotifier()` resolves `\Redis` from `REDIS_SOCKET` / `REDIS_HOST` / `REDIS_PORT` / `REDIS_PASSWORD`,
+returning a notifier over a null `\Redis` when `ext-redis` is missing or neither host nor socket is set —
+never throwing, because Redis is optional.
+
+`mergePollRunner()` builds the same Guzzle client and token cache the publisher uses and constructs
+`MergePollRunner` with the repository, a `GitHubGitDataClient`, an optional
+`ResourceTuplePurgeServiceInterface` (null when OpenFGA is unconfigured) and an `AuditLogRepository`.
+
+- [ ] **Step 4: Rewire `scripts/publish-sourcedata.php`**
+
+Replace the inline wiring with factory calls. **The CLI contract does not change** — `[limit]` positional,
+same exit codes, same `publish-sourcedata published=N stopped_on_failure=B parked=N` summary line — because
+`PublishSourceDataScriptTest` pins it and the runbook documents it. Update the file's header docblock to say
+its ROLE is now the backstop behind the stream consumer, catching a lost `XADD` or a dead consumer.
+
+- [ ] **Step 5: Write `scripts/poll-sourcedata-merges.php`**
+
+Same shape as `publish-sourcedata.php`: CLI-only guard, Dotenv chain over the same six files, logger first,
+factory, wrapped run, summary line, exit code. Its docblock must state:
+
+```text
+ * Exit codes:
+ *   0  Every open pull request was polled, or there were none.
+ *   1  Misconfiguration (GitHub App or GITHUB_REPOSITORY unset OR malformed — GITHUB_REPOSITORY
+ *      must be exactly "owner/repo"), a database failure, OR a poll failed and the run stopped
+ *      early.
+ *
+ * The summary line also reports `reset=N` and `unpollable=N`. `reset` counts batches whose pull
+ * request merged WITHOUT them (a review that landed concurrently with a publish); they are
+ * claimable again and the next publish opens a fresh pull request carrying them, so this is not a
+ * failure — but a value that keeps climbing means publishes and merges are racing routinely.
+ * `unpollable` counts `open` batches with no pull request number, which should always be zero;
+ * a non-zero value is an unexplained state that needs an operator, and it does NOT affect the
+ * exit code, so monitor the line and GET /health, not the exit code alone.
+```
+
+Catch `\Throwable` around the factory call, not `\RuntimeException`: `fromEnv()` throws
+`InvalidArgumentException` — a `LogicException`, not a `RuntimeException` — for a malformed
+`GITHUB_REPOSITORY`, which is one pasted repository URL away for any operator. A narrower catch is what made
+phase 2's publisher exit 255 with nothing logged past "run starting".
+
+- [ ] **Step 6: Write `bin/publish-sourcedata-consumer`**
+
+Mirror `bin/reconcile-outbox`'s structure: CLI guard, the same Dotenv chain, an `ext-redis` check that exits 2
+with a clear message, `\Redis` connection from `REDIS_SOCKET` or `REDIS_HOST`/`REDIS_PORT` plus optional
+`REDIS_PASSWORD`, then:
+
+```php
+$streamName   = (string) ($_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM']   ?? 'litcal:sourcedata-publish-stream');
+$groupName    = (string) ($_ENV['REDIS_SOURCEDATA_PUBLISH_GROUP']    ?? 'sourcedata-publisher');
+$consumerName = (string) ($_ENV['REDIS_SOURCEDATA_PUBLISH_CONSUMER'] ?? (gethostname() ?: 'consumer'));
+
+$factory = new SourceDataPublisherFactory();
+$logger  = $factory->logger('publish-sourcedata-consumer');
+
+$stream = new RedisStreamConsumer($redis, $streamName, $groupName, $consumerName, $logger, 'batch_id');
+$loop   = new PublishConsumerLoop(
+    $stream,
+    $factory->publishRunner($logger),
+    $factory->mergePollRunner($logger),
+    blockMs: 5000,
+    logger: $logger
+);
+
+$loop->run();
+```
+
+Note the sixth `RedisStreamConsumer` argument: `'batch_id'`, not the `row_id` default. Getting that wrong makes
+every message look malformed and get ACKed away — silently, since the consumer would report "bad message" and
+carry on.
+
+- [ ] **Step 7: RUN all three entry points for real**
+
+This step is not optional and is not covered by any unit test. Two defects shipped in phase 2 with entirely
+green suites because a script constructed what tests injected.
+
+```bash
+php scripts/publish-sourcedata.php 1 ; echo "exit=$?"
+php scripts/poll-sourcedata-merges.php ; echo "exit=$?"
+timeout 12 php bin/publish-sourcedata-consumer ; echo "exit=$?"
+tail -n 40 logs/publish-sourcedata*.log logs/poll-sourcedata-merges*.log
+```
+
+Expected: each prints its summary line (or a clear configuration error) and exits 0 or 1 — never 255, never a
+stack trace. The consumer stays up for the full 12 seconds and is killed by `timeout` (exit 124). Confirm the
+log files exist, are readable (not 0600 — the umask window must cover only the token cache), and contain a
+`run starting` record. **A log file that is empty or missing means the logger is throwing.**
+
+- [ ] **Step 8: PHPStan the scripts standalone**
+
+`phpstan.neon.dist` scans `paths: [src]` only, so CI will not check these:
+
+```bash
+composer analyse
+vendor/bin/phpstan analyse --level=10 scripts/publish-sourcedata.php scripts/poll-sourcedata-merges.php bin/publish-sourcedata-consumer
+composer lint && composer parallel-lint
+```
+
+Expected: clean.
+
+- [ ] **Step 9: Run the full suite**
+
+Run: `composer test`
+
+Expected: no failures, and no drop against the phase-2 baseline of 4,136 tests.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/Services/SourceData/SourceDataPublisherFactory.php scripts/publish-sourcedata.php \
+        scripts/poll-sourcedata-merges.php bin/publish-sourcedata-consumer \
+        phpunit_tests/Services/SourceData/SourceDataPublisherFactoryTest.php \
+        phpunit_tests/Services/SourceData/PollSourceDataMergesScriptTest.php \
+        phpunit_tests/Services/SourceData/PublishSourceDataScriptTest.php
+git commit -m "feat(sourcedata): one wiring factory behind cron, the merge poller and the consumer"
+```
+
+---
+
+### Task 14: Health reports what is awaiting a merge decision
+
+**Files:**
+
+- Modify: `src/Health.php`
+- Test: `phpunit_tests/HealthSourceDataPublisherTest.php`
+
+**Interfaces:**
+
+- Consumes: Task 5's `SourceDataChangeRequestRepository::openBatchStats()`.
+- Produces: `Health::buildSourceDataPublisherStatus(): array{status: 'ok'|'warning', message: string,
+  parked_batches: int, open_batches: int, oldest_open_age_seconds: int}` — two keys added, none removed.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `phpunit_tests/HealthSourceDataPublisherTest.php`:
+
+```php
+public function testTheBlockReportsOpenBatchesAndTheOldestAge(): void
+{
+    $status = Health::buildSourceDataPublisherStatus();
+
+    self::assertArrayHasKey('open_batches', $status);
+    self::assertArrayHasKey('oldest_open_age_seconds', $status);
+    self::assertIsInt($status['open_batches']);
+    self::assertIsInt($status['oldest_open_age_seconds']);
+}
+
+/**
+ * An open pull request is the ORDINARY state — a reviewer has not got to it yet — so it must not
+ * alarm. Only the age carries a signal, and only past a threshold no review plausibly reaches.
+ */
+public function testAnOpenBatchIsNotItselfAWarning(): void
+{
+    $this->givenAnOpenBatchAgedSeconds(3600);
+
+    $status = Health::buildSourceDataPublisherStatus();
+
+    self::assertSame(1, $status['open_batches']);
+    self::assertNotSame('warning', $status['status'], 'a pull request awaiting review is not a fault');
+}
+
+public function testAVeryOldOpenBatchWarnsWithoutBlamingTheReviewer(): void
+{
+    $this->givenAnOpenBatchAgedSeconds(Health::STALE_OPEN_BATCH_SECONDS + 60);
+
+    $status = Health::buildSourceDataPublisherStatus();
+
+    self::assertSame('warning', $status['status']);
+    self::assertStringContainsString('poll-sourcedata-merges', $status['message']);
+}
+
+/**
+ * The degradation rule the whole block already follows: a database that is down must not break the
+ * endpoint monitoring relies on.
+ */
+public function testTheCountsDegradeToZeroWhenTheDatabaseIsUnreachable(): void
+{
+    $this->withUnreachableDatabase(function (): void {
+        $status = Health::buildSourceDataPublisherStatus();
+
+        self::assertSame(0, $status['open_batches']);
+        self::assertSame(0, $status['oldest_open_age_seconds']);
+    });
+}
+```
+
+`givenAnOpenBatchAgedSeconds()` inserts a row at `publication_status = 'open'` with a backdated `updated_at`;
+`withUnreachableDatabase()` follows whatever pattern the existing test in this file already uses to exercise
+the `Connection::isConfigured()` guard.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/HealthSourceDataPublisherTest.php`
+
+Expected: FAIL — `assertArrayHasKey('open_batches', …)` fails; `Health::STALE_OPEN_BATCH_SECONDS` is undefined.
+
+- [ ] **Step 3: Add the constant and the stats reader**
+
+In `src/Health.php`, beside the existing publisher helpers:
+
+```php
+    /**
+     * How long a batch may sit `open` before `/health` says something.
+     *
+     * Thirty days, deliberately generous, because this number does NOT measure a fault: a pull
+     * request awaiting review is the ordinary state, and a reviewer who has not got to one in a
+     * fortnight is a reviewer, not an outage. What it catches is the case where the age keeps
+     * climbing because nothing is polling at all — no cron entry for
+     * `scripts/poll-sourcedata-merges.php`, no consumer running — which is otherwise INVISIBLE:
+     * a merged pull request whose merge is never detected looks exactly like an unreviewed one
+     * from this side, and every editor is told their change is still awaiting review forever.
+     *
+     * The message says both readings out loud rather than accusing the poller, because at this
+     * threshold either is genuinely possible.
+     */
+    public const STALE_OPEN_BATCH_SECONDS = 2_592_000;
+
+    /**
+     * Read through the same `Connection::isConfigured()` + catch-everything guard
+     * {@see buildOutboxStats()} uses: a database that is down must degrade this block to zeroes,
+     * not break the endpoint monitoring relies on.
+     *
+     * @return array{open_batches: int, oldest_open_age_seconds: int}
+     */
+    private static function openChangeRequestBatchStats(): array
+    {
+        if (!Connection::isConfigured()) {
+            return ['open_batches' => 0, 'oldest_open_age_seconds' => 0];
+        }
+
+        try {
+            return ( new SourceDataChangeRequestRepository(Connection::getInstance()) )->openBatchStats();
+        } catch (\Throwable) {
+            return ['open_batches' => 0, 'oldest_open_age_seconds' => 0];
+        }
+    }
+```
+
+- [ ] **Step 4: Fold the two keys into every return path**
+
+`buildSourceDataPublisherStatus()` has four `return` statements. **Every one** must carry the new keys, or a
+deployment in the unconfigured-publisher state — the one this block exists to catch — would answer without
+them and break a client that reads them unconditionally. Read the stats once at the top, beside `$parked`:
+
+```php
+        $queueModeOn = SourceDataWriteMode::changeRequestsEnabled();
+        $configured  = SourceDataPublisher::isConfigured();
+        $parked      = self::parkedChangeRequestBatches();
+        $open        = self::openChangeRequestBatchStats();
+```
+
+then add `...$open,` to each returned array, and insert the new branch AFTER the existing `$parked > 0` branch
+(an unconfigured publisher and a parked batch are both more actionable than a stale poll):
+
+```php
+        if ($open['oldest_open_age_seconds'] > self::STALE_OPEN_BATCH_SECONDS) {
+            return [
+                'status'         => 'warning',
+                'message'        => sprintf(
+                    'A source data change request batch has been awaiting a merge decision for %d days. Either a '
+                        . 'reviewer has not reached its pull request, or nothing is detecting merges — check that '
+                        . 'scripts/poll-sourcedata-merges.php runs on a schedule, or that the publish consumer is up. '
+                        . 'An undetected merge is invisible from this side: it looks exactly like an unreviewed one, '
+                        . 'and every editor waiting on it is told it is still open',
+                    intdiv($open['oldest_open_age_seconds'], 86400)
+                ),
+                'parked_batches' => $parked,
+                ...$open,
+            ];
+        }
+```
+
+Update the method's `@return` shape to include both new keys.
+
+- [ ] **Step 5: Run the tests**
+
+Run:
+
+```bash
+vendor/bin/phpunit phpunit_tests/HealthSourceDataPublisherTest.php
+vendor/bin/phpunit --filter Health
+```
+
+Expected: PASS, with no regression in the other Health tests.
+
+- [ ] **Step 6: Static analysis and style**
+
+Run: `composer analyse && composer lint`
+
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Health.php phpunit_tests/HealthSourceDataPublisherTest.php
+git commit -m "feat(health): report batches awaiting a merge decision, and a poll that has stopped"
+```
+
+---
+
+### Task 15: Operator documentation
+
+**Files:**
+
+- Modify: `docs/ops/change-request-runbook.md`, `.env.example`, `CHANGELOG.md`,
+  `docs/superpowers/2026-08-30-phase-3-handoff.md`
+
+**Interfaces:**
+
+- Consumes: everything above.
+- Produces: no code. This task is what makes phase 3 operable by somebody who did not build it.
+
+- [ ] **Step 1: Add the new environment variables**
+
+In `.env.example`, beside the existing commented Redis block and the `REDIS_OUTBOX_*` group:
+
+```bash
+# --- Source-data publish stream (optional) -----------------------------------
+# Latency only. The queue of record stays in Postgres: an approved batch is durable there and
+# scripts/publish-sourcedata.php is the backstop, so with Redis absent everything still publishes —
+# it just waits for the next cron tick instead of waking in under a second.
+REDIS_SOURCEDATA_PUBLISH_STREAM=litcal:sourcedata-publish-stream
+REDIS_SOURCEDATA_PUBLISH_GROUP=sourcedata-publisher
+REDIS_SOURCEDATA_PUBLISH_CONSUMER=          # default: hostname
+```
+
+- [ ] **Step 2: Extend the runbook**
+
+Add a `## Merge detection (phase 3)` section after `### Exit codes and monitoring`, covering:
+
+1. **The lifecycle, completed.** `none` → `queued` → `open` → `merged` | `closed`, and what writes each.
+2. **The two cron entries**, with real crontab lines:
+
+   ```cron
+   */5 * * * * cd /path/to/api && php scripts/publish-sourcedata.php >> logs/cron-publish.log 2>&1
+   */5 * * * * cd /path/to/api && php scripts/poll-sourcedata-merges.php >> logs/cron-poll.log 2>&1
+   ```
+
+3. **The consumer as an optional accelerator**, with a systemd unit mirroring the outbox consumer's, and the
+   explicit statement that it is optional: cron alone is a complete, correct deployment.
+4. **`reset=N` on the poll summary line** — what a concurrent merge is, why the batch is republished rather
+   than marked merged, and why a value that keeps climbing means publishes and merges are racing routinely.
+5. **`unpollable=N`** — should always be zero; a non-zero value is an unexplained state. Include the SQL:
+
+   ```sql
+   SELECT batch_id, resource_type, resource_id, commit_sha, updated_at
+     FROM sourcedata_change_requests
+    WHERE publication_status = 'open' AND pr_number IS NULL;
+   ```
+
+6. **Replace the "Known limitation: a deleted resource's editors keep access" section.** It is now closed.
+   State what closed it (the merge-time purge), what the trigger is (`metadata.deletes_resource`, NOT
+   `operation = 'delete'`), and that `admin` tuples deliberately survive so a recreated resource id keeps its
+   owner. Include the SQL to find a deletion batch that merged:
+
+   ```sql
+   SELECT DISTINCT batch_id, resource_type, resource_id, merge_commit_sha, publication_settled_at
+     FROM sourcedata_change_requests
+    WHERE publication_status = 'merged'
+      AND metadata->>'deletes_resource' = 'true'
+    ORDER BY publication_settled_at DESC;
+   ```
+
+7. **Un-parking and claim tokens.** The existing "Parked batches" SQL clears `publish_attempts`; note that
+   `publish_claim_token` is cleared by the same recovery and that a row `queued` with a token older than the
+   grace period is reclaimed automatically.
+
+- [ ] **Step 3: Add the CHANGELOG entry**
+
+Follow the file's existing format. Cover: merge detection with containment verification; the OpenFGA purge for
+merged deletions (closing the known limitation phase 2 documented); claim ownership; change-request
+notifications on `GET /auth/notifications`, calling out that `items` is now a **discriminated** list and
+clients must switch on `type`; the optional Redis publish stream; two new `/health` keys. The notifications
+shape change is the only one a client can trip over — say so plainly.
+
+- [ ] **Step 4: Update the phase-3 handoff document**
+
+`docs/superpowers/2026-08-30-phase-3-handoff.md` currently says phase 3 is "not started" and lists five
+obligations. Update the table, mark obligations 1–3 done with the commits that closed them, and leave 4
+(per-file `base_sha`) and 5 (schema re-validation at the approval gate) as the two that remain — each needs
+its own issue. Add what phase 3 learned, in the same "traps this project has already paid for" spirit:
+
+- `operation = 'delete'` does not mean a resource was deleted. `RegionalDataHandler::writeI18nFiles()` stages a
+  DELETE per dropped locale on a calendar that still exists, so keying authorization changes on the operation
+  revokes every editor on a live calendar because a translator removed a language.
+- Sharing a pull request number is not being in its merge. A reviewer merging concurrently with a publish
+  separates them, and marking the overtaken batch `merged` loses its content silently.
+
+- [ ] **Step 5: Lint the markdown**
+
+Run: `composer lint:md`
+
+Expected: 0 issues. If MD060 fires on a table, align its pipes by hand — `lint:md:fix` does not fix alignment.
+
+- [ ] **Step 6: File the two follow-up issues**
+
+```bash
+gh issue create --repo Liturgical-Calendar/LiturgicalCalendarAPI \
+  --title "Keep per-file base_sha so rebase detection is possible" \
+  --body "Deferred from phase 3 (#902). recordPublication() overwrites every row's base_sha with the batch-level branch head, destroying the per-file bookkeeping a rebase check needs. See docs/superpowers/specs/2026-08-30-sourcedata-merge-detection-design.md, Scope."
+
+gh issue create --repo Liturgical-Calendar/LiturgicalCalendarAPI \
+  --title "Re-validate a change request against the current schema before publishing" \
+  --body "Deferred from phase 3 (#902). approveBatch() is a single status UPDATE, so a batch approved against one schema and published after that schema changed produces a pull request whose CI fails lint:jsondata — a backstop on the wrong side of the gate. See docs/superpowers/specs/2026-08-30-sourcedata-merge-detection-design.md, Scope."
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/ops/change-request-runbook.md .env.example CHANGELOG.md docs/superpowers/2026-08-30-phase-3-handoff.md
+git commit -m "docs(sourcedata): operate phase 3 — merge detection, the purge, and the publish stream"
+```
+
+---
+
+## Final verification
+
+Run before opening the pull request. Nothing here is optional, and two of the four steps exist because a green
+suite has already lied to this project twice.
+
+- [ ] **Full suite, no drop against the phase-2 baseline**
+
+```bash
+composer test
+```
+
+Expected: 0 failures, and no fewer than phase 2's 4,136 tests.
+
+- [ ] **Static analysis, including the parts CI does not scan**
+
+```bash
+composer analyse
+vendor/bin/phpstan analyse --level=10 scripts/publish-sourcedata.php scripts/poll-sourcedata-merges.php bin/publish-sourcedata-consumer
+composer lint && composer parallel-lint && composer lint:md && composer lint:jsondata
+```
+
+Expected: clean. `phpstan.neon.dist` scans `paths: [src]` only — the standalone run is the only thing checking
+the three entry points.
+
+- [ ] **Run the entry points, do not merely test them**
+
+```bash
+php scripts/publish-sourcedata.php 1 ; echo "exit=$?"
+php scripts/poll-sourcedata-merges.php ; echo "exit=$?"
+timeout 12 php bin/publish-sourcedata-consumer ; echo "exit=$?"
+ls -l logs/publish-sourcedata*.log logs/poll-sourcedata-merges*.log
+```
+
+Expected: summary lines or clear configuration errors; exit 0 or 1, never 255 and never a stack trace; the
+consumer survives its 12 seconds. **An empty or missing log file means the logger is throwing** — the exact
+defect `SourceDataPublisherFactory` exists to prevent.
+
+- [ ] **Migration round-trip**
+
+```bash
+vendor/bin/doctrine-migrations migrate prev --no-interaction
+vendor/bin/doctrine-migrations migrate --no-interaction
+```
+
+Expected: both succeed. A `down()` that leaves an index behind fails the second `migrate`.
+
+- [ ] **Open the pull request**
+
+```bash
+gh pr create --base development --title "feat(data): merge detection and stream publishing — phase 3"
+```
+
+`--base development`. Never `main`.
+
+The body must cover, because a reviewer cannot infer any of them from the diff:
+
+- **Why containment is verified rather than assumed** — a reviewer merging concurrently with a publish leaves a
+  batch on the branch and outside the merge, and marking it `merged` loses its content silently.
+- **Why `operation = 'delete'` is not the purge trigger** — the i18n locale-removal path stages deletes on a
+  calendar that still exists.
+- **That `GET /auth/notifications` `items` is now a discriminated list** — the one change a client can trip over.
+- **That Redis is optional** and cron alone remains a complete deployment.
+- **What was deferred** and to which issues.
+
+## What this plan does not do
+
+Named here so a reviewer does not read their absence as an oversight:
+
+- **Per-file `base_sha` and rebase detection**, and **schema re-validation at the approval gate** — deferred
+  from phase 3, each filed as its own issue in Task 15.
+- **The frontend inbox UI.** `GET /auth/notifications` carries `change_request_published` items after this;
+  rendering them is a follow-up issue in `LiturgicalCalendarFrontend`.
+- **Moving the claim protocol into Redis consumer groups.** #915 excludes it explicitly: it would make Redis
+  mandatory and break a self-hoster running cron only.
+- **Notifying on review decisions** (approve, reject at the gate). Equally unnotified today, but a phase-1 gap
+  rather than something phase 3 produces.

--- a/docs/superpowers/plans/2026-08-30-sourcedata-merge-detection-phase3.md
+++ b/docs/superpowers/plans/2026-08-30-sourcedata-merge-detection-phase3.md
@@ -234,7 +234,7 @@ final class Version20260830120000 extends AbstractMigration
 Run:
 
 ```bash
-vendor/bin/doctrine-migrations migrate --no-interaction
+bin/doctrine-migrations migrate --no-interaction
 vendor/bin/phpunit phpunit_tests/Repositories/SourceDataChangeRequestSchemaTest.php
 ```
 
@@ -245,8 +245,8 @@ Expected: PASS.
 Run:
 
 ```bash
-vendor/bin/doctrine-migrations migrate prev --no-interaction
-vendor/bin/doctrine-migrations migrate --no-interaction
+bin/doctrine-migrations migrate prev --no-interaction
+bin/doctrine-migrations migrate --no-interaction
 ```
 
 Expected: both succeed. A `down()` that leaves an index behind makes the second `migrate` fail on a duplicate
@@ -2894,6 +2894,12 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(SourceDataPublishNotifier::class)]
 final class SourceDataPublishNotifierTest extends TestCase
 {
+    // NO `extension_loaded('redis')` guard on any test in this file, deliberately.
+    // `phpunit_tests/bootstrap.php` loads `stubs/Redis.php` whenever the extension is absent, so
+    // `\Redis` and `\RedisException` always exist under PHPUnit. A skip guard here would silently
+    // skip this class's two most important tests on any machine without ext-redis — which is every
+    // developer machine AND CI.
+
     public function testANullRedisIsAQuietNoOp(): void
     {
         // A self-hoster running cron only has no Redis. This must not throw and must not log.
@@ -2907,10 +2913,6 @@ final class SourceDataPublishNotifierTest extends TestCase
 
     public function testItXaddsTheBatchId(): void
     {
-        if (!extension_loaded('redis')) {
-            self::markTestSkipped('ext-redis is required for this test');
-        }
-
         $redis = $this->createMock(\Redis::class);
         $redis->expects(self::once())
             ->method('xAdd')
@@ -2927,10 +2929,6 @@ final class SourceDataPublishNotifierTest extends TestCase
      */
     public function testARedisFailureIsLoggedAndSwallowed(): void
     {
-        if (!extension_loaded('redis')) {
-            self::markTestSkipped('ext-redis is required for this test');
-        }
-
         $redis = $this->createMock(\Redis::class);
         $redis->method('xAdd')->willThrowException(new \RedisException('connection refused'));
 
@@ -3922,10 +3920,38 @@ timeout 12 php bin/publish-sourcedata-consumer ; echo "exit=$?"
 tail -n 40 logs/publish-sourcedata*.log logs/poll-sourcedata-merges*.log
 ```
 
-Expected: each prints its summary line (or a clear configuration error) and exits 0 or 1 — never 255, never a
-stack trace. The consumer stays up for the full 12 seconds and is killed by `timeout` (exit 124). Confirm the
-log files exist, are readable (not 0600 — the umask window must cover only the token cache), and contain a
-`run starting` record. **A log file that is empty or missing means the logger is throwing.**
+Expected for the two cron scripts: each prints its summary line (or a clear configuration error) and exits 0
+or 1 — never 255, never a stack trace. Confirm their log files exist, are readable (not 0600 — the umask
+window must cover only the token cache), and contain a `run starting` record. **A log file that is empty or
+missing means the logger is throwing.**
+
+Expected for the consumer: **`exit=2` with the message that `ext-redis` is required.** This machine has
+neither the extension nor a Redis server, so the loop cannot be reached, and that exit verifies the guard
+rather than the wiring. Do NOT install anything to get past it, and do NOT report the consumer as smoke
+-tested.
+
+Because the consumer's wiring therefore goes unexercised, add the one assertion a runtime smoke test would
+have made — the payload field. Getting it wrong makes every message look malformed and be ACKed away
+silently, with a "bad message" log and no other symptom:
+
+```php
+public function testTheConsumerEntryPointReadsTheBatchIdField(): void
+{
+    $source = file_get_contents(__DIR__ . '/../../../bin/publish-sourcedata-consumer');
+    self::assertIsString($source);
+
+    self::assertStringContainsString(
+        "'batch_id'",
+        $source,
+        "bin/publish-sourcedata-consumer must pass 'batch_id' as RedisStreamConsumer's payload field; "
+            . "the default is 'row_id', which would make every message look malformed and be ACKed away"
+    );
+}
+```
+
+A source-text assertion is a poor substitute for running the thing, and it is chosen here only because the
+runtime path is unreachable in this environment. Say so in the report, so the reviewer weighs it as the
+stopgap it is rather than as coverage.
 
 - [ ] **Step 8: PHPStan the scripts standalone**
 
@@ -4294,8 +4320,8 @@ defect `SourceDataPublisherFactory` exists to prevent.
 - [ ] **Migration round-trip**
 
 ```bash
-vendor/bin/doctrine-migrations migrate prev --no-interaction
-vendor/bin/doctrine-migrations migrate --no-interaction
+bin/doctrine-migrations migrate prev --no-interaction
+bin/doctrine-migrations migrate --no-interaction
 ```
 
 Expected: both succeed. A `down()` that leaves an index behind fails the second `migrate`.

--- a/docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md
+++ b/docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md
@@ -538,6 +538,12 @@ Phase 3) must perform this purge for both `RegionalDataHandler`'s calendar delet
 
 ## Phase 3: merge detection
 
+**Specified in full (2026-08-30) in [`2026-08-30-sourcedata-merge-detection-design.md`](2026-08-30-sourcedata-merge-detection-design.md),**
+which settles the four decisions this section defers by name — whether `closed` belongs in the
+accumulation-base exclusion, the claim-ownership token, the trigger for the OpenFGA purge, and how
+the submitter is notified — and folds in #915's Redis stream. The sketch below is still accurate;
+it is simply not the whole of it.
+
 Polling, not webhooks. `GET /repos/{o}/{r}/pulls/{number}` returns `merged`, `merged_at` and
 `merge_commit_sha`; it runs on the consumer's idle tick and on the existing five-minute cron
 backstop.
@@ -615,7 +621,7 @@ forever parks rather than retrying forever.
 | ----- | -------------------------------------------------------------------------------------- |
 | 1     | `SourceDataWriter` seam, change requests, approval, RBAC admin UI, history. No GitHub. |
 | 2     | GitHub App, `SourceDataPublishProcessor`, rolling PRs.                                 |
-| 3     | Merge polling, status transitions, notifications.                                      |
+| 3     | Merge polling, status transitions, notifications, Redis-stream publishing (#915).      |
 | 4     | Preview: compute a calendar in memory with a pending change applied.                   |
 
 Phase 1 is independently valuable: once `SOURCEDATA_CHANGE_REQUESTS` is enabled on a deployment,
@@ -638,10 +644,12 @@ exactly what it is today.
 - **Federated upstream submission.** A third `SourceDataWriter` that submits change requests to the
   upstream canonical API, so a self-hosting diocese pools its edits rather than forking to local
   disk. The interface exists for this; the implementation does not.
-- **OpenFGA operational-tuple purge for merged deletions.** See "Side effects a merged deletion must
-  still perform" under Phase 2 — the redeploy that follows a merge covers the file side of a
-  deletion but never calls OpenFGA, so a merged deletion's editor/viewer tuples stay live until
-  Phase 2 or 3 grows an explicit purge step.
+- **Per-file `base_sha` and rebase detection.** `recordPublication()` overwrites every row's
+  `base_sha` with the batch-level branch head, so the bookkeeping a rebase check needs is already
+  gone. Restoring it changes what the publisher persists per row; deferred out of Phase 3.
+- **Schema re-validation at the approval gate.** `approveBatch()` is a single status `UPDATE`. A
+  batch approved against one schema and published after that schema changed fails `lint:jsondata`
+  on the resulting pull request — visible, but a backstop on the wrong side of the gate.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-08-30-sourcedata-merge-detection-design.md
+++ b/docs/superpowers/specs/2026-08-30-sourcedata-merge-detection-design.md
@@ -1,6 +1,6 @@
 # Source-data change requests, phase 3: merge detection, and publishing from a Redis stream
 
-**Status:** design approved, not yet implemented
+**Status:** implemented, in [#916](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/pull/916)
 **Extends:** [`2026-08-28-sourcedata-change-requests-design.md`](2026-08-28-sourcedata-change-requests-design.md)
 **Tracked by:** [#902](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/902) (phase 3),
 [#915](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/915) (Redis stream)

--- a/docs/superpowers/specs/2026-08-30-sourcedata-merge-detection-design.md
+++ b/docs/superpowers/specs/2026-08-30-sourcedata-merge-detection-design.md
@@ -1,0 +1,427 @@
+# Source-data change requests, phase 3: merge detection, and publishing from a Redis stream
+
+**Status:** design approved, not yet implemented
+**Extends:** [`2026-08-28-sourcedata-change-requests-design.md`](2026-08-28-sourcedata-change-requests-design.md)
+**Tracked by:** [#902](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/902) (phase 3),
+[#915](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/915) (Redis stream)
+**Date:** 2026-08-30
+**Repos affected:** `LiturgicalCalendarAPI`; a follow-up issue in `LiturgicalCalendarFrontend` for the inbox UI
+
+The parent design's "Phase 3: merge detection" section is three paragraphs, and it defers four
+decisions to this phase by name. This document makes those decisions and specifies what phase 3
+builds. It does not restate the parent design; read that first.
+
+## Where phases 1 and 2 left off
+
+| Phase | Content                                                      | State  | PR   |
+| ----- | ------------------------------------------------------------ | ------ | ---- |
+| 1     | Change request store, approval gate, RBAC-scoped views       | merged | #912 |
+| 2     | The publisher: GitHub App, Git Data API, rolling PRs         | merged | #914 |
+| 3     | Merge detection, publication side effects, stream publishing | this   | —    |
+
+Nothing writes `merged` or `closed` today. `publication_status` reaches `open` and stops there,
+which means every side effect that depends on a change actually landing has never fired.
+
+## Scope
+
+In:
+
+1. Merge detection — poll the rolling pull requests, write `merged` / `closed`.
+2. The OpenFGA operational-tuple purge for a merged resource deletion.
+3. A decision on whether `closed` belongs in the accumulation-base exclusion.
+4. Claim ownership — a claim token, so a late release cannot revoke a live claim.
+5. Notifying the submitter, API side.
+6. Publishing from a Redis stream, with cron demoted to the backstop (#915).
+
+Deliberately out, each an issue of its own:
+
+- **Per-file `base_sha` and rebase detection.** `recordPublication()` overwrites every row's
+  `base_sha` with the batch-level branch head, so the per-file bookkeeping a rebase check needs is
+  already gone. Restoring it changes what phase 2 persists per row, which is a larger change than
+  merge detection and is not a prerequisite for it.
+- **Schema re-validation at the approval gate.** A batch approved against one schema and published
+  after that schema changed produces a pull request whose CI fails `lint:jsondata` — visible, on
+  the wrong side of the gate, and unchanged by anything here.
+- **Moving the claim protocol into Redis consumer groups.** #915 puts this out of scope explicitly,
+  and it would make Redis mandatory for a self-hoster. See "Why the queue stays in Postgres".
+
+## Merge detection
+
+### Poll pull requests, not batches
+
+The rolling branch is per **resource**, and `SourceDataPublisher` reuses an already-open pull
+request via `findOpenPullRequest()`. So two batches for one resource — the same submitter's
+successive proposals, or two different editors' — are published onto one branch and recorded with
+one `pr_number`. Iterating batches would issue N identical `GET /pulls/{number}` calls and answer
+the same question N times.
+
+`MergePollRunner` therefore selects the DISTINCT `pr_number` values among rows at
+`publication_status = 'open'`, oldest first, and polls each once. One GitHub call decides the fate
+of every batch on that pull request.
+
+`GitHubGitDataClient` grows one method, `getPullRequest(int $number): PullRequestState`, returning
+a small readonly DTO of `state`, `merged`, `mergeCommitSha` and `headSha`. A 404 here is a real
+failure, not a value — the only 404-as-value in that class stays `getRef()`.
+
+`pr_number` is nullable in the schema but is never null in practice on an `open` row:
+`SourceDataPublisher` opens a pull request whenever `findOpenPullRequest()` returns null, and
+`openPullRequest()` either returns an `int` or throws. An `open` row with a null `pr_number` is
+therefore an unexplained state — unpollable, and stuck forever if the poller silently skipped it —
+so the runner counts and logs those rows rather than filtering them out of its query and moving on.
+
+| Observed                         | Written                                                                                                |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `state: open`                    | nothing                                                                                                |
+| `merged: true`                   | `publication_status = merged`, `merge_commit_sha`, `publication_settled_at`                            |
+| `state: closed`, `merged: false` | `publication_status = closed`, `review_status = rejected`, `rejected_reason`, `publication_settled_at` |
+
+On close-unmerged, nothing needs reverting because nothing was ever live. `rejected_reason` is
+generated rather than left null, so the editor's history says why a batch they never withdrew is
+rejected: `Pull request #N was closed without merging.`
+
+### Containment is verified, not assumed
+
+A batch's rows share a pull request number, but sharing a pull request is not the same as being
+IN the merge. A human clicking Merge concurrently with a publish is enough to separate them:
+
+1. The publisher fast-forwards `litcal-data/<type>/<id>` to batch C's commit.
+2. Before `findOpenPullRequest()`/`recordPublication()` complete, a reviewer merges PR N at the
+   head it had a moment earlier.
+3. C is recorded `open` with `pr_number = N`, its commit sits on the branch, and PR N is merged
+   without it.
+
+Marking C `merged` would assert that C reached the repository. The publisher selects approved rows
+that are not yet `merged`, so C would never be attempted again and its content would be lost
+silently. That is the same failure mode phase 2's age-based ancestor exclusion was chosen to avoid
+— "marking ancestors merged asserts they were published" — reached from the other direction, and
+it deserves the same answer: assert only what is observed.
+
+So containment is checked per batch:
+
+- `commit_sha === headSha` — contained, no extra call. This is the ordinary case: one batch per
+  pull request, or the newest batch on a shared one.
+- otherwise, one `GET /repos/{o}/{r}/compare/{commit_sha}...{merge_commit_sha}`. A `status` of
+  `ahead` or `identical` means the merge commit's history contains the batch's commit.
+
+Cost is bounded by the number of batches on the merged pull request whose commit is not its head —
+typically zero, occasionally one or two.
+
+A batch found NOT contained is reset to `publication_status = 'none'` with `publish_attempts`
+cleared and `pr_number` / `commit_sha` / `branch` left in place for forensics. Its commit is still
+on the branch; the next publish for that resource finds no open pull request and opens a fresh one
+that carries the stranded commit along with the new work. This asserts nothing false, self-heals
+on the next tick, and degrades — as everything else in this feature does — toward re-publishing
+rather than toward losing content.
+
+### Failure handling
+
+`MergePollRunner` follows `PublishRunner`'s rules, because they were arrived at the hard way and
+the failure modes are identical:
+
+- **Stop, don't hammer.** A `\Throwable` from a poll stops the run. If GitHub is down or the
+  installation credential is stale, every remaining pull request fails identically.
+- **A run reports what it did.** `MergePollRunResult{merged, closed, reset, stoppedOnFailure}`,
+  and a non-zero exit code when it stopped early, so a stale credential cannot pile up silently.
+- **No new claim protocol.** Polling holds nothing and claims nothing: the writes are guarded
+  `UPDATE`s keyed on `(batch_id, publication_status = 'open')`, so two pollers racing produce one
+  transition and one no-op. There is no stranded state to reclaim, which is why polling needs no
+  grace period and no attempt bound.
+
+## The OpenFGA purge, and the trap in its trigger
+
+In disk mode, deleting a calendar or a test definition purges that resource's operational
+(editor/viewer) OpenFGA tuples, and deliberately keeps the `admin` tuple so ownership survives
+recreation. In queue mode the purge is gated on `commit()` returning `disposition === 'applied'`,
+which never happens — so the tuples stay live. Until this ships, a diocese deleted through a change
+request keeps its former editors' access to an object whose files are gone.
+
+Only merge detection knows the deletion actually happened, which is why the parent design put the
+purge here rather than at publish time: publishing a pull request does not make a deletion true,
+and a pull request can still be closed unmerged.
+
+### `operation = 'delete'` is the wrong trigger
+
+The obvious trigger — "the batch contains a delete" — is wrong, and wrong in the dangerous
+direction.
+
+`RegionalDataHandler::writeI18nFiles()` stages a `DELETE` for every locale file in a calendar's
+`i18n/` folder that is no longer named in `metadata.locales` (`src/Handlers/RegionalDataHandler.php:1262`).
+That is an ordinary update: a translator dropped a language from a calendar that very much still
+exists. Purging on it would revoke every editor and viewer on a live calendar because one
+translation was removed.
+
+### The handler that deletes a resource says so
+
+`SourceDataWriter::commit()` takes a new `bool $deletesResource = false`.
+
+- `DiskSourceDataWriter` ignores it. It already purges inline, gated on the write having landed.
+- `ChangeRequestSourceDataWriter` merges `deletes_resource: true` into the row `metadata` JSONB,
+  beside the `authorizing_relation` key already stored there.
+
+Only two call sites pass `true`: `RegionalDataHandler::deleteCalendar()` and
+`TestsHandler::handleDeleteRequest()` — the two places that remove a whole resource rather than one
+of its files. The signal is set by the code that knows, at the moment it knows.
+
+On `merged`, a batch whose metadata carries the flag gets
+`ResourceTuplePurgeServiceInterface::purgeForObject("{resource_type}:{resource_id}")`. The row
+already stores both halves of that object string rite-qualified, so nothing is re-derived and
+nothing can double-qualify (`roman/roman/US`) the way rebuilding a `ChangeResource` would.
+
+An absent flag means no purge. Every row written before this ships lacks it, so the pre-existing
+corpus fails closed toward NOT revoking — the safe direction for an authorization decision.
+
+The purge is best-effort and must never fail the transition: the batch is already `merged`, that
+is a fact about the repository, and a reachable OpenFGA is not a precondition for recording it.
+A failure logs and leaves the tuples for `ResourceTuplePurgeReconciler`'s sweep, exactly as the
+disk-mode path does.
+
+The `rmdir()` half of disk-mode deletion has no analogue and needs none: the redeploy that follows
+a merge replaces `jsondata/sourcedata` from the merged tree, and rsync removes the directory.
+
+## `closed` in the accumulation base: decided, with no SQL change
+
+The parent design records this as an open question phase 3 must settle, and warns against leaving
+it carried "by coincidence".
+
+The accumulation base is `review_status IN ('submitted','approved') AND publication_status <> 'merged'`.
+A `closed` batch is admitted by the publication half and excluded by the review half, because
+phase 3 writes `review_status = 'rejected'` alongside `closed`.
+
+**That is correct, not coincidental, and the predicate does not change.** The publication axis
+answers "is this row's content in the repository?" — and for a pull request closed unmerged the
+answer is no, so `closed` genuinely belongs in the base on that axis. What excludes it is the
+review axis answering a different question: a rejected batch is no longer a proposal, whatever
+happened to its pull request. Two axes, two answers, and the parent design's own reason for
+keeping them as two columns rather than one enum.
+
+What changes is that this stops being an accident:
+
+- `SourceDataChangeRequestRepository`'s `UNPUBLISHED_PREDICATE` docblock states it.
+- Two tests pin it: a `closed` + `rejected` row is excluded from the base, and a `closed` row that
+  is still `approved` — constructible only by direct SQL — IS included, proving the exclusion comes
+  from the review axis and not from `closed` being mistaken for published.
+- `NOT_SUPERSEDED_BY_PUBLISHED`'s floor stays `publication_status = 'merged'` alone. A `closed`
+  batch published nothing, so it must never become the floor that excludes older rows.
+
+## Claim ownership
+
+`releaseClaim()`'s `publication_status = 'queued'` guard identifies *a* claim, not *whose*. The
+reachable consequence, recorded in that method's docblock: runner A is merely slow, the grace
+period elapses, `reclaimStaleClaims()` releases A's claim and spends an attempt, B claims and
+starts publishing, then A's own doomed call returns and A's release revokes B's LIVE claim and
+spends a second attempt. A batch that is simply large parks after three cycles instead of five.
+
+`publish_claim_token UUID NULL` closes it:
+
+- `claimNextPublishableBatch()` generates a token inside the claiming transaction and returns
+  `?PublishClaim{batchId, token}` instead of `?string`.
+- `releaseClaim(string $batchId, string $token)` adds `AND publish_claim_token = :token` to the
+  guarded `UPDATE`, so a stale runner's release matches nothing and — the point — spends no attempt.
+- `recordPublication()` and `reclaimStaleClaims()` both clear the token, so no token outlives the
+  claim it names.
+
+`ClaimReleaseOutcome` gains `CLAIM_LOST`: the row is `queued` under a different token, so another
+runner holds it. That is not `SETTLED_ELSEWHERE` — nothing is published — and not `NOT_CLAIMED`.
+`PublishRunner` treats it as a failure and stops the run: rare, visible, and safe, since the runner
+that actually holds the claim carries on.
+
+This is bundled with phase 3 rather than issued separately because it touches the same table, the
+same claim/release/reclaim contract, and the same migration as `publication_settled_at`. One
+migration instead of two, as the phase-3 handoff argued.
+
+## Notifying the submitter
+
+`GET /auth/notifications` exists, but `UserNotificationRepository::fetchInbox()` reads
+`access_requests` and nothing else. Change-request notifications are new work, not a wiring change.
+
+Phase 3 notifies on **publication settling** — `merged` or `closed` — which is what phase 3
+produces. Review decisions (approve, reject at the gate) are equally notification-worthy and equally
+unnotified today, but that is a phase-1 gap and belongs to its own issue rather than being smuggled
+in here.
+
+### Merged in PHP, not in SQL
+
+`fetchInbox()` queries each source separately, merges the two lists in PHP, sorts by timestamp
+descending, and slices to `limit`. Totals and unread counts come from two aggregate queries and are
+summed.
+
+A single `UNION` with `COUNT(*) OVER ()` window functions over two differently-shaped row sets is
+the alternative, and it is the wrong trade here: the shapes genuinely differ, the window functions
+would have to span the union to keep `total` and `unread_count` honest, and the result is one query
+that is hard to read and harder to prove correct. Two straightforward queries and an `usort` are
+verifiable by inspection. Neither source can exceed the 50-row contract, so the merge is bounded.
+
+### The cursor is a new column, not `updated_at`
+
+`updated_at` moves on every write to the row — claim, release, reclaim, record, transition — so it
+answers "when was this row last touched", not "when did this become news for the submitter".
+`publication_settled_at TIMESTAMPTZ NULL` is written once, by the transition to `merged` or
+`closed`, and is what the unread comparison against `user_notification_state.last_notification_seen_at`
+uses.
+
+One item per batch, not per file: an editor who changed a calendar and its fourteen i18n files
+proposed one thing.
+
+```json
+{
+  "type": "change_request_published",
+  "batch_id": "…",
+  "resource_type": "diocesan_calendar",
+  "resource_id": "roman/dioceseoflondon_gb",
+  "publication_status": "merged",
+  "pr_number": 1234,
+  "settled_at": "2026-08-30T10:15:00+00:00",
+  "unread": true
+}
+```
+
+`items` therefore becomes a discriminated list — `access_request_reviewed` and
+`change_request_published` carry different keys — and the handler documents that clients must switch
+on `type`. Rendering it is a follow-up issue in `LiturgicalCalendarFrontend`.
+
+## Publishing from a Redis stream (#915)
+
+### Why the queue stays in Postgres
+
+`sourcedata_change_requests.publication_status` remains the source of truth. A batch can be
+withdrawn or rejected in Postgres, so a second queue would be a second truth that can disagree with
+it. Redis is an accelerator over a durable database queue, never a replacement for one — the same
+arrangement the OpenFGA outbox already documents in `BackstopRunner`.
+
+The gain is latency: the delay between an approval and its pull request existing drops from up to
+one cron interval to sub-second on the happy path.
+
+### The message is a hint, never a work item
+
+`SourceDataPublishNotifier` mirrors `OutboxNotifier` exactly: a best-effort `XADD` carrying
+`batch_id`, a null `\Redis` disabling it, and a `\RedisException` logged at warning rather than
+raised. It is called from **two** places, and missing either is the easy mistake:
+
+1. `ChangeRequestAdminHandler::approve()`, after the status `UPDATE` commits — the same ordering
+   constraint the outbox already documents.
+2. `ChangeRequestSourceDataWriter::commit()` on auto-approval, which is the common path whenever an
+   admin edits a resource they administer. A batch approved there never passes through the admin
+   handler at all.
+
+The consumer **ignores the batch id except for logging**. On a message it calls
+`PublishRunner::runOnce()`, which claims from Postgres exactly as cron does: the stream says *when*
+to look, the database says *what* is claimable and by whom. Three consequences, all of them the
+point:
+
+- A lost `XADD` costs latency, never correctness. The backstop finds the batch.
+- A duplicate or out-of-order message costs one wasted claim attempt against an empty queue.
+- The consumer inherits every guarantee phase 2 built — the claim protocol, bounded attempts,
+  parking, stop-don't-hammer — without reimplementing any of it.
+
+### The stream seam widens by one type
+
+`StreamConsumerInterface::readOnce()` is `callable(int): void` and `RedisStreamConsumer` hardcodes
+the payload field `row_id`, because the outbox's unit of work is an integer row id. The unit of
+publication is a batch id, which is a UUID.
+
+`readOnce()` widens to `callable(string): void`, and `RedisStreamConsumer` takes its payload field
+name as a constructor argument defaulting to `row_id`. The outbox's `ConsumerLoop` keeps its `(int)`
+cast and inherits the `<= 0` bad-message guard that moves with it — the consumer no longer knows
+what a valid id looks like, so the loop that does must say.
+
+`ConsumerLoop` itself is not reused: it is constructor-typed to `OutboxProcessorInterface`.
+`PublishConsumerLoop` is its sibling — same `tick()` / `run()` split, same `ensureGroup()` memoisation,
+same "systemd restarts on crash" contract.
+
+### Cron becomes the backstop it already resembles
+
+`scripts/publish-sourcedata.php` keeps its CLI (`[limit]`), its exit codes and its documented
+behaviour. Its ROLE changes: it catches a lost `XADD` or a dead consumer, which is what
+`BackstopRunner` does for the outbox, and its grace period is already sized for exactly that.
+
+Redis stays optional. `REDIS_SOCKET` / `REDIS_HOST` are commented out in `.env.example`, and a
+self-hoster running cron only keeps working unchanged — the same promise the disk-write path makes
+to a self-hoster without Postgres or OpenFGA.
+
+## Entry points, and the trap they exist to avoid
+
+Phase 2's most expensive defect was a script CONSTRUCTING what every test INJECTED: the cron entry
+point took `LoggerFactory::create()`'s default processors, which throw on non-request context, so
+every log line the runner wrote would have thrown in production — including the ones inside its
+catch blocks, before `releaseClaim()` ran. Every test passed. No test crossed that seam.
+
+Phase 3 adds two more entry points to the same wiring, which triples the surface for that defect.
+So the wiring moves out of the scripts:
+
+`SourceDataPublisherFactory`, in `src/`, builds the logger, the PDO connection, the repository, the
+timeout-bounded Guzzle client, the umask-protected token cache, the publisher, the runners and the
+optional notifier — and returns them assembled. `phpstan.neon.dist` scans `paths: [src]` only, so
+this also brings the wiring under the same level-10 pass as everything else, instead of leaving it
+in a file that needs a standalone run to be checked at all.
+
+| Entry point                          | Kind       | Does                                                  |
+| ------------------------------------ | ---------- | ----------------------------------------------------- |
+| `scripts/publish-sourcedata.php`     | cron       | `PublishRunner::runOnce()` — the backstop             |
+| `scripts/poll-sourcedata-merges.php` | cron       | `MergePollRunner::runOnce()`                          |
+| `bin/publish-sourcedata-consumer`    | long-lived | `PublishConsumerLoop::run()`, plus the idle-tick poll |
+
+The consumer's idle tick — a `readOnce()` that blocked and returned nothing — also runs
+`MergePollRunner`, as the parent design describes. It is rate-limited to at most once per 60
+seconds: `blockMs` is 5000, so an unlimited idle tick would poll GitHub 720 times an hour to watch
+for a transition nobody is waiting on.
+
+## Data model
+
+One migration, two columns:
+
+| Column                   | Type               | Written by                                                   |
+| ------------------------ | ------------------ | ------------------------------------------------------------ |
+| `publish_claim_token`    | `UUID NULL`        | `claimNextPublishableBatch()`; cleared on record and reclaim |
+| `publication_settled_at` | `TIMESTAMPTZ NULL` | the transition to `merged` or `closed`                       |
+
+No new table. No enum change: `chk_scr_publication_status` already admits `merged` and `closed`,
+which phase 1 wrote in anticipation of exactly this.
+
+A partial index on `(pr_number) WHERE publication_status = 'open'` serves the poller's distinct-PR
+scan, and a partial index on `(submitted_by_sub, publication_settled_at DESC) WHERE publication_settled_at IS NOT NULL`
+serves the inbox.
+
+## Health
+
+`GET /health`'s `source_data_publisher` block gains `open_batches` and
+`oldest_open_age_seconds`. A batch sitting `open` is not an error — a pull request awaiting review
+is the normal state — so this is reported, not alarmed on, and only becomes a `warning` past a
+generous threshold that means the poller is not running at all rather than that a reviewer is slow.
+
+The block keeps degrading to zeroes behind `Connection::isConfigured()` and a catch-everything
+guard, for the reason `buildOutboxStats()` does: a database that is down must not break the endpoint
+monitoring relies on.
+
+## Error handling
+
+| Failure                                             | Behaviour                                                                        |
+| --------------------------------------------------- | -------------------------------------------------------------------------------- |
+| GitHub unreachable during a poll                    | Log, stop the run, exit 1. No status is written; the next tick retries           |
+| `open` row with a null `pr_number`                  | Unpollable and unexplained. Counted and logged; never silently skipped           |
+| `GET /pulls/{n}` returns 404                        | A configuration or repository problem, not a value. Stop the run                 |
+| `compare` fails for a containment check             | The batch is NOT marked merged. Left `open`; the next tick re-checks             |
+| Batch on a merged PR, commit not contained          | Reset to `none`, attempts cleared. Re-published under a fresh pull request       |
+| `purgeForObject()` throws after a merge             | Logged. The transition stands; `ResourceTuplePurgeReconciler` sweeps the tuples  |
+| Redis unavailable at approval                       | `XADD` logged at warning and skipped. Cron publishes it                          |
+| Redis unavailable to the consumer                   | The consumer crashes; systemd restarts it. Cron publishes meanwhile              |
+| Late `releaseClaim()` whose token no longer matches | `CLAIM_LOST`. No attempt spent. The run stops; the live claim's runner continues |
+
+## Testing
+
+Beyond the ordinary unit coverage, four cases are worth naming because they are the ones that hide:
+
+- **Two batches, one pull request.** The merged transition must move both, and exactly one GitHub
+  call must be made.
+- **The not-contained batch.** A batch whose `commit_sha` is neither the head nor an ancestor is
+  reset to `none`, NOT marked merged. Asserted against the repository row, not against a log line.
+- **The locale-delete false positive.** A batch that deletes an i18n file without deleting the
+  calendar must NOT purge tuples when it merges. This is the defect the `deletes_resource` flag
+  exists to prevent, and it is invisible unless a test names it.
+- **Claim ownership under real concurrency.** Two real OS processes via `proc_open`, against the
+  actual `claimNextPublishableBatch()` / `releaseClaim()` methods rather than hand-copied SQL.
+  Phase 2 found four concurrency defects and every one needed a genuinely concurrent runner; a test
+  that duplicates the fixed query passes even with the fix reverted.
+
+Both entry points and the consumer must be RUN, not only unit-tested, for the reason the wiring
+moved into a factory: the two defects that shipped with green suites were both at a seam no test
+crossed.

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -14000,9 +14000,9 @@
         ],
         "additionalProperties": false
       },
-      "UserNotification": {
+      "AccessRequestNotification": {
         "type": "object",
-        "description": "A single notification item in the authenticated user's inbox.",
+        "description": "A single access-request notification item in the authenticated user's inbox: one of the caller's own access requests was reviewed. One of the two shapes UserNotificationsResponse.items may contain — see ChangeRequestNotification for the other. Discriminated on `type`; the two shapes share only `type` and `unread`.",
         "properties": {
           "type": {
             "type": "string",
@@ -14065,14 +14065,91 @@
         ],
         "additionalProperties": false
       },
+      "ChangeRequestNotification": {
+        "type": "object",
+        "description": "A single change-request notification item in the authenticated user's inbox: one of the caller's own submitted source-data change-request batches merged or was closed, unmerged, on GitHub. One item per batch, not per file. Only settled batches (publication_status merged or closed) ever appear here — an open batch is not news yet. One of the two shapes UserNotificationsResponse.items may contain — see AccessRequestNotification for the other. Discriminated on `type`; the two shapes share only `type` and `unread`.",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "change_request_published"
+            ],
+            "description": "Discriminator for the notification kind."
+          },
+          "batch_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "UUID shared by every sourcedata_change_requests row submitted together in this batch."
+          },
+          "resource_type": {
+            "type": "string",
+            "enum": [
+              "national_calendar",
+              "diocesan_calendar",
+              "wider_region",
+              "national_calendar_test",
+              "diocesan_calendar_test",
+              "general_roman_calendar_test",
+              "rite_calendar_test",
+              "general_roman_calendar"
+            ]
+          },
+          "resource_id": {
+            "type": "string",
+            "description": "Rite-qualified as `<rite>/<calendarId>` for calendar-naming types (e.g. `roman/US`), and for the `national_calendar_test` and `diocesan_calendar_test` scopes. Bare for `general_roman_calendar` ids such as `decrees`, and for `general_roman_calendar_test` and `rite_calendar_test`."
+          },
+          "publication_status": {
+            "type": "string",
+            "enum": [
+              "merged",
+              "closed"
+            ],
+            "description": "This batch's settled position on GitHub. Only `merged` and `closed` ever reach the inbox — publication_settled_at, which gates inclusion here, is written only by those two transitions."
+          },
+          "pr_number": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "The GitHub pull request number this batch was published as, if one was ever opened."
+          },
+          "settled_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "RFC 3339 UTC timestamp of when the batch transitioned to merged or closed."
+          },
+          "unread": {
+            "type": "boolean",
+            "description": "True if settled_at is more recent than the user's last_seen_at bookmark."
+          }
+        },
+        "required": [
+          "type",
+          "batch_id",
+          "resource_type",
+          "resource_id",
+          "publication_status",
+          "pr_number",
+          "settled_at",
+          "unread"
+        ],
+        "additionalProperties": false
+      },
       "UserNotificationsResponse": {
         "type": "object",
-        "description": "Response from GET /auth/notifications — the inbox with unread badge metadata.",
+        "description": "Response from GET /auth/notifications — the inbox with unread badge metadata. `items` is a discriminated union: clients MUST switch on each item's `type` (`access_request_reviewed` or `change_request_published`) before reading any other key — the two shapes share only `type` and `unread`.",
         "properties": {
           "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/UserNotification"
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/AccessRequestNotification"
+                },
+                {
+                  "$ref": "#/components/schemas/ChangeRequestNotification"
+                }
+              ]
             }
           },
           "total": {

--- a/phpunit_tests/Handlers/ChangeRequestAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/ChangeRequestAdminHandlerTest.php
@@ -16,6 +16,7 @@ use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
 use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
 use LiturgicalCalendar\Api\Services\ChangeResource;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier;
 use LiturgicalCalendar\Tests\Repositories\RepositoryTestCase;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Nyholm\Psr7\ServerRequest;
@@ -42,8 +43,13 @@ final class ChangeRequestAdminHandlerTest extends RepositoryTestCase
         $this->repo = new SourceDataChangeRequestRepository(self::$pdo);
     }
 
-    /** @param array<int, GuzzleResponse> $fgaResponses */
-    private function handler(array $pathParts, array $fgaResponses): ChangeRequestAdminHandler
+    /**
+     * @param array<int, GuzzleResponse> $fgaResponses
+     * @param ?SourceDataPublishNotifier $notifier      Injected the same way the repository and FGA
+     *                                                   client already are, so tests can substitute a
+     *                                                   recording subclass instead of touching Redis.
+     */
+    private function handler(array $pathParts, array $fgaResponses, ?SourceDataPublishNotifier $notifier = null): ChangeRequestAdminHandler
     {
         $guzzle = new GuzzleClient(['handler' => HandlerStack::create(new MockHandler($fgaResponses))]);
         $psr17  = new Psr17Factory();
@@ -57,7 +63,7 @@ final class ChangeRequestAdminHandlerTest extends RepositoryTestCase
             apiToken: 'test-token'
         );
 
-        return new ChangeRequestAdminHandler($pathParts, $this->repo, $client);
+        return new ChangeRequestAdminHandler($pathParts, $this->repo, $client, $notifier);
     }
 
     private static function allowed(bool $allowed): GuzzleResponse
@@ -307,5 +313,27 @@ final class ChangeRequestAdminHandlerTest extends RepositoryTestCase
 
         $rows = $this->repo->getBatch($batchId);
         self::assertSame(ChangeReviewStatus::SUBMITTED->value, $rows[0]['review_status'], 'batch must remain undecided');
+    }
+
+    public function testApproveNotifiesTheStreamAfterTheStatusUpdate(): void
+    {
+        $batchId  = $this->submitFor('editor-1', 'USA');
+        $notifier = new RecordingPublishNotifier();
+
+        $handler = $this->handler(['change-requests', $batchId, 'approve'], [self::allowed(true)], $notifier);
+        $handler->handle($this->request('POST', '/admin/change-requests/' . $batchId . '/approve', 'admin-1'));
+
+        self::assertSame([$batchId], $notifier->notified);
+    }
+
+    public function testRejectDoesNotNotifyTheStream(): void
+    {
+        $batchId  = $this->submitFor('editor-1', 'USA');
+        $notifier = new RecordingPublishNotifier();
+
+        $handler = $this->handler(['change-requests', $batchId, 'reject'], [self::allowed(true)], $notifier);
+        $handler->handle($this->request('POST', '/admin/change-requests/' . $batchId . '/reject', 'admin-1'));
+
+        self::assertSame([], $notifier->notified, 'a rejected batch is never publishable');
     }
 }

--- a/phpunit_tests/Handlers/ChangeRequestTraitHost.php
+++ b/phpunit_tests/Handlers/ChangeRequestTraitHost.php
@@ -59,9 +59,9 @@ final class ChangeRequestTraitHost
     }
 
     /** @return array<string, mixed> */
-    public function commitStagedFiles(ChangeResource $resource): array
+    public function commitStagedFiles(ChangeResource $resource, bool $deletesResource = false): array
     {
-        $result       = $this->writer()->commit($resource);
+        $result       = $this->writer()->commit($resource, $deletesResource);
         $this->writer = null;
 
         return $result;

--- a/phpunit_tests/Handlers/ChangeRequestTraitHost.php
+++ b/phpunit_tests/Handlers/ChangeRequestTraitHost.php
@@ -15,6 +15,7 @@ use LiturgicalCalendar\Api\Services\ChangeResource;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Api\Services\ResourceAdminService;
 use LiturgicalCalendar\Api\Services\SourceData\ChangeRequestSourceDataWriter;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier;
 use LiturgicalCalendar\Tests\Support\CollectingLogger;
 use Nyholm\Psr7\Factory\Psr17Factory;
 
@@ -36,6 +37,8 @@ final class ChangeRequestTraitHost
 
     private ?ChangeRequestSourceDataWriter $writer = null;
 
+    private ?SourceDataPublishNotifier $publishNotifier = null;
+
     public function __construct(private readonly SourceDataChangeRequestRepository $repository)
     {
     }
@@ -51,6 +54,17 @@ final class ChangeRequestTraitHost
     {
         $this->administers = $administers;
         $this->writer      = null;
+    }
+
+    /**
+     * Inject the notifier the writer should forward to, the same way
+     * {@see ChangeRequestAdminHandlerTest}'s `handler()` injects one — so a test can substitute a
+     * recording subclass instead of touching Redis.
+     */
+    public function setPublishNotifier(SourceDataPublishNotifier $notifier): void
+    {
+        $this->publishNotifier = $notifier;
+        $this->writer          = null;
     }
 
     public function stageFile(string $absolutePath, ChangeOperation $operation, ?string $content): void
@@ -73,7 +87,8 @@ final class ChangeRequestTraitHost
             $this->repository,
             new ChangeRequestReview(new ResourceAdminService($this->fgaAnswering($this->administers), new CollectingLogger())),
             $this->oidcUser,
-            '/app/'
+            '/app/',
+            $this->publishNotifier
         );
     }
 

--- a/phpunit_tests/Handlers/RecordingPublishNotifier.php
+++ b/phpunit_tests/Handlers/RecordingPublishNotifier.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier;
+
+/**
+ * Records every batch id `notify()` was called with instead of touching Redis — the seam
+ * {@see SourceDataPublishNotifier}'s own docblock reserves subclassing for. Mirrors
+ * {@see \LiturgicalCalendar\Tests\Services\SourceData\RecordingAuditLogRepository}'s
+ * recording-spy shape.
+ *
+ * Shared by {@see ChangeRequestAdminHandlerTest} (the admin-approve call site) and
+ * {@see RegionalDataChangeRequestTest} (the auto-approval write-path call site) — the two
+ * places a batch can become publishable.
+ */
+final class RecordingPublishNotifier extends SourceDataPublishNotifier
+{
+    /** @var list<string> */
+    public array $notified = [];
+
+    public function __construct()
+    {
+        parent::__construct(null, 'litcal:sourcedata-publish-stream');
+    }
+
+    public function notify(string $batchId): void
+    {
+        $this->notified[] = $batchId;
+    }
+}

--- a/phpunit_tests/Handlers/RegionalDataChangeRequestTest.php
+++ b/phpunit_tests/Handlers/RegionalDataChangeRequestTest.php
@@ -172,4 +172,74 @@ final class RegionalDataChangeRequestTest extends RepositoryTestCase
         sort($operations);
         self::assertSame(['delete', 'update'], $operations);
     }
+
+    /**
+     * The signal Task 8's OpenFGA purge keys on. It must be set ONLY when the resource itself is
+     * removed — see the sibling test below for the case that makes `operation = 'delete'` unusable.
+     */
+    public function testDeletingACalendarFlagsTheBatchAsAResourceDeletion(): void
+    {
+        $this->host->stageFile(
+            '/app/jsondata/sourcedata/rite/roman/calendars/dioceses/IT/romamo_it/Diocesi di Roma.json',
+            ChangeOperation::DELETE,
+            null
+        );
+        $this->host->stageFile(
+            '/app/jsondata/sourcedata/rite/roman/calendars/dioceses/IT/romamo_it/i18n/it_IT.json',
+            ChangeOperation::DELETE,
+            null
+        );
+
+        $body = $this->host->commitStagedFiles(
+            ChangeResource::diocesanCalendar(Rite::ROMAN, 'romamo_it'),
+            deletesResource: true
+        );
+
+        $repo = new SourceDataChangeRequestRepository(self::$pdo);
+        foreach ($repo->getBatch($body['change_request']['batch_id']) as $row) {
+            self::assertTrue(
+                $row['metadata']['deletes_resource'] ?? false,
+                'every row of a resource-deletion batch carries the flag'
+            );
+        }
+    }
+
+    /**
+     * THE false positive. Dropping a locale from `metadata.locales` stages a DELETE for that i18n
+     * file on a calendar that still exists. If this batch were flagged, merging it would revoke every
+     * editor and viewer on a live calendar because a translator removed one language. This reuses
+     * the same update-plus-locale-delete shape as testAnUpdateAndADeleteCanShareABatch() above,
+     * committed WITHOUT deletesResource — the default caller shape for every non-delete write path.
+     */
+    public function testRemovingALocaleStagesADeleteButIsNotAResourceDeletion(): void
+    {
+        $this->host->stageFile(
+            '/app/jsondata/sourcedata/rite/roman/calendars/nations/US/US.json',
+            ChangeOperation::UPDATE,
+            '{"litcal":[]}'
+        );
+        $this->host->stageFile(
+            '/app/jsondata/sourcedata/rite/roman/calendars/nations/US/i18n/fr_FR.json',
+            ChangeOperation::DELETE,
+            null
+        );
+
+        $body = $this->host->commitStagedFiles(ChangeResource::nationalCalendar(Rite::ROMAN, 'US'));
+
+        $repo = new SourceDataChangeRequestRepository(self::$pdo);
+        $rows = $repo->getBatch($body['change_request']['batch_id']);
+
+        self::assertContains(
+            ChangeOperation::DELETE->value,
+            array_column($rows, 'operation'),
+            'the fixture must actually stage a delete, or this test proves nothing'
+        );
+
+        foreach ($rows as $row) {
+            self::assertFalse(
+                $row['metadata']['deletes_resource'] ?? false,
+                'a locale removal is an update, not a resource deletion'
+            );
+        }
+    }
 }

--- a/phpunit_tests/Handlers/RegionalDataChangeRequestTest.php
+++ b/phpunit_tests/Handlers/RegionalDataChangeRequestTest.php
@@ -88,6 +88,36 @@ final class RegionalDataChangeRequestTest extends RepositoryTestCase
         self::assertSame('user-1', $row['approved_by_sub']);
     }
 
+    /**
+     * The auto-approval path is the COMMON case — an admin editing a resource they administer —
+     * and it never passes through ChangeRequestAdminHandler at all. Missing this call site would
+     * leave the most frequent approval waiting for cron.
+     */
+    public function testAnAdministratorSubmissionAlsoNotifiesTheStream(): void
+    {
+        $notifier = new RecordingPublishNotifier();
+        $this->host->setPublishNotifier($notifier);
+        $this->host->setAdministers(true);
+        $this->host->stageFile('/app/jsondata/sourcedata/rite/roman/calendars/nations/US/US.json', ChangeOperation::CREATE, '{}');
+
+        $body = $this->host->commitStagedFiles(ChangeResource::nationalCalendar(Rite::ROMAN, 'US'));
+
+        self::assertSame('approved', $body['disposition']);
+        self::assertSame([$body['change_request']['batch_id']], $notifier->notified);
+    }
+
+    public function testANonAdministratorSubmissionDoesNotNotifyTheStream(): void
+    {
+        $notifier = new RecordingPublishNotifier();
+        $this->host->setPublishNotifier($notifier);
+        $this->host->setAdministers(false);
+        $this->host->stageFile('/app/jsondata/sourcedata/rite/roman/calendars/nations/US/US.json', ChangeOperation::CREATE, '{}');
+
+        $this->host->commitStagedFiles(ChangeResource::nationalCalendar(Rite::ROMAN, 'US'));
+
+        self::assertSame([], $notifier->notified, 'a merely-submitted batch is not yet publishable');
+    }
+
     public function testAnUnverifiedEmailIsNotUsedAsTheGitAuthorEmail(): void
     {
         $this->host->setSubmitter([

--- a/phpunit_tests/Handlers/RegionalDataQueueModeTest.php
+++ b/phpunit_tests/Handlers/RegionalDataQueueModeTest.php
@@ -8,6 +8,7 @@ use LiturgicalCalendar\Api\Database\Connection;
 use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Handlers\RegionalDataHandler;
 use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Api\Services\ChangeRequestReview;
 use LiturgicalCalendar\Api\Services\SourceData\ChangeRequestSourceDataWriter;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
@@ -258,5 +259,52 @@ final class RegionalDataQueueModeTest extends AbstractHandlerTestCase
         self::assertSame(201, $response->getStatusCode());
         self::assertQueued($body, 'roman/Europe');
         self::assertNotSame([], $this->pendingRows());
+    }
+
+    /**
+     * The handler-level counterpart to
+     * RegionalDataChangeRequestTest::testDeletingACalendarFlagsTheBatchAsAResourceDeletion(): this
+     * proves `RegionalDataHandler::deleteCalendar()` itself passes `deletesResource: true` through
+     * to the writer, not merely that the writer honours the flag when handed it directly.
+     *
+     * Croatia (HR) is reused from RegionalDataHandlerTest's disk-mode delete fixtures: it has no
+     * diocesan calendars in the bundled source data, so the "diocesan calendars depend on this
+     * nation" pre-check passes cleanly. Unlike those disk-mode tests, queue mode never touches the
+     * filesystem, so there is nothing to back up or restore here.
+     */
+    public function testDeletingANationalCalendarIsQueuedAndFlaggedAsAResourceDeletion(): void
+    {
+        $onDisk = Router::$apiFilePath . 'jsondata/sourcedata/rite/roman/calendars/nations/HR/HR.json';
+        self::assertFileExists($onDisk, 'fixture assumption: HR has a national calendar on disk');
+
+        $response = ( new RegionalDataHandler(['nation', 'HR']) )
+            ->handle($this->withOidcUser($this->requestFor('DELETE', '/data/nation/HR'), 'editor-1'));
+
+        $body = $this->decodeJsonBody($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertQueued($body, 'roman/HR');
+
+        // Queue mode must not have touched the filesystem.
+        self::assertFileExists($onDisk);
+
+        $rows = $this->pendingRows();
+        self::assertNotSame([], $rows, 'the calendar and its i18n file must both be queued');
+        foreach ($rows as $row) {
+            self::assertSame('national_calendar', $row['resource_type']);
+        }
+
+        self::assertIsArray($body['change_request'] ?? null);
+        /** @var array<string,mixed> $changeRequest */
+        $changeRequest = $body['change_request'];
+        self::assertIsString($changeRequest['batch_id'] ?? null);
+
+        $repo = new SourceDataChangeRequestRepository();
+        foreach ($repo->getBatch($changeRequest['batch_id']) as $batchRow) {
+            self::assertTrue(
+                $batchRow['metadata']['deletes_resource'] ?? false,
+                'every row of a resource-deletion batch must carry the flag'
+            );
+        }
     }
 }

--- a/phpunit_tests/Handlers/TestsChangeRequestTest.php
+++ b/phpunit_tests/Handlers/TestsChangeRequestTest.php
@@ -69,4 +69,24 @@ final class TestsChangeRequestTest extends RepositoryTestCase
         self::assertSame('delete', $row['operation']);
         self::assertNull($row['content']);
     }
+
+    /**
+     * The analogue of RegionalDataChangeRequestTest::testDeletingACalendarFlagsTheBatchAsAResourceDeletion().
+     * Trait-level only: see TestsHandlerTest for whether TestsHandler's own DELETE path is proven to
+     * pass this flag at the handler level.
+     */
+    public function testDeletingATestDefinitionFlagsTheBatchAsAResourceDeletion(): void
+    {
+        $this->host->stageFile('/app/jsondata/tests/roman/MyTest.json', ChangeOperation::DELETE, null);
+
+        $body = $this->host->commitStagedFiles(
+            ChangeResource::test(Rite::ROMAN, 'general_roman_calendar_test', 'general_roman_calendar'),
+            deletesResource: true
+        );
+
+        $repo = new SourceDataChangeRequestRepository(self::$pdo);
+        foreach ($repo->getBatch($body['change_request']['batch_id']) as $row) {
+            self::assertTrue($row['metadata']['deletes_resource'] ?? false);
+        }
+    }
 }

--- a/phpunit_tests/Handlers/TestsQueueModeTest.php
+++ b/phpunit_tests/Handlers/TestsQueueModeTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Database\Connection;
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\TestsHandler;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * TestsHandler's DELETE path, driven end to end in queue mode.
+ *
+ * The handler-level counterpart to
+ * TestsChangeRequestTest::testDeletingATestDefinitionFlagsTheBatchAsAResourceDeletion(): that test
+ * proves ChangeRequestSourceDataWriter honours `deletesResource` when handed it directly; this one
+ * proves TestsHandler::handleDeleteRequest() itself passes `deletesResource: true` through to the
+ * writer. Modelled on RegionalDataQueueModeTest, which established this same env-setup pattern for
+ * RegionalDataHandler's write paths.
+ */
+#[CoversClass(TestsHandler::class)]
+final class TestsQueueModeTest extends AbstractHandlerTestCase
+{
+    /** @var array<string, string|false> */
+    private array $originalEnv = [];
+
+    /** Absolute path to a temporary test fixture created during a test; cleaned up in tearDown. */
+    private ?string $testFixturePath = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // AbstractHandlerTestCase does not open a connection of its own here, so this must
+        // use the same one the handler writes through or it silently truncates nothing.
+        Connection::getInstance()->exec('TRUNCATE TABLE sourcedata_change_requests RESTART IDENTITY CASCADE');
+
+        foreach ([SourceDataWriteMode::FLAG, 'OPENFGA_API_URL', 'OPENFGA_STORE_ID', 'OPENFGA_MODEL_ID'] as $key) {
+            $this->originalEnv[$key] = $_ENV[$key] ?? false;
+        }
+
+        // A store id that does not exist, so every FGA check fails fast and
+        // ChangeRequestReview::administers() returns false. Submissions therefore stay
+        // `submitted` rather than being auto-approved, which is what these assertions read.
+        $_ENV[SourceDataWriteMode::FLAG] = 'true';
+        $_ENV['OPENFGA_API_URL']         = 'http://localhost:8083';
+        $_ENV['OPENFGA_STORE_ID']        = 'no-such-store-tests-queue-test';
+        $_ENV['OPENFGA_MODEL_ID']        = 'no-such-model-tests-queue-test';
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalEnv as $key => $value) {
+            if (false === $value) {
+                unset($_ENV[$key]);
+            } else {
+                $_ENV[$key] = $value;
+            }
+        }
+        $this->originalEnv = [];
+
+        // Queue mode never touches the filesystem, so the fixture this test wrote is still
+        // there — unlike disk mode's DELETE tests, where the handler itself removes it.
+        if ($this->testFixturePath !== null && file_exists($this->testFixturePath)) {
+            unlink($this->testFixturePath);
+        }
+        $this->testFixturePath = null;
+
+        parent::tearDown();
+    }
+
+    public function testDeletingATestIsQueuedAndFlaggedAsAResourceDeletion(): void
+    {
+        $testName              = 'QueueDeleteFixture_' . bin2hex(random_bytes(6));
+        $testsDir              = JsonData::testsFolderFor(Rite::ROMAN)->path();
+        $fixturePath           = $testsDir . DIRECTORY_SEPARATOR . $testName . '.json';
+        $this->testFixturePath = $fixturePath;
+
+        file_put_contents($fixturePath, json_encode(
+            ['name' => $testName, 'applies_to' => ['national_calendar' => 'US']],
+            JSON_THROW_ON_ERROR
+        ));
+
+        $handler  = new TestsHandler([$testName], Rite::ROMAN);
+        $response = $handler->handle(
+            $this->withOidcUser($this->requestFor('DELETE', "/tests/roman/{$testName}"), 'editor-1')
+        );
+
+        $body = $this->decodeJsonBody($response);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('submitted', $body['disposition'] ?? null);
+        self::assertIsArray($body['change_request'] ?? null);
+        /** @var array<string,mixed> $changeRequest */
+        $changeRequest = $body['change_request'];
+        self::assertIsString($changeRequest['batch_id'] ?? null);
+
+        // Queue mode must not have touched the filesystem.
+        self::assertFileExists($fixturePath);
+
+        $repo = new SourceDataChangeRequestRepository();
+        $rows = $repo->getBatch($changeRequest['batch_id']);
+        self::assertNotSame([], $rows, 'the deletion must have been queued');
+        foreach ($rows as $row) {
+            self::assertTrue(
+                $row['metadata']['deletes_resource'] ?? false,
+                'every row of a resource-deletion batch must carry the flag'
+            );
+        }
+    }
+}

--- a/phpunit_tests/HealthSourceDataPublisherTest.php
+++ b/phpunit_tests/HealthSourceDataPublisherTest.php
@@ -213,4 +213,55 @@ final class HealthSourceDataPublisherTest extends TestCase
             'three segments'        => ['github.com/owner/repo'],
         ];
     }
+
+    /**
+     * The block always carries `open_batches` and `oldest_open_age_seconds`, on every branch —
+     * a deployment in the unconfigured-publisher state, the very state this block exists to
+     * catch, must not answer without them.
+     */
+    public function testTheBlockAlwaysCarriesOpenBatchKeysAsInts(): void
+    {
+        $status = Health::buildSourceDataPublisherStatus();
+
+        self::assertArrayHasKey('open_batches', $status);
+        self::assertArrayHasKey('oldest_open_age_seconds', $status);
+        self::assertIsInt($status['open_batches']);
+        self::assertIsInt($status['oldest_open_age_seconds']);
+    }
+
+    /**
+     * This suite has no database — setUp() clears the DB_* keys and closes the connection — so
+     * the two counts must degrade to zero via {@see Connection::isConfigured()} returning false,
+     * the same guard {@see \LiturgicalCalendar\Api\Health::parkedChangeRequestBatches()} already
+     * relies on for `parked_batches`. That degradation IS the "database unreachable" case: it
+     * needs no dedicated helper because every test in this file already runs under it, this one
+     * with no env configured at all.
+     */
+    public function testTheOpenBatchCountsDegradeToZeroWhenThereIsNoDatabaseToAsk(): void
+    {
+        $status = Health::buildSourceDataPublisherStatus();
+
+        self::assertSame(0, $status['open_batches']);
+        self::assertSame(0, $status['oldest_open_age_seconds']);
+    }
+
+    /**
+     * Same degradation, reached from the other side: `enableQueueMode()` sets DB_HOST etc. to
+     * placeholder credentials that are configured but not reachable (a real test database, if
+     * any, is loaded separately by
+     * {@see \LiturgicalCalendar\Tests\Repositories\RepositoryTestCase}). `Connection::isConfigured()`
+     * now answers true, so this exercises the try/catch around the actual connection attempt
+     * rather than the isConfigured() short-circuit above — the same case
+     * `testQueueModeOnAndPublisherConfiguredReportsOk()` already covers for `parked_batches`.
+     */
+    public function testTheOpenBatchCountsDegradeToZeroWhenTheConfiguredDatabaseIsUnreachable(): void
+    {
+        $this->enableQueueMode();
+        $this->configurePublisher();
+
+        $status = Health::buildSourceDataPublisherStatus();
+
+        self::assertSame(0, $status['open_batches']);
+        self::assertSame(0, $status['oldest_open_age_seconds']);
+    }
 }

--- a/phpunit_tests/HealthSourceDataPublisherTest.php
+++ b/phpunit_tests/HealthSourceDataPublisherTest.php
@@ -31,6 +31,7 @@ final class HealthSourceDataPublisherTest extends TestCase
     private const KEYS = [
         SourceDataWriteMode::FLAG,
         'DB_HOST',
+        'DB_PORT',
         'DB_NAME',
         'DB_USER',
         'DB_PASSWORD',
@@ -107,12 +108,17 @@ final class HealthSourceDataPublisherTest extends TestCase
     {
         $_ENV[SourceDataWriteMode::FLAG] = 'true';
         $_ENV['DB_HOST']                 = 'localhost';
-        $_ENV['DB_NAME']                 = 'litcal';
-        $_ENV['DB_USER']                 = 'litcal';
-        $_ENV['DB_PASSWORD']             = 'secret';
-        $_ENV['OPENFGA_API_URL']         = 'http://localhost:8083';
-        $_ENV['OPENFGA_STORE_ID']        = 'store';
-        $_ENV['OPENFGA_MODEL_ID']        = 'model';
+        // Port 1 is a privileged port nothing on this machine can be listening on for Postgres,
+        // so the connect is refused immediately regardless of local auth configuration — see
+        // testTheOpenBatchCountsDegradeToZeroWhenTheConfiguredDatabaseIsUnreachable()'s docblock
+        // for why DB_HOST/DB_NAME/DB_USER alone were not enough to guarantee that.
+        $_ENV['DB_PORT']          = '1';
+        $_ENV['DB_NAME']          = 'litcal';
+        $_ENV['DB_USER']          = 'litcal';
+        $_ENV['DB_PASSWORD']      = 'secret';
+        $_ENV['OPENFGA_API_URL']  = 'http://localhost:8083';
+        $_ENV['OPENFGA_STORE_ID'] = 'store';
+        $_ENV['OPENFGA_MODEL_ID'] = 'model';
     }
 
     private function configurePublisher(): void
@@ -246,13 +252,21 @@ final class HealthSourceDataPublisherTest extends TestCase
     }
 
     /**
-     * Same degradation, reached from the other side: `enableQueueMode()` sets DB_HOST etc. to
-     * placeholder credentials that are configured but not reachable (a real test database, if
-     * any, is loaded separately by
-     * {@see \LiturgicalCalendar\Tests\Repositories\RepositoryTestCase}). `Connection::isConfigured()`
-     * now answers true, so this exercises the try/catch around the actual connection attempt
-     * rather than the isConfigured() short-circuit above — the same case
-     * `testQueueModeOnAndPublisherConfiguredReportsOk()` already covers for `parked_batches`.
+     * Same degradation, reached from the other side: `enableQueueMode()` sets DB_HOST, DB_NAME,
+     * and DB_USER to the SAME values as the live development database in `.env.local` — only
+     * DB_PASSWORD differs. Placeholder credentials alone are not reliably unreachable: on a
+     * machine whose Postgres uses trust auth, or where the placeholder password happens to
+     * match, the connection would SUCCEED against a live database, and this test would assert
+     * `0` for the wrong reason (or fail confusingly if that database has open batches).
+     * `enableQueueMode()` therefore also pins DB_PORT to `1`, a port nothing can be listening on,
+     * so the connection attempt is refused immediately regardless of local auth configuration —
+     * deterministically unreachable rather than merely unauthenticated. (A real test database,
+     * if any, is loaded separately by
+     * {@see \LiturgicalCalendar\Tests\Repositories\RepositoryTestCase}, which does not go through
+     * `enableQueueMode()`.) `Connection::isConfigured()` now answers true, so this exercises the
+     * try/catch around the actual connection attempt rather than the isConfigured()
+     * short-circuit above — the same case `testQueueModeOnAndPublisherConfiguredReportsOk()`
+     * already covers for `parked_batches`.
      */
     public function testTheOpenBatchCountsDegradeToZeroWhenTheConfiguredDatabaseIsUnreachable(): void
     {

--- a/phpunit_tests/Repositories/HealthOpenBatchesTest.php
+++ b/phpunit_tests/Repositories/HealthOpenBatchesTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Repositories;
+
+use LiturgicalCalendar\Api\Enum\ChangeOperation;
+use LiturgicalCalendar\Api\Enum\ChangePublicationStatus;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\ChangeResource;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * `/health`'s `source_data_publisher` block must report batches still awaiting a merge
+ * decision, and say something once the oldest of them has waited far longer than any review
+ * plausibly takes.
+ *
+ * An open batch is the ORDINARY state — a reviewer has not got to its pull request yet — so it
+ * must never alarm on its own; only the age, past {@see Health::STALE_OPEN_BATCH_SECONDS}, is a
+ * signal. What that threshold actually catches is invisible from every other angle: an
+ * undetected merge (no cron entry for `scripts/poll-sourcedata-merges.php`, no consumer
+ * running) looks EXACTLY like an unreviewed pull request from this side, so this is asserted
+ * against a real Postgres rather than a mocked repository — a sibling of
+ * {@see HealthParkedBatchesTest}, which covers the other DB-backed reading of this same block.
+ * The environment-decided branches (queue mode, publisher configuration) are covered by
+ * {@see \LiturgicalCalendar\Tests\HealthSourceDataPublisherTest}.
+ */
+#[CoversClass(Health::class)]
+final class HealthOpenBatchesTest extends RepositoryTestCase
+{
+    private SourceDataChangeRequestRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new SourceDataChangeRequestRepository(self::$pdo);
+    }
+
+    /**
+     * Submits, approves, and publication-marks a batch `open`, then backdates `updated_at` so
+     * its age is exactly `$ageSeconds` as read by {@see SourceDataChangeRequestRepository::openBatchStats()}.
+     */
+    private function openOneAgedSeconds(string $nation, int $ageSeconds): string
+    {
+        $batchId = $this->repo->submitBatch(
+            ChangeResource::nationalCalendar(Rite::ROMAN, $nation),
+            [
+                [
+                    'path'      => "jsondata/sourcedata/rite/roman/calendars/nations/{$nation}/{$nation}.json",
+                    'operation' => ChangeOperation::CREATE,
+                    'content'   => '{"litcal":[]}',
+                ],
+            ],
+            'editor-' . $nation,
+            'Editor',
+            'editor@example.test',
+            true
+        )['batch_id'];
+
+        $this->repo->approveBatch($batchId, 'reviewer-1');
+        $this->repo->markBatchPublicationStatus($batchId, ChangePublicationStatus::OPEN);
+
+        self::$pdo->prepare(
+            "UPDATE sourcedata_change_requests SET updated_at = NOW() - (:age * INTERVAL '1 second') WHERE batch_id = :b"
+        )->execute(['age' => $ageSeconds, 'b' => $batchId]);
+
+        return $batchId;
+    }
+
+    /**
+     * A pull request awaiting review is the ordinary state — a reviewer has not got to it yet —
+     * so a freshly-opened batch must be counted but must not itself alarm.
+     */
+    public function testAnOpenBatchIsCountedButIsNotItselfAWarning(): void
+    {
+        $this->openOneAgedSeconds('US', 3600);
+
+        $status = Health::buildSourceDataPublisherStatus();
+
+        self::assertSame(1, $status['open_batches']);
+        self::assertNotSame('warning', $status['status'], 'a pull request awaiting review is not a fault');
+    }
+
+    /**
+     * Past the threshold, the block warns — and the message must name both plausible readings
+     * (a slow reviewer, or a stopped poller) rather than accusing the poller outright, because
+     * at this age either is genuinely possible.
+     */
+    public function testAVeryOldOpenBatchWarnsWithoutBlamingTheReviewer(): void
+    {
+        $this->openOneAgedSeconds('US', Health::STALE_OPEN_BATCH_SECONDS + 60);
+
+        $status = Health::buildSourceDataPublisherStatus();
+
+        self::assertSame('warning', $status['status']);
+        self::assertStringContainsString('poll-sourcedata-merges', $status['message']);
+        self::assertStringContainsString('reviewer', $status['message']);
+    }
+
+    /**
+     * `open_batches` counts distinct batches; `oldest_open_age_seconds` reports the oldest of
+     * them, not an average or the newest.
+     */
+    public function testMultipleOpenBatchesReportTheOldestAge(): void
+    {
+        $this->openOneAgedSeconds('US', 3600);
+        $this->openOneAgedSeconds('DE', 7200);
+
+        $status = Health::buildSourceDataPublisherStatus();
+
+        self::assertSame(2, $status['open_batches']);
+        self::assertGreaterThanOrEqual(7200, $status['oldest_open_age_seconds']);
+    }
+}

--- a/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
@@ -103,14 +103,14 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
      * genuinely concurrent rather than sequential.
      *
      * Extracted from what was originally inlined in
-     * {@see testTwoRealConcurrentRunnersNeverClaimTheSameBatch()}, so that every test needing
-     * real two-process concurrency shares one proc_open harness rather than each hand-rolling
-     * its own.
+     * {@see testTwoRealConcurrentRunnersNeverClaimTheSameBatch()}. The low-level primitive
+     * behind {@see raceTwoProcesses()}, which every test needing real two-process concurrency
+     * goes through rather than each hand-rolling its own proc_open dance.
      *
      * @param list<string> $command
      * @return array{0: array{string, string, int}, 1: array{string, string, int}}
      */
-    private function raceTwoProcesses(array $command): array
+    private function launchTwoProcesses(array $command): array
     {
         $env         = [
             'DB_HOST'     => (string) self::env('DB_HOST'),
@@ -142,11 +142,47 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         return [[$outA, $errA, $exitA], [$outB, $errB, $exitB]];
     }
 
+    /**
+     * Runs $code as two OS processes racing against the same live database — via
+     * {@see launchTwoProcesses()}, so both are started before either pipe is read — and
+     * returns each one's JSON-decoded stdout.
+     *
+     * $code may reference `$pdo` (a PDO connected per the DB_* environment this test class
+     * itself was configured with) and `$repo` (a {@see SourceDataChangeRequestRepository}
+     * over that connection); both are constructed by a small bootstrap this method prepends
+     * before $code runs. $code is expected to `echo json_encode(...)` exactly once.
+     *
+     * @return array{0: mixed, 1: mixed}
+     */
+    private function raceTwoProcesses(string $code): array
+    {
+        $autoload  = var_export(dirname(__DIR__, 2) . '/vendor/autoload.php', true);
+        $bootstrap = <<<PHP
+            require {$autoload};
+            \$pdo = new PDO(
+                sprintf('pgsql:host=%s;port=%s;dbname=%s', getenv('DB_HOST'), getenv('DB_PORT') ?: '5432', getenv('DB_NAME')),
+                getenv('DB_USER'),
+                getenv('DB_PASSWORD'),
+                [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+            );
+            \$repo = new \\LiturgicalCalendar\\Api\\Repositories\\SourceDataChangeRequestRepository(\$pdo);
+            PHP;
+
+        [$resultA, $resultB]   = $this->launchTwoProcesses([PHP_BINARY, '-r', $bootstrap . "\n" . $code]);
+        [$outA, $errA, $exitA] = $resultA;
+        [$outB, $errB, $exitB] = $resultB;
+
+        self::assertSame(0, $exitA, "process A failed:\n{$errA}");
+        self::assertSame(0, $exitB, "process B failed:\n{$errB}");
+
+        return [json_decode($outA, true), json_decode($outB, true)];
+    }
+
     public function testClaimingReturnsAnApprovedBatchAndMarksItQueued(): void
     {
         $batchId = $this->submitAndApprove('editor-1');
 
-        self::assertSame($batchId, $this->repo->claimNextPublishableBatch());
+        self::assertSame($batchId, $this->repo->claimNextPublishableBatch()?->batchId);
 
         foreach ($this->repo->getBatch($batchId) as $row) {
             self::assertSame(ChangePublicationStatus::QUEUED->value, $row['publication_status']);
@@ -171,11 +207,16 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
     public function testReleasingAClaimMakesItPublishableAgain(): void
     {
         $batchId = $this->submitAndApprove('editor-1');
-        $this->repo->claimNextPublishableBatch();
+        $claim   = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claim);
 
-        $this->repo->releaseClaim($batchId);
+        $this->repo->releaseClaim($batchId, $claim->token);
 
-        self::assertSame($batchId, $this->repo->claimNextPublishableBatch(), 'a failed attempt must be retryable');
+        self::assertSame(
+            $batchId,
+            $this->repo->claimNextPublishableBatch()?->batchId,
+            'a failed attempt must be retryable'
+        );
 
         foreach ($this->repo->getBatch($batchId) as $row) {
             self::assertSame(ChangePublicationStatus::QUEUED->value, $row['publication_status']);
@@ -202,7 +243,8 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
     public function testReleaseClaimIsANoOpOnceAnotherRunnerHasAlreadyPublished(): void
     {
         $batchId = $this->submitAndApprove('editor-1');
-        $this->repo->claimNextPublishableBatch();
+        $claimA  = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claimA);
 
         // Runner B: publishes successfully while A's own attempt is (unbeknownst to A) still
         // in flight.
@@ -210,7 +252,7 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
 
         // Runner A: its own GitHub call now fails for real (branch moved under it) and it
         // tries to release the claim it believes it still holds.
-        $outcome = $this->repo->releaseClaim($batchId);
+        $outcome = $this->repo->releaseClaim($batchId, $claimA->token);
         self::assertSame(
             ClaimReleaseOutcome::SETTLED_ELSEWHERE,
             $outcome,
@@ -232,7 +274,7 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         self::$pdo->exec('UPDATE sourcedata_change_requests SET created_at = created_at - INTERVAL \'1 hour\'');
         $this->submitAndApprove('editor-2', 'DE');
 
-        self::assertSame($older, $this->repo->claimNextPublishableBatch());
+        self::assertSame($older, $this->repo->claimNextPublishableBatch()?->batchId);
     }
 
     public function testRecordPublicationSetsOpenStatusAndGitFields(): void
@@ -314,7 +356,7 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         // Once connection A's transaction ends, the lock is released and the batch
         // becomes claimable again — proving the null above was "locked, try later", not
         // some unrelated bug swallowing the row.
-        self::assertSame($batchId, $this->repo->claimNextPublishableBatch());
+        self::assertSame($batchId, $this->repo->claimNextPublishableBatch()?->batchId);
     }
 
     /**
@@ -360,7 +402,7 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         $fixture = dirname(__DIR__) . '/fixtures/claim-race-worker.php';
         self::assertFileExists($fixture);
 
-        [$resultA, $resultB]   = $this->raceTwoProcesses([PHP_BINARY, $fixture]);
+        [$resultA, $resultB]   = $this->launchTwoProcesses([PHP_BINARY, $fixture]);
         [$outA, $errA, $exitA] = $resultA;
         [$outB, $errB, $exitB] = $resultB;
 
@@ -399,24 +441,29 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
     public function testReleaseClaimReportsWhatItObservedNotJustWhetherItChangedAnything(): void
     {
         // 1. The live claim: released, and the failure is genuine.
-        $queued = $this->submitAndApprove('editor-1', 'US');
-        $this->repo->claimNextPublishableBatch();
-        self::assertSame(ClaimReleaseOutcome::RELEASED, $this->repo->releaseClaim($queued));
+        $queued      = $this->submitAndApprove('editor-1', 'US');
+        $queuedClaim = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($queuedClaim);
+        self::assertSame(ClaimReleaseOutcome::RELEASED, $this->repo->releaseClaim($queued, $queuedClaim->token));
 
         // 2. Already back at `none` — the sibling of `open`, and the one that used to read as
         //    "settled, carry on" purely because both affect zero rows.
-        self::assertSame(ClaimReleaseOutcome::NOT_CLAIMED, $this->repo->releaseClaim($queued));
+        self::assertSame(ClaimReleaseOutcome::NOT_CLAIMED, $this->repo->releaseClaim($queued, $queuedClaim->token));
 
         // 3. Published by someone else: the ONLY zero-row case that is not a failure.
-        $published = $this->submitAndApprove('editor-2', 'DE');
-        $this->repo->claimNextPublishableBatch();
+        $published      = $this->submitAndApprove('editor-2', 'DE');
+        $publishedClaim = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($publishedClaim);
         $this->repo->recordPublication($published, 'litcal-data/national_calendar/roman/DE', 'sha', 7, 'base');
-        self::assertSame(ClaimReleaseOutcome::SETTLED_ELSEWHERE, $this->repo->releaseClaim($published));
+        self::assertSame(
+            ClaimReleaseOutcome::SETTLED_ELSEWHERE,
+            $this->repo->releaseClaim($published, $publishedClaim->token)
+        );
 
         // 4. No such batch: an unexplained state, never read optimistically.
         self::assertSame(
             ClaimReleaseOutcome::BATCH_MISSING,
-            $this->repo->releaseClaim('00000000-0000-4000-8000-000000000000')
+            $this->repo->releaseClaim('00000000-0000-4000-8000-000000000000', '00000000-0000-4000-8000-000000000001')
         );
     }
 
@@ -430,8 +477,10 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         $batchId = $this->submitAndApprove('editor-1', 'US');
 
         for ($attempt = 1; $attempt <= SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS; $attempt++) {
-            self::assertSame($batchId, $this->repo->claimNextPublishableBatch(), "attempt {$attempt} must be claimable");
-            self::assertSame(ClaimReleaseOutcome::RELEASED, $this->repo->releaseClaim($batchId));
+            $claim = $this->repo->claimNextPublishableBatch();
+            self::assertNotNull($claim, "attempt {$attempt} must be claimable");
+            self::assertSame($batchId, $claim->batchId, "attempt {$attempt} must be claimable");
+            self::assertSame(ClaimReleaseOutcome::RELEASED, $this->repo->releaseClaim($batchId, $claim->token));
 
             foreach ($this->repo->getBatch($batchId) as $row) {
                 self::assertEquals($attempt, $row['publish_attempts']);
@@ -448,7 +497,7 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         // what the runbook tells an operator to do.
         self::$pdo->prepare('UPDATE sourcedata_change_requests SET publish_attempts = 0 WHERE batch_id = :b')
             ->execute(['b' => $batchId]);
-        self::assertSame($batchId, $this->repo->claimNextPublishableBatch());
+        self::assertSame($batchId, $this->repo->claimNextPublishableBatch()?->batchId);
         self::assertSame(0, $this->repo->countParkedBatches());
     }
 
@@ -463,9 +512,13 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         $first  = $this->submitAndApprove('editor-1', 'US');
         $second = $this->submitAndApprove('editor-2', 'DE');
 
-        self::assertSame($second, $this->repo->claimNextPublishableBatch([$first]));
+        self::assertSame($second, $this->repo->claimNextPublishableBatch([$first])?->batchId);
         self::assertSame(0, $this->repo->countParkedBatches(), 'skipping is not parking');
-        self::assertSame($first, $this->repo->claimNextPublishableBatch(), 'and it lasts only as long as the caller says');
+        self::assertSame(
+            $first,
+            $this->repo->claimNextPublishableBatch()?->batchId,
+            'and it lasts only as long as the caller says'
+        );
     }
 
     public function testCountParkedBatchesIgnoresBatchesThatAreNoLongerWaiting(): void
@@ -483,5 +536,140 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
             $this->repo->countParkedBatches(),
             'a batch that reached GitHub is not stuck, whatever its attempt history'
         );
+    }
+
+    public function testClaimReturnsATokenAndReleaseRequiresIt(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+
+        $claim = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claim);
+        self::assertSame($batchId, $claim->batchId);
+        self::assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/',
+            $claim->token
+        );
+
+        self::assertSame(ClaimReleaseOutcome::RELEASED, $this->repo->releaseClaim($batchId, $claim->token));
+    }
+
+    /**
+     * The defect this column exists for: runner A is slow, the grace period elapses,
+     * reclaimStaleClaims() frees the batch, runner B claims it — and then A's late release must
+     * NOT revoke B's live claim, and must NOT spend one of B's attempts.
+     */
+    public function testStaleReleaseNeitherRevokesTheLiveClaimNorSpendsAnAttempt(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+
+        $claimA = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claimA);
+
+        // The grace period elapses and the reclaim frees it (spending A's attempt), then B claims.
+        $this->backdateUpdatedAt($batchId, 60);
+        self::assertSame(1, $this->repo->reclaimStaleClaims(new \DateTimeImmutable('-30 minutes')));
+        $claimB = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claimB);
+        self::assertNotSame($claimA->token, $claimB->token);
+
+        $attemptsBefore = $this->publishAttempts($batchId);
+
+        // A's doomed GitHub call finally returns and A releases.
+        self::assertSame(ClaimReleaseOutcome::CLAIM_LOST, $this->repo->releaseClaim($batchId, $claimA->token));
+
+        self::assertSame(
+            ChangePublicationStatus::QUEUED->value,
+            $this->publicationStatus($batchId),
+            "B's claim must survive A's stale release"
+        );
+        self::assertSame($attemptsBefore, $this->publishAttempts($batchId), 'A stale release spends no attempt');
+    }
+
+    public function testRecordPublicationClearsTheClaimToken(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+        $claim   = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claim);
+
+        $this->repo->recordPublication($batchId, 'litcal-data/national_calendar/roman/US', 'sha1', 7, 'base');
+
+        self::assertNull($this->claimToken($batchId));
+    }
+
+    public function testReclaimStaleClaimsClearsTheClaimToken(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+        self::assertNotNull($this->repo->claimNextPublishableBatch());
+
+        $this->backdateUpdatedAt($batchId, 60);
+        self::assertSame(1, $this->repo->reclaimStaleClaims(new \DateTimeImmutable('-30 minutes')));
+
+        self::assertNull($this->claimToken($batchId));
+    }
+
+    /**
+     * Two real processes, one approved batch. Exactly one claim, and — the phase-3 half — the winner's
+     * token is the one on the row, so the loser cannot later release a claim it never held.
+     */
+    public function testTwoRealConcurrentRunnersProduceOneClaimAndOneToken(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+
+        $results = $this->raceTwoProcesses(<<<'PHP'
+            $claim = $repo->claimNextPublishableBatch();
+            echo json_encode(['batch' => $claim?->batchId, 'token' => $claim?->token]);
+            PHP);
+
+        $claimed = array_values(array_filter($results, static fn (array $r): bool => null !== $r['batch']));
+        self::assertCount(1, $claimed, 'exactly one process may claim the batch');
+        self::assertSame($batchId, $claimed[0]['batch']);
+        self::assertSame($claimed[0]['token'], $this->claimToken($batchId), 'the row carries the winner\'s token');
+
+        // The loser holds no token, so it cannot release the winner's claim even by guessing the batch id.
+        self::assertSame(
+            ClaimReleaseOutcome::CLAIM_LOST,
+            $this->repo->releaseClaim($batchId, '00000000-0000-4000-8000-000000000000')
+        );
+    }
+
+    private function claimToken(string $batchId): ?string
+    {
+        $stmt = self::$pdo->prepare(
+            'SELECT publish_claim_token FROM sourcedata_change_requests WHERE batch_id = :b LIMIT 1'
+        );
+        $stmt->execute(['b' => $batchId]);
+        $value = $stmt->fetchColumn();
+
+        return is_string($value) ? $value : null;
+    }
+
+    private function publishAttempts(string $batchId): int
+    {
+        $stmt = self::$pdo->prepare(
+            'SELECT MAX(publish_attempts) FROM sourcedata_change_requests WHERE batch_id = :b'
+        );
+        $stmt->execute(['b' => $batchId]);
+
+        return (int) $stmt->fetchColumn();
+    }
+
+    private function publicationStatus(string $batchId): string
+    {
+        $stmt = self::$pdo->prepare(
+            'SELECT publication_status FROM sourcedata_change_requests WHERE batch_id = :b LIMIT 1'
+        );
+        $stmt->execute(['b' => $batchId]);
+
+        return (string) $stmt->fetchColumn();
+    }
+
+    private function backdateUpdatedAt(string $batchId, int $minutesAgo): void
+    {
+        $stmt = self::$pdo->prepare(
+            "UPDATE sourcedata_change_requests
+                SET updated_at = NOW() - (:mins || ' minutes')::interval
+              WHERE batch_id = :b"
+        );
+        $stmt->execute(['mins' => (string) $minutesAgo, 'b' => $batchId]);
     }
 }

--- a/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
@@ -307,6 +307,37 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
     }
 
     /**
+     * The `AND publication_status = 'queued'` guard's whole point: once a batch has already
+     * been recorded `open` by one recorder, a SECOND `recordPublication()` call for the same
+     * batch id — the shape a stale runner A's own late-arriving publish takes, after runner B
+     * already recorded it (see {@see testReleaseClaimIsANoOpOnceAnotherRunnerHasAlreadyPublished()}
+     * for the matching `releaseClaim()` half of this same race) — must change nothing and must
+     * report zero rows, so the caller ({@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher::publish()})
+     * can detect and log the block rather than silently overwriting B's identifiers with A's.
+     */
+    public function testASecondRecordPublicationForAnAlreadyOpenBatchChangesNothingAndReportsZeroRows(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+        $this->repo->claimNextPublishableBatch();
+
+        // Runner B: the first, winning recorder.
+        $firstUpdated = $this->repo->recordPublication($batchId, 'litcal-data/national_calendar/roman/US', 'b-sha', 42, 'base-b');
+        self::assertGreaterThan(0, $firstUpdated);
+
+        // Runner A: a stale second recorder for the SAME batch id, with different identifiers.
+        $secondUpdated = $this->repo->recordPublication($batchId, 'litcal-data/national_calendar/roman/US', 'a-sha', 99, 'base-a');
+        self::assertSame(0, $secondUpdated, 'a batch no longer "queued" must not be recordable again');
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::OPEN->value, $row['publication_status']);
+            self::assertSame('litcal-data/national_calendar/roman/US', $row['branch'], 'B\'s branch must survive A\'s stale call');
+            self::assertSame('b-sha', $row['commit_sha'], 'B\'s commit sha must survive A\'s stale call');
+            self::assertEquals(42, $row['pr_number'], 'B\'s pull request number must survive A\'s stale call');
+            self::assertSame('base-b', $row['base_sha'], 'B\'s base sha must survive A\'s stale call');
+        }
+    }
+
+    /**
      * The test that actually demonstrates atomicity, not just that a single caller's
      * claim behaves. It reproduces the exact locking half of claimNextPublishableBatch()
      * on a second, independent connection and holds it open in an uncommitted
@@ -451,9 +482,14 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         self::assertSame(ClaimReleaseOutcome::NOT_CLAIMED, $this->repo->releaseClaim($queued, $queuedClaim->token));
 
         // 3. Published by someone else: the ONLY zero-row case that is not a failure.
-        $published      = $this->submitAndApprove('editor-2', 'DE');
-        $publishedClaim = $this->repo->claimNextPublishableBatch();
+        $published = $this->submitAndApprove('editor-2', 'DE');
+        // $queued is back at `none` after step 1's release, and older, so it would otherwise be
+        // reclaimed here instead of $published — skip it explicitly so this claim (and the
+        // `recordPublication()` guard below, which now requires the row to be `queued`) targets
+        // the batch this step actually means to publish.
+        $publishedClaim = $this->repo->claimNextPublishableBatch([$queued]);
         self::assertNotNull($publishedClaim);
+        self::assertSame($published, $publishedClaim->batchId);
         $this->repo->recordPublication($published, 'litcal-data/national_calendar/roman/DE', 'sha', 7, 'base');
         self::assertSame(
             ClaimReleaseOutcome::SETTLED_ELSEWHERE,
@@ -525,10 +561,21 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
     {
         $published = $this->submitAndApprove('editor-1', 'US');
 
-        // Exhaust the bound, then publish anyway (an operator retry, or phase 3).
+        // Exhaust the bound: parked while still `none`.
         self::$pdo->prepare('UPDATE sourcedata_change_requests SET publish_attempts = :n WHERE batch_id = :b')
             ->execute(['n' => SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS, 'b' => $published]);
         self::assertSame(1, $this->repo->countParkedBatches());
+
+        // Recover it the only way the schema allows — reset the counter so it becomes claimable
+        // again (see testReleaseClaimCountsAnAttemptAndParksTheBatchAtTheBound()), then claim and
+        // publish it. recordPublication() now requires the row to be `queued`, which only a claim
+        // produces — an operator retry or phase 3 reaches this same state through the ordinary
+        // claim path, not by calling recordPublication() directly on a still-`none` row.
+        self::$pdo->prepare('UPDATE sourcedata_change_requests SET publish_attempts = 0 WHERE batch_id = :b')
+            ->execute(['b' => $published]);
+        $claim = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claim);
+        self::assertSame($published, $claim->batchId);
 
         $this->repo->recordPublication($published, 'litcal-data/national_calendar/roman/US', 'sha', 7, 'base');
         self::assertSame(

--- a/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
@@ -672,4 +672,125 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         );
         $stmt->execute(['mins' => (string) $minutesAgo, 'b' => $batchId]);
     }
+
+    private function publishTo(string $batchId, int $prNumber, string $commitSha): void
+    {
+        $claim = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claim);
+        self::assertSame($batchId, $claim->batchId);
+        $this->repo->recordPublication($batchId, 'litcal-data/national_calendar/roman/US', $commitSha, $prNumber, 'base');
+    }
+
+    public function testListOpenPullRequestNumbersDeduplicatesAndOrdersOldestFirst(): void
+    {
+        $first = $this->submitAndApprove('editor-1', 'US');
+        $this->publishTo($first, 11, 'sha-a');
+        $second = $this->submitAndApprove('editor-2', 'US');
+        $this->publishTo($second, 11, 'sha-b');   // same rolling PR
+        $third = $this->submitAndApprove('editor-3', 'IT');
+        $this->publishTo($third, 22, 'sha-c');
+
+        self::assertSame([11, 22], $this->repo->listOpenPullRequestNumbers());
+    }
+
+    public function testListOpenBatchesForPullRequestReturnsEveryBatchOnIt(): void
+    {
+        $first = $this->submitAndApprove('editor-1', 'US');
+        $this->publishTo($first, 11, 'sha-a');
+        $second = $this->submitAndApprove('editor-2', 'US');
+        $this->publishTo($second, 11, 'sha-b');
+
+        $rows = $this->repo->listOpenBatchesForPullRequest(11);
+
+        self::assertCount(2, $rows);
+        self::assertSame(
+            ['sha-a', 'sha-b'],
+            array_column($rows, 'commit_sha')
+        );
+    }
+
+    public function testMarkBatchMergedRecordsTheMergeCommitAndSettledAt(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+        $this->publishTo($batchId, 11, 'sha-a');
+
+        self::assertSame(1, $this->repo->markBatchMerged($batchId, 'merge-sha'));
+
+        $row = $this->firstRow($batchId);
+        self::assertSame(ChangePublicationStatus::MERGED->value, $row['publication_status']);
+        self::assertSame('merge-sha', $row['merge_commit_sha']);
+        self::assertNotNull($row['publication_settled_at']);
+        self::assertSame(ChangeReviewStatus::APPROVED->value, $row['review_status'], 'a merge does not re-review');
+    }
+
+    public function testMarkBatchClosedUnmergedAlsoRejectsAndGivesAReason(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+        $this->publishTo($batchId, 11, 'sha-a');
+
+        self::assertSame(1, $this->repo->markBatchClosedUnmerged($batchId, 'Pull request #11 was closed without merging.'));
+
+        $row = $this->firstRow($batchId);
+        self::assertSame(ChangePublicationStatus::CLOSED->value, $row['publication_status']);
+        self::assertSame(ChangeReviewStatus::REJECTED->value, $row['review_status']);
+        self::assertSame('Pull request #11 was closed without merging.', $row['rejected_reason']);
+        self::assertNotNull($row['publication_settled_at']);
+    }
+
+    /**
+     * Both transitions are guarded on `open`, so two racing pollers produce one transition and one
+     * no-op rather than two writes of possibly-different merge shas.
+     */
+    public function testTransitionsAreGuardedOnOpen(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+        $this->publishTo($batchId, 11, 'sha-a');
+
+        self::assertSame(1, $this->repo->markBatchMerged($batchId, 'merge-sha'));
+        self::assertSame(0, $this->repo->markBatchMerged($batchId, 'other-sha'), 'second poller must be a no-op');
+        self::assertSame('merge-sha', $this->firstRow($batchId)['merge_commit_sha']);
+    }
+
+    /**
+     * A batch on a merged PR whose commit was NOT in the merge goes back to claimable, clearing the
+     * attempts it never spent, so the next publish opens a fresh pull request carrying it.
+     */
+    public function testReturnBatchToUnpublishedMakesItClaimableAgain(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+        $this->publishTo($batchId, 11, 'sha-a');
+
+        self::assertSame(1, $this->repo->returnBatchToUnpublished($batchId));
+
+        $row = $this->firstRow($batchId);
+        self::assertSame(ChangePublicationStatus::NONE->value, $row['publication_status']);
+        self::assertSame(0, (int) $row['publish_attempts']);
+        self::assertSame('sha-a', $row['commit_sha'], 'git identifiers are kept for forensics');
+
+        $claim = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claim);
+        self::assertSame($batchId, $claim->batchId);
+    }
+
+    public function testCountOpenBatchesWithoutPullRequestFindsTheUnpollableOnes(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+        $this->publishTo($batchId, 11, 'sha-a');
+        self::assertSame(0, $this->repo->countOpenBatchesWithoutPullRequest());
+
+        self::$pdo->exec("UPDATE sourcedata_change_requests SET pr_number = NULL WHERE batch_id = '{$batchId}'");
+        self::assertSame(1, $this->repo->countOpenBatchesWithoutPullRequest());
+    }
+
+    /** @return array<string, mixed> */
+    private function firstRow(string $batchId): array
+    {
+        $stmt = self::$pdo->prepare('SELECT * FROM sourcedata_change_requests WHERE batch_id = :b LIMIT 1');
+        $stmt->execute(['b' => $batchId]);
+        /** @var array<string, mixed>|false $row */
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        self::assertNotFalse($row);
+
+        return $row;
+    }
 }

--- a/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
@@ -96,6 +96,52 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         return $pdo;
     }
 
+    /**
+     * Launches two copies of $command as OS processes and returns each one's captured
+     * [stdout, stderr, exit code]. Both are launched — and therefore both running — before
+     * either pipe is read: proc_open() itself does not block, so this is what makes the two
+     * genuinely concurrent rather than sequential.
+     *
+     * Extracted from what was originally inlined in
+     * {@see testTwoRealConcurrentRunnersNeverClaimTheSameBatch()}, so that every test needing
+     * real two-process concurrency shares one proc_open harness rather than each hand-rolling
+     * its own.
+     *
+     * @param list<string> $command
+     * @return array{0: array{string, string, int}, 1: array{string, string, int}}
+     */
+    private function raceTwoProcesses(array $command): array
+    {
+        $env         = [
+            'DB_HOST'     => (string) self::env('DB_HOST'),
+            'DB_PORT'     => (string) ( self::env('DB_PORT') ?? '5432' ),
+            'DB_NAME'     => (string) self::env('DB_NAME'),
+            'DB_USER'     => (string) self::env('DB_USER'),
+            'DB_PASSWORD' => (string) self::env('DB_PASSWORD'),
+            'PATH'        => (string) getenv('PATH'),
+        ];
+        $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+
+        $procA = proc_open($command, $descriptors, $pipesA, null, $env);
+        $procB = proc_open($command, $descriptors, $pipesB, null, $env);
+        self::assertIsResource($procA, 'could not start process A');
+        self::assertIsResource($procB, 'could not start process B');
+
+        $outA = (string) stream_get_contents($pipesA[1]);
+        $errA = (string) stream_get_contents($pipesA[2]);
+        fclose($pipesA[1]);
+        fclose($pipesA[2]);
+        $exitA = proc_close($procA);
+
+        $outB = (string) stream_get_contents($pipesB[1]);
+        $errB = (string) stream_get_contents($pipesB[2]);
+        fclose($pipesB[1]);
+        fclose($pipesB[2]);
+        $exitB = proc_close($procB);
+
+        return [[$outA, $errA, $exitA], [$outB, $errB, $exitB]];
+    }
+
     public function testClaimingReturnsAnApprovedBatchAndMarksItQueued(): void
     {
         $batchId = $this->submitAndApprove('editor-1');
@@ -314,35 +360,9 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         $fixture = dirname(__DIR__) . '/fixtures/claim-race-worker.php';
         self::assertFileExists($fixture);
 
-        $env         = [
-            'DB_HOST'     => (string) self::env('DB_HOST'),
-            'DB_PORT'     => (string) ( self::env('DB_PORT') ?? '5432' ),
-            'DB_NAME'     => (string) self::env('DB_NAME'),
-            'DB_USER'     => (string) self::env('DB_USER'),
-            'DB_PASSWORD' => (string) self::env('DB_PASSWORD'),
-            'PATH'        => (string) getenv('PATH'),
-        ];
-        $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
-
-        // Both subprocesses are launched — and therefore both running — before either pipe
-        // is read. proc_open() itself does not block, so this is what makes the two workers
-        // genuinely concurrent rather than sequential.
-        $procA = proc_open([PHP_BINARY, $fixture], $descriptors, $pipesA, null, $env);
-        $procB = proc_open([PHP_BINARY, $fixture], $descriptors, $pipesB, null, $env);
-        self::assertIsResource($procA, 'could not start worker A');
-        self::assertIsResource($procB, 'could not start worker B');
-
-        $outA = (string) stream_get_contents($pipesA[1]);
-        $errA = (string) stream_get_contents($pipesA[2]);
-        fclose($pipesA[1]);
-        fclose($pipesA[2]);
-        $exitA = proc_close($procA);
-
-        $outB = (string) stream_get_contents($pipesB[1]);
-        $errB = (string) stream_get_contents($pipesB[2]);
-        fclose($pipesB[1]);
-        fclose($pipesB[2]);
-        $exitB = proc_close($procB);
+        [$resultA, $resultB]   = $this->raceTwoProcesses([PHP_BINARY, $fixture]);
+        [$outA, $errA, $exitA] = $resultA;
+        [$outB, $errB, $exitB] = $resultB;
 
         self::assertSame(0, $exitA, "worker A failed:\n{$errA}");
         self::assertSame(0, $exitB, "worker B failed:\n{$errB}");

--- a/phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php
@@ -1029,4 +1029,86 @@ final class SourceDataChangeRequestRepositoryTest extends RepositoryTestCase
         // rather than leave it inferred from the two columns above.
         self::assertSame($approvedAt, $row['approved_at']);
     }
+
+    private function submitDecrees(string $sub, string $content): string
+    {
+        return $this->repo->submitBatch(
+            ChangeResource::decrees(),
+            [
+                [
+                    'path'      => 'jsondata/sourcedata/rite/roman/decrees/decrees.json',
+                    'operation' => ChangeOperation::UPDATE,
+                    'content'   => $content,
+                ]
+            ],
+            $sub,
+            'Editor',
+            $sub . '@example.test',
+            true
+        )['batch_id'];
+    }
+
+    /** Both statuses at once, by direct SQL — no code path produces every combination this pins. */
+    private function forceStatuses(string $batchId, string $review, string $publication): void
+    {
+        $stmt = self::$pdo->prepare(
+            'UPDATE sourcedata_change_requests
+                SET review_status = :r, publication_status = :p
+              WHERE batch_id = :b'
+        );
+        $stmt->execute(['r' => $review, 'p' => $publication, 'b' => $batchId]);
+    }
+
+    /**
+     * A batch whose PR was closed unmerged is excluded from the accumulation base — by the REVIEW
+     * axis (phase 3 writes `rejected` alongside `closed`), not by the publication axis.
+     */
+    public function testClosedAndRejectedRowIsExcludedFromTheAccumulationBase(): void
+    {
+        $path    = 'jsondata/sourcedata/rite/roman/decrees/decrees.json';
+        $batchId = $this->submitDecrees('editor-1', '{"decrees":["A"]}');
+
+        $this->forceStatuses($batchId, review: 'rejected', publication: 'closed');
+
+        self::assertNull($this->repo->findUnpublishedContent($path, 'editor-1'));
+    }
+
+    /**
+     * The mirror image, and the reason the previous test proves what it claims: a `closed` row that
+     * is still `approved` IS in the base. `closed` means nothing reached the repository, so on the
+     * publication axis it genuinely belongs there. If this ever starts returning null, someone has
+     * "simplified" `publication_status <> 'merged'` into treating `closed` as published — which would
+     * silently drop an editor's un-merged work from their next submission.
+     *
+     * Constructible only by direct SQL: no code path produces closed-without-rejected.
+     */
+    public function testClosedButStillApprovedRowRemainsInTheAccumulationBase(): void
+    {
+        $path    = 'jsondata/sourcedata/rite/roman/decrees/decrees.json';
+        $batchId = $this->submitDecrees('editor-1', '{"decrees":["A"]}');
+
+        $this->forceStatuses($batchId, review: 'approved', publication: 'closed');
+
+        self::assertSame('{"decrees":["A"]}', $this->repo->findUnpublishedContent($path, 'editor-1'));
+    }
+
+    /**
+     * `closed` must never become the NOT_SUPERSEDED_BY_PUBLISHED floor. A closed batch published
+     * nothing, so using it as the floor would exclude older rows on the strength of content that
+     * never reached the repository.
+     */
+    public function testClosedRowIsNotASupersessionFloor(): void
+    {
+        $path = 'jsondata/sourcedata/rite/roman/decrees/decrees.json';
+
+        $older = $this->submitDecrees('editor-1', '{"decrees":["A"]}');
+        $this->repo->approveBatch($older, 'reviewer-1');
+
+        $newer = $this->submitDecrees('editor-1', '{"decrees":["A","B"]}');
+        $this->forceStatuses($newer, review: 'rejected', publication: 'closed');
+
+        // The closed batch is out of the base; the older approved one is still in it, NOT excluded
+        // by a floor the closed batch had no right to set.
+        self::assertSame('{"decrees":["A"]}', $this->repo->findUnpublishedContent($path, 'editor-1'));
+    }
 }

--- a/phpunit_tests/Repositories/SourceDataChangeRequestSchemaTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestSchemaTest.php
@@ -57,6 +57,43 @@ final class SourceDataChangeRequestSchemaTest extends RepositoryTestCase
         $this->insertRow(ChangeOperation::UPDATE, ChangeReviewStatus::SUBMITTED, ChangePublicationStatus::NONE);
     }
 
+    public function testPublishClaimTokenAndSettledAtColumnsExist(): void
+    {
+        $stmt = self::$pdo->query(
+            "SELECT column_name, data_type, is_nullable
+               FROM information_schema.columns
+              WHERE table_name = 'sourcedata_change_requests'
+                AND column_name IN ('publish_claim_token', 'publication_settled_at')
+              ORDER BY column_name"
+        );
+        self::assertNotFalse($stmt);
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        self::assertCount(2, $rows, 'Both phase-3 columns must exist');
+        self::assertSame('publication_settled_at', $rows[0]['column_name']);
+        self::assertSame('timestamp with time zone', $rows[0]['data_type']);
+        self::assertSame('YES', $rows[0]['is_nullable']);
+        self::assertSame('publish_claim_token', $rows[1]['column_name']);
+        self::assertSame('uuid', $rows[1]['data_type']);
+        self::assertSame('YES', $rows[1]['is_nullable']);
+    }
+
+    public function testPhase3IndexesExist(): void
+    {
+        $stmt = self::$pdo->query(
+            "SELECT indexname FROM pg_indexes
+              WHERE tablename = 'sourcedata_change_requests'
+                AND indexname IN ('idx_scr_open_pr', 'idx_scr_settled_for_submitter')
+              ORDER BY indexname"
+        );
+        self::assertNotFalse($stmt);
+        self::assertSame(
+            ['idx_scr_open_pr', 'idx_scr_settled_for_submitter'],
+            $stmt->fetchAll(\PDO::FETCH_COLUMN)
+        );
+    }
+
     private function insertRow(
         ChangeOperation $operation,
         ChangeReviewStatus $reviewStatus,

--- a/phpunit_tests/Repositories/UserNotificationRepositoryTest.php
+++ b/phpunit_tests/Repositories/UserNotificationRepositoryTest.php
@@ -18,8 +18,116 @@ final class UserNotificationRepositoryTest extends AbstractHandlerTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        // AbstractHandlerTestCase::TABLES does not include sourcedata_change_requests
+        // (only RepositoryTestCase::TABLES does — see SourceDataChangeRequestSupersedeRegressionTest's
+        // setUp() for the same precedent), so truncate it here explicitly.
+        self::$pdo?->exec('TRUNCATE TABLE sourcedata_change_requests RESTART IDENTITY CASCADE');
+
         $this->repo          = new UserNotificationRepository(self::$pdo);
         $this->accessReqRepo = new AccessRequestRepository(self::$pdo);
+    }
+
+    /**
+     * Insert a settled (merged or closed) source-data change-request batch directly, bypassing
+     * SourceDataChangeRequestRepository::submitBatch() — driving the whole publish path to produce
+     * one inbox row would test the publisher, not the inbox.
+     *
+     * @param string $publicationStatus 'merged' or 'closed'.
+     * @param string $offset            A Postgres interval literal relative to NOW(), e.g. '-1 hour'.
+     */
+    private function settledBatch(
+        string $sub,
+        string $publicationStatus,
+        string $offset,
+        int $files = 1,
+        ?int $prNumber = 101
+    ): string {
+        /** @var string $batchId */
+        $batchId = self::$pdo->query('SELECT gen_random_uuid()::text')->fetchColumn();
+
+        $stmt = self::$pdo->prepare(
+            <<<'SQL'
+                INSERT INTO sourcedata_change_requests
+                    (batch_id, resource_type, resource_id, path, operation, content,
+                     submitted_by_sub, submitted_by_name, submitted_by_email, submitted_by_email_verified,
+                     review_status, publication_status, pr_number, publication_settled_at)
+                VALUES
+                    (:batch_id, :resource_type, :resource_id, :path, 'create', :content,
+                     :sub, :name, :email, TRUE,
+                     'approved', :publication_status, :pr_number, NOW() + :offset::interval)
+                SQL
+        );
+
+        for ($i = 0; $i < $files; $i++) {
+            $stmt->execute([
+                'batch_id'           => $batchId,
+                'resource_type'      => 'national_calendar',
+                'resource_id'        => 'roman/US',
+                'path'               => "jsondata/sourcedata/rite/roman/calendars/nations/US/file{$i}.json",
+                'content'            => '{"litcal":[]}',
+                'sub'                => $sub,
+                'name'               => 'Submitter',
+                'email'              => 'submitter@example.test',
+                'publication_status' => $publicationStatus,
+                'pr_number'          => $prNumber,
+                'offset'             => $offset,
+            ]);
+        }
+
+        return $batchId;
+    }
+
+    /** Insert an OPEN batch (publication_settled_at left NULL) — not news yet. */
+    private function openBatch(string $sub): string
+    {
+        /** @var string $batchId */
+        $batchId = self::$pdo->query('SELECT gen_random_uuid()::text')->fetchColumn();
+
+        $stmt = self::$pdo->prepare(
+            <<<'SQL'
+                INSERT INTO sourcedata_change_requests
+                    (batch_id, resource_type, resource_id, path, operation, content,
+                     submitted_by_sub, submitted_by_name, submitted_by_email, submitted_by_email_verified,
+                     review_status, publication_status, pr_number, publication_settled_at)
+                VALUES
+                    (:batch_id, 'national_calendar', 'roman/US', :path, 'create', '{"litcal":[]}',
+                     :sub, 'Submitter', 'submitter@example.test', TRUE,
+                     'approved', 'open', 101, NULL)
+                SQL
+        );
+        $stmt->execute([
+            'batch_id' => $batchId,
+            'path'     => 'jsondata/sourcedata/rite/roman/calendars/nations/US/US.json',
+            'sub'      => $sub,
+        ]);
+
+        return $batchId;
+    }
+
+    /** Insert a reviewed access_requests row with reviewed_at offset from NOW() by a Postgres interval literal. */
+    private function reviewedAccessRequest(string $sub, string $offset): string
+    {
+        $stmt = self::$pdo->prepare(
+            <<<'SQL'
+                INSERT INTO access_requests
+                    (zitadel_user_id, user_email, user_name, requested_role, permissions,
+                     status, reviewed_by, reviewed_at)
+                VALUES
+                    (:sub, :email, :name, :role, '[]',
+                     'approved', 'admin-x', NOW() + :offset::interval)
+                RETURNING id
+                SQL
+        );
+        $stmt->execute([
+            'sub'    => $sub,
+            'email'  => $sub . '@example.test',
+            'name'   => $sub,
+            'role'   => 'calendar_editor',
+            'offset' => $offset,
+        ]);
+
+        return (string) $stmt->fetchColumn();
     }
 
     public function testFetchInboxReturnsEmptyShapeWhenUserHasNoRequests(): void
@@ -337,5 +445,81 @@ final class UserNotificationRepositoryTest extends AbstractHandlerTestCase
         $statuses = array_column($result['items'], 'status');
         sort($statuses);
         self::assertSame(['approved', 'rejected', 'revoked'], $statuses);
+    }
+
+    public function testInboxCarriesSettledChangeRequests(): void
+    {
+        $batchId = $this->settledBatch('user-1', 'merged', '-1 hour');
+
+        $inbox = $this->repo->fetchInbox('user-1');
+
+        self::assertSame(1, $inbox['total']);
+        self::assertSame('change_request_published', $inbox['items'][0]['type']);
+        self::assertSame($batchId, $inbox['items'][0]['batch_id']);
+        self::assertSame('merged', $inbox['items'][0]['publication_status']);
+        self::assertTrue($inbox['items'][0]['unread']);
+    }
+
+    public function testAnUnsettledBatchIsNotNews(): void
+    {
+        $this->openBatch('user-1');
+
+        self::assertSame(0, $this->repo->fetchInbox('user-1')['total']);
+    }
+
+    public function testOneItemPerBatchNotPerFile(): void
+    {
+        $this->settledBatch('user-1', 'merged', '-1 hour', files: 3);
+
+        self::assertCount(1, $this->repo->fetchInbox('user-1')['items']);
+    }
+
+    public function testTheTwoSourcesInterleaveByTimestampAndShareTheTotals(): void
+    {
+        $this->reviewedAccessRequest('user-1', '-2 hours');
+        $this->settledBatch('user-1', 'merged', '-1 hour');
+        $this->reviewedAccessRequest('user-1', '-3 hours');
+
+        $inbox = $this->repo->fetchInbox('user-1');
+
+        self::assertSame(3, $inbox['total']);
+        self::assertSame(3, $inbox['unread_count']);
+        self::assertSame(
+            ['change_request_published', 'access_request_reviewed', 'access_request_reviewed'],
+            array_column($inbox['items'], 'type'),
+            'newest first, across both sources'
+        );
+    }
+
+    public function testTheSeenBookmarkMarksChangeRequestsRead(): void
+    {
+        $this->settledBatch('user-1', 'merged', '-2 hours');
+        $this->repo->markSeen('user-1');
+        $this->settledBatch('user-1', 'closed', '+0 seconds');
+
+        $inbox = $this->repo->fetchInbox('user-1');
+
+        self::assertSame(2, $inbox['total']);
+        self::assertSame(1, $inbox['unread_count']);
+    }
+
+    public function testAnotherUsersBatchIsInvisible(): void
+    {
+        $this->settledBatch('user-2', 'merged', '-1 hour');
+
+        self::assertSame(0, $this->repo->fetchInbox('user-1')['total']);
+    }
+
+    public function testChangeRequestItemCarriesPrNumberAndSettledAtAsRfc3339(): void
+    {
+        $this->settledBatch('user-1', 'merged', '-1 hour', prNumber: 4321);
+
+        $item = $this->repo->fetchInbox('user-1')['items'][0];
+
+        self::assertSame(4321, $item['pr_number']);
+        self::assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00$/',
+            $item['settled_at']
+        );
     }
 }

--- a/phpunit_tests/Repositories/UserNotificationRepositoryTest.php
+++ b/phpunit_tests/Repositories/UserNotificationRepositoryTest.php
@@ -522,4 +522,21 @@ final class UserNotificationRepositoryTest extends AbstractHandlerTestCase
             $item['settled_at']
         );
     }
+
+    public function testChangeRequestTotalReflectsAllSettledBatchesNotJustThePage(): void
+    {
+        // Mirrors testFetchInboxRespectsLimit for the access-request half: more settled batches
+        // than the page limit must still report their TRUE total/unread_count, not the count of
+        // the returned (already-capped) page. Distinct per-batch offsets avoid any same-instant
+        // ordering ambiguity between batches.
+        for ($i = 0; $i < 55; $i++) {
+            $this->settledBatch('user-1', 'merged', "-{$i} minutes");
+        }
+
+        $result = $this->repo->fetchInbox('user-1', limit: 50);
+
+        self::assertCount(50, $result['items']);
+        self::assertSame(55, $result['total']);
+        self::assertSame(55, $result['unread_count']);
+    }
 }

--- a/phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php
+++ b/phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php
@@ -362,6 +362,30 @@ final class GitHubGitDataClientTest extends TestCase
     }
 
     /**
+     * A missing `merged` must throw rather than default to `false` — a silent default on a
+     * CLOSED pull request would write `closed` + `rejected` for a batch that was actually
+     * merged, drop it from the accumulation base, skip the OpenFGA purge, and tell the
+     * submitter their merged work was rejected. Mirrors
+     * {@see testGetPullRequestTreatsA404AsAFailureNotAValue} and
+     * {@see testCompareCommitsThrowsWhenGithubReturnsNoStatus}, which refuse to guess for
+     * `state` and `status` the same way.
+     */
+    public function testGetPullRequestThrowsWhenGithubReturnsNoMergedFlag(): void
+    {
+        $client = $this->client([
+            new GuzzleResponse(200, [], json_encode([
+                'number'           => 42,
+                'state'            => 'closed',
+                'merge_commit_sha' => 'merge-sha',
+                'head'             => ['sha' => 'head-sha'],
+            ], JSON_THROW_ON_ERROR)),
+        ]);
+
+        $this->expectException(GitHubApiException::class);
+        $client->getPullRequest(42);
+    }
+
+    /**
      * An open pull request has no merge commit. Null, not the empty string, so a caller cannot
      * accidentally record '' as a merge_commit_sha.
      */

--- a/phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php
+++ b/phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php
@@ -331,6 +331,77 @@ final class GitHubGitDataClientTest extends TestCase
         ];
     }
 
+    public function testGetPullRequestReadsStateMergedAndShas(): void
+    {
+        $client = $this->client([
+            new GuzzleResponse(200, [], json_encode([
+                'number'           => 42,
+                'state'            => 'closed',
+                'merged'           => true,
+                'merge_commit_sha' => 'merge-sha',
+                'head'             => ['sha' => 'head-sha'],
+            ], JSON_THROW_ON_ERROR)),
+        ]);
+
+        $pr = $client->getPullRequest(42);
+
+        self::assertSame('closed', $pr->state);
+        self::assertTrue($pr->merged);
+        self::assertSame('merge-sha', $pr->mergeCommitSha);
+        self::assertSame('head-sha', $pr->headSha);
+    }
+
+    public function testGetPullRequestTreatsA404AsAFailureNotAValue(): void
+    {
+        $client = $this->client([
+            new GuzzleResponse(404, [], json_encode(['message' => 'Not Found'], JSON_THROW_ON_ERROR)),
+        ]);
+
+        $this->expectException(GitHubApiException::class);
+        $client->getPullRequest(42);
+    }
+
+    /**
+     * An open pull request has no merge commit. Null, not the empty string, so a caller cannot
+     * accidentally record '' as a merge_commit_sha.
+     */
+    public function testGetPullRequestReportsNoMergeCommitWhileOpen(): void
+    {
+        $client = $this->client([
+            new GuzzleResponse(200, [], json_encode([
+                'number'           => 42,
+                'state'            => 'open',
+                'merged'           => false,
+                'merge_commit_sha' => null,
+                'head'             => ['sha' => 'head-sha'],
+            ], JSON_THROW_ON_ERROR)),
+        ]);
+
+        $pr = $client->getPullRequest(42);
+
+        self::assertFalse($pr->merged);
+        self::assertNull($pr->mergeCommitSha);
+    }
+
+    public function testCompareCommitsReturnsGithubStatus(): void
+    {
+        $client = $this->client([
+            new GuzzleResponse(200, [], json_encode(['status' => 'behind'], JSON_THROW_ON_ERROR)),
+        ]);
+
+        self::assertSame('behind', $client->compareCommits('aaa', 'bbb'));
+    }
+
+    public function testCompareCommitsThrowsWhenGithubReturnsNoStatus(): void
+    {
+        $client = $this->client([
+            new GuzzleResponse(200, [], json_encode(['files' => []], JSON_THROW_ON_ERROR)),
+        ]);
+
+        $this->expectException(GitHubApiException::class);
+        $client->compareCommits('aaa', 'bbb');
+    }
+
     public function testEveryRequestCarriesTheRequiredAuthAndVersionHeaders(): void
     {
         $captured = [];

--- a/phpunit_tests/Services/Outbox/ConsumerLoopTest.php
+++ b/phpunit_tests/Services/Outbox/ConsumerLoopTest.php
@@ -35,10 +35,12 @@ final class ConsumerLoopTest extends TestCase
     public function testTickPassesRowIdToProcessor(): void
     {
         // No expectations on consumer beyond behavior — use stub to avoid notice.
+        // The consumer now hands over a raw string; ConsumerLoop is the layer that casts it to int
+        // before it reaches the processor.
         $consumer = $this->createStub(StreamConsumerInterface::class);
         $consumer->method('readOnce')->willReturnCallback(
             static function (int $blockMs, callable $process): void {
-                $process(42);
+                $process('42');
             },
         );
 
@@ -52,12 +54,39 @@ final class ConsumerLoopTest extends TestCase
         $loop->tick();
     }
 
+    /**
+     * The `<= 0` guard (and non-numeric rejection) moved here with the cast. The outbox's unit of
+     * work is an integer row id, and this is now the only layer that knows that — the stream layer
+     * itself no longer validates the shape of the id it hands over.
+     */
+    public function testANonNumericOrNonPositiveIdIsNotProcessed(): void
+    {
+        $consumer = $this->createStub(StreamConsumerInterface::class);
+        $consumer->method('readOnce')->willReturnCallback(
+            static function (int $blockMs, callable $process): void {
+                $process('0');
+                $process('-1');
+                $process('not-a-number');
+                $process('7');
+            },
+        );
+
+        $processor = $this->createMock(OutboxProcessorInterface::class);
+        $processor->expects(self::once())
+            ->method('processOne')
+            ->with(7)
+            ->willReturn(OutboxDisposition::BENIGN_SUCCESS);
+
+        $loop = new ConsumerLoop($consumer, $processor, blockMs: 5000);
+        $loop->tick();
+    }
+
     public function testTickInvokesCascadeReconcilerOnBenignSuccess(): void
     {
         $consumer = $this->createStub(StreamConsumerInterface::class);
         $consumer->method('readOnce')->willReturnCallback(
             static function (int $blockMs, callable $process): void {
-                $process(7);
+                $process('7');
             },
         );
 
@@ -76,8 +105,8 @@ final class ConsumerLoopTest extends TestCase
         $consumer = $this->createStub(StreamConsumerInterface::class);
         $consumer->method('readOnce')->willReturnCallback(
             static function (int $blockMs, callable $process): void {
-                $process(7);
-                $process(8);
+                $process('7');
+                $process('8');
             },
         );
 
@@ -99,7 +128,7 @@ final class ConsumerLoopTest extends TestCase
         $consumer = $this->createStub(StreamConsumerInterface::class);
         $consumer->method('readOnce')->willReturnCallback(
             static function (int $blockMs, callable $process): void {
-                $process(7);
+                $process('7');
             },
         );
 

--- a/phpunit_tests/Services/Outbox/ConsumerLoopTest.php
+++ b/phpunit_tests/Services/Outbox/ConsumerLoopTest.php
@@ -84,16 +84,27 @@ final class ConsumerLoopTest extends TestCase
             ->with(7)
             ->willReturn(OutboxDisposition::BENIGN_SUCCESS);
 
+        // Captures the id from every call, in call order, so the assertion below can check the
+        // complete ORDERED sequence rather than only "each id is one of the expected three" —
+        // the latter would also pass a loop that logged '0' three times in a row.
+        $loggedIds = [];
+
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::exactly(3))
             ->method('warning')
             ->with(
                 'outbox.consumer.bad_message',
-                self::callback(static fn (array $ctx): bool => in_array($ctx['id'] ?? null, ['0', '-1', 'not-a-number'], true)),
+                self::callback(static function (array $ctx) use (&$loggedIds): bool {
+                    $loggedIds[] = $ctx['id'] ?? null;
+
+                    return true;
+                }),
             );
 
         $loop = new ConsumerLoop($consumer, $processor, blockMs: 5000, logger: $logger);
         $loop->tick();
+
+        self::assertSame(['0', '-1', 'not-a-number'], $loggedIds);
     }
 
     public function testTickInvokesCascadeReconcilerOnBenignSuccess(): void

--- a/phpunit_tests/Services/Outbox/ConsumerLoopTest.php
+++ b/phpunit_tests/Services/Outbox/ConsumerLoopTest.php
@@ -11,6 +11,7 @@ use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessorInterface;
 use LiturgicalCalendar\Api\Services\Outbox\StreamConsumerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 #[CoversClass(ConsumerLoop::class)]
 final class ConsumerLoopTest extends TestCase
@@ -58,6 +59,12 @@ final class ConsumerLoopTest extends TestCase
      * The `<= 0` guard (and non-numeric rejection) moved here with the cast. The outbox's unit of
      * work is an integer row id, and this is now the only layer that knows that — the stream layer
      * itself no longer validates the shape of the id it hands over.
+     *
+     * The validation moving here from `RedisStreamConsumer` must carry its `bad_message` log line
+     * with it — that class already logs and ACKs its own "no id at all" case, and a non-numeric or
+     * non-positive id discarded silently here would be an observability regression on the very
+     * same OpenFGA outbox path, invisible until a genuinely malformed stream went quiet with no
+     * symptom at all.
      */
     public function testANonNumericOrNonPositiveIdIsNotProcessed(): void
     {
@@ -77,7 +84,15 @@ final class ConsumerLoopTest extends TestCase
             ->with(7)
             ->willReturn(OutboxDisposition::BENIGN_SUCCESS);
 
-        $loop = new ConsumerLoop($consumer, $processor, blockMs: 5000);
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::exactly(3))
+            ->method('warning')
+            ->with(
+                'outbox.consumer.bad_message',
+                self::callback(static fn (array $ctx): bool => in_array($ctx['id'] ?? null, ['0', '-1', 'not-a-number'], true)),
+            );
+
+        $loop = new ConsumerLoop($consumer, $processor, blockMs: 5000, logger: $logger);
         $loop->tick();
     }
 

--- a/phpunit_tests/Services/Outbox/RedisStreamConsumerTest.php
+++ b/phpunit_tests/Services/Outbox/RedisStreamConsumerTest.php
@@ -65,12 +65,47 @@ final class RedisStreamConsumerTest extends TestCase
         $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
         $consumer->readOnce(
             blockMs: 5000,
-            process: function (int $rowId) use (&$captured): void {
+            process: function (string $rowId) use (&$captured): void {
                 $captured = $rowId;
             },
         );
 
-        self::assertSame(42, $captured);
+        // The consumer no longer casts to int — it hands the raw string straight through.
+        // Narrowing to a positive integer row id is now the caller's job (ConsumerLoop).
+        self::assertSame('42', $captured);
+    }
+
+    public function testItReadsAConfigurablePayloadField(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->method('xPending')->willReturn(false);
+        $redis->method('xReadGroup')->willReturn([
+            'litcal:publish-stream' => [
+                '1700000000-0' => ['batch_id' => 'b7f3-uuid'],
+            ],
+        ]);
+        $redis->expects(self::once())
+            ->method('xAck')
+            ->with('litcal:publish-stream', 'publisher', ['1700000000-0'])
+            ->willReturn(1);
+
+        $captured = null;
+        $consumer = new RedisStreamConsumer(
+            $redis,
+            'litcal:publish-stream',
+            'publisher',
+            'consumer-1',
+            null,
+            'batch_id',
+        );
+        $consumer->readOnce(
+            blockMs: 100,
+            process: function (string $id) use (&$captured): void {
+                $captured = $id;
+            },
+        );
+
+        self::assertSame('b7f3-uuid', $captured);
     }
 
     public function testReadOneReturnsWithoutAckOnEmptyRead(): void
@@ -81,7 +116,7 @@ final class RedisStreamConsumerTest extends TestCase
         $redis->expects(self::never())->method('xAck');
 
         $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
-        $consumer->readOnce(blockMs: 100, process: function (int $rowId): void {
+        $consumer->readOnce(blockMs: 100, process: function (string $rowId): void {
         });
         $this->addToAssertionCount(1);
     }
@@ -98,7 +133,7 @@ final class RedisStreamConsumerTest extends TestCase
         $redis->expects(self::never())->method('xAck');
 
         $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
-        $consumer->readOnce(blockMs: 100, process: function (int $rowId): void {
+        $consumer->readOnce(blockMs: 100, process: function (string $rowId): void {
         });
         $this->addToAssertionCount(1);
     }
@@ -129,12 +164,12 @@ final class RedisStreamConsumerTest extends TestCase
         $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
         $consumer->readOnce(
             blockMs: 100,
-            process: function (int $rowId) use (&$captured): void {
+            process: function (string $rowId) use (&$captured): void {
                 $captured = $rowId;
             },
         );
 
-        self::assertSame(99, $captured);
+        self::assertSame('99', $captured);
     }
 
     public function testClaimStaleSkipsClaimsForFreshEntries(): void
@@ -150,7 +185,7 @@ final class RedisStreamConsumerTest extends TestCase
         $redis->expects(self::never())->method('xAck');
 
         $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
-        $consumer->readOnce(blockMs: 100, process: function (int $rowId): void {
+        $consumer->readOnce(blockMs: 100, process: function (string $rowId): void {
         });
         $this->addToAssertionCount(1);
     }
@@ -174,12 +209,42 @@ final class RedisStreamConsumerTest extends TestCase
         $consumer       = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
         $consumer->readOnce(
             blockMs: 100,
-            process: function (int $rowId) use (&$callbackCalled): void {
+            process: function (string $rowId) use (&$callbackCalled): void {
                 $callbackCalled = true;
             },
         );
 
         self::assertFalse($callbackCalled, 'callback must NOT fire for malformed message');
+    }
+
+    /**
+     * A message whose payload field is an empty string is just as unprocessable as a missing one —
+     * still ACKed and skipped, never handed to the caller.
+     */
+    public function testAMessageWithAnEmptyPayloadFieldIsAckedAndSkipped(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->method('xPending')->willReturn(false);
+        $redis->method('xReadGroup')->willReturn([
+            'litcal:reconcile-stream' => [
+                '1700000000-0' => ['row_id' => ''],
+            ],
+        ]);
+        $redis->expects(self::once())
+            ->method('xAck')
+            ->with('litcal:reconcile-stream', 'reconciler', ['1700000000-0'])
+            ->willReturn(1);
+
+        $callbackCalled = false;
+        $consumer       = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
+        $consumer->readOnce(
+            blockMs: 100,
+            process: function (string $rowId) use (&$callbackCalled): void {
+                $callbackCalled = true;
+            },
+        );
+
+        self::assertFalse($callbackCalled, 'callback must NOT fire for an empty payload value');
     }
 
     public function testReadOnceLeavesBadProcessThrowInPel(): void
@@ -197,10 +262,51 @@ final class RedisStreamConsumerTest extends TestCase
         $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
         $consumer->readOnce(
             blockMs: 100,
-            process: function (int $rowId): void {
+            process: function (string $rowId): void {
                 throw new \RuntimeException('boom');
             },
         );
         $this->addToAssertionCount(1);
+    }
+
+    /**
+     * The claimStale() XCLAIM reclaim path must also hand the raw string through — it shares the
+     * same $payloadField configuration as readOnce(), not a hardcoded 'row_id'.
+     */
+    public function testClaimStaleUsesConfiguredPayloadField(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->method('xPending')->willReturnOnConsecutiveCalls(
+            [1, '1700000000-0', '1700000000-0', [['consumer-x', '1']]],
+            [['1700000000-0', 'consumer-x', 45_000, 1]],
+        );
+        $redis->expects(self::once())
+            ->method('xClaim')
+            ->willReturn([
+                '1700000000-0' => ['batch_id' => 'stale-uuid'],
+            ]);
+        $redis->method('xReadGroup')->willReturn([]);
+        $redis->expects(self::once())
+            ->method('xAck')
+            ->with('litcal:publish-stream', 'publisher', ['1700000000-0'])
+            ->willReturn(1);
+
+        $captured = null;
+        $consumer = new RedisStreamConsumer(
+            $redis,
+            'litcal:publish-stream',
+            'publisher',
+            'consumer-1',
+            null,
+            'batch_id',
+        );
+        $consumer->readOnce(
+            blockMs: 100,
+            process: function (string $id) use (&$captured): void {
+                $captured = $id;
+            },
+        );
+
+        self::assertSame('stale-uuid', $captured);
     }
 }

--- a/phpunit_tests/Services/SourceData/ClaimStolenSourceDataPublisher.php
+++ b/phpunit_tests/Services/SourceData/ClaimStolenSourceDataPublisher.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\SourceData\PublishResult;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisherInterface;
+use PDO;
+
+/**
+ * Simulates the CLAIM_LOST sequence {@see SourceDataChangeRequestRepository::releaseClaim()}'s
+ * own docblock narrates: for one designated batch id, `publish()` first overwrites the row's
+ * `publish_claim_token` with a fresh value — standing in for the grace-period reclaim freeing
+ * THIS runner's claim and a SECOND runner claiming the very same batch with a new token,
+ * exactly what `claimNextPublishableBatch()` would generate for a real second process — and
+ * THEN throws, standing in for this (merely SLOW, not dead) runner's own, now-doomed GitHub
+ * call finally returning.
+ *
+ * Reproduces the race directly against the row rather than needing two real OS processes,
+ * mirroring {@see RaceLosingSourceDataPublisher}'s approach for the `SETTLED_ELSEWHERE`
+ * sibling of this same defect class. Real inter-process concurrency for
+ * `claimNextPublishableBatch()` itself is covered separately by
+ * {@see \LiturgicalCalendar\Tests\Repositories\SourceDataChangeRequestPublishQueueTest}'s
+ * `proc_open` races.
+ *
+ * The exception thrown is caller-supplied so the same double drives both the branch-contention
+ * (`GitHubApiException` 422) and the genuine-failure (anything else) sides of the CLAIM_LOST
+ * behaviour in {@see \LiturgicalCalendar\Api\Services\SourceData\PublishRunner::runOnce()}.
+ *
+ * Every other batch id is published normally, mirroring {@see FakeSourceDataPublisher}'s
+ * successful path, so a single test can drive one CLAIM_LOST batch alongside an ordinary one.
+ */
+final class ClaimStolenSourceDataPublisher implements SourceDataPublisherInterface
+{
+    public function __construct(
+        private readonly SourceDataChangeRequestRepository $repo,
+        private readonly PDO $pdo,
+        private readonly string $raceBatchId,
+        private readonly \Throwable $throws
+    ) {
+    }
+
+    public function publish(string $batchId): PublishResult
+    {
+        if ($batchId === $this->raceBatchId) {
+            // Steal the claim: a fresh token, as if a second runner had just won it via
+            // claimNextPublishableBatch(). The row stays `queued`, now under a token this
+            // runner does not hold.
+            $this->pdo
+                ->prepare('UPDATE sourcedata_change_requests SET publish_claim_token = gen_random_uuid() WHERE batch_id = :batch_id')
+                ->execute(['batch_id' => $batchId]);
+
+            throw $this->throws;
+        }
+
+        $this->repo->recordPublication(
+            $batchId,
+            FakeSourceDataPublisher::BRANCH,
+            FakeSourceDataPublisher::COMMIT_SHA,
+            FakeSourceDataPublisher::PR_NUMBER,
+            FakeSourceDataPublisher::BASE_SHA
+        );
+
+        return new PublishResult(
+            FakeSourceDataPublisher::BRANCH,
+            FakeSourceDataPublisher::COMMIT_SHA,
+            FakeSourceDataPublisher::PR_NUMBER,
+            FakeSourceDataPublisher::BASE_SHA
+        );
+    }
+}

--- a/phpunit_tests/Services/SourceData/MergePollRunnerTest.php
+++ b/phpunit_tests/Services/SourceData/MergePollRunnerTest.php
@@ -84,6 +84,32 @@ final class MergePollRunnerTest extends RepositoryTestCase
         return $batchId;
     }
 
+    private function deletionBatch(string $sub, string $nation, int $prNumber, string $commitSha): string
+    {
+        $batchId = $this->repo->submitBatch(
+            ChangeResource::nationalCalendar(Rite::ROMAN, $nation),
+            [
+                [
+                    'path'      => "jsondata/sourcedata/rite/roman/calendars/nations/{$nation}/{$nation}.json",
+                    'operation' => ChangeOperation::DELETE,
+                    'content'   => null,
+                ]
+            ],
+            $sub,
+            'Editor',
+            $sub . '@example.test',
+            true,
+            ['authorizing_relation' => 'admin', 'deletes_resource' => true]
+        )['batch_id'];
+
+        $this->repo->approveBatch($batchId, 'reviewer-1');
+        $claim = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claim);
+        $this->repo->recordPublication($batchId, "litcal-data/national_calendar/roman/{$nation}", $commitSha, $prNumber, 'base');
+
+        return $batchId;
+    }
+
     /**
      * Pre-seeds the installation token cache so `GitHubAppAuth::installationToken()` never
      * exchanges over HTTP. See the class docblock: this repo's convention (matching
@@ -108,7 +134,7 @@ final class MergePollRunnerTest extends RepositoryTestCase
     }
 
     /** @param list<GuzzleResponse> $responses */
-    private function runnerFor(array $responses): MergePollRunner
+    private function runnerFor(array $responses, ?RecordingTuplePurgeService $purge = null): MergePollRunner
     {
         $mock  = new MockHandler($responses);
         $stack = HandlerStack::create($mock);
@@ -123,7 +149,7 @@ final class MergePollRunnerTest extends RepositoryTestCase
 
         $client = new GitHubGitDataClient('Liturgical-Calendar', 'LiturgicalCalendarAPI', $this->auth(), $http);
 
-        return new MergePollRunner($this->repo, $client);
+        return new MergePollRunner($this->repo, $client, $purge);
     }
 
     private static function prJson(string $state, bool $merged, ?string $mergeSha, string $headSha): GuzzleResponse
@@ -320,5 +346,89 @@ final class MergePollRunnerTest extends RepositoryTestCase
 
         self::assertSame(1, $result->unpollable);
         self::assertFalse($result->stoppedOnFailure, 'an unexplained row is reported, not an outage');
+    }
+
+    public function testAMergedResourceDeletionPurgesOperationalTuples(): void
+    {
+        $this->deletionBatch('editor-1', 'US', 11, 'sha-a');
+        $purge = new RecordingTuplePurgeService();
+
+        $this->runnerFor([
+            self::prJson('closed', true, 'merge-sha', 'sha-a'),
+        ], $purge)->runOnce();
+
+        self::assertSame(['national_calendar:roman/US'], $purge->purged);
+    }
+
+    /**
+     * THE false positive, at the level that matters. A batch that stages a DELETE for an i18n locale
+     * file but does NOT delete the calendar must purge nothing when it merges — otherwise removing a
+     * translation revokes every editor on a live calendar.
+     */
+    public function testAMergedLocaleRemovalPurgesNothing(): void
+    {
+        $batchId = $this->repo->submitBatch(
+            ChangeResource::nationalCalendar(Rite::ROMAN, 'US'),
+            [
+                [
+                    'path'      => 'jsondata/sourcedata/rite/roman/calendars/nations/US/US.json',
+                    'operation' => ChangeOperation::UPDATE,
+                    'content'   => '{"litcal":[]}',
+                ],
+                [
+                    'path'      => 'jsondata/sourcedata/rite/roman/calendars/nations/US/i18n/fr.json',
+                    'operation' => ChangeOperation::DELETE,
+                    'content'   => null,
+                ],
+            ],
+            'editor-1',
+            'Editor',
+            'editor-1@example.test',
+            true,
+            ['authorizing_relation' => 'admin']
+        )['batch_id'];
+
+        $this->repo->approveBatch($batchId, 'reviewer-1');
+        $claim = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claim);
+        $this->repo->recordPublication($batchId, 'litcal-data/national_calendar/roman/US', 'sha-a', 11, 'base');
+
+        $purge = new RecordingTuplePurgeService();
+
+        $this->runnerFor([
+            self::prJson('closed', true, 'merge-sha', 'sha-a'),
+        ], $purge)->runOnce();
+
+        self::assertSame([], $purge->purged, 'a locale removal is not a resource deletion');
+    }
+
+    public function testAClosedUnmergedDeletionPurgesNothing(): void
+    {
+        $this->deletionBatch('editor-1', 'US', 11, 'sha-a');
+        $purge = new RecordingTuplePurgeService();
+
+        $this->runnerFor([
+            self::prJson('closed', false, null, 'sha-a'),
+        ], $purge)->runOnce();
+
+        self::assertSame([], $purge->purged, 'a deletion that never merged deleted nothing');
+    }
+
+    /**
+     * The transition is a fact about the repository. A purge failure must not un-record it — the
+     * reconciler sweep is what cleans up, exactly as in disk mode.
+     */
+    public function testAFailingPurgeDoesNotUndoTheMerge(): void
+    {
+        $batchId = $this->deletionBatch('editor-1', 'US', 11, 'sha-a');
+        $purge   = new RecordingTuplePurgeService(new \RuntimeException('OpenFGA unreachable'));
+
+        $result = $this->runnerFor([
+            self::prJson('closed', true, 'merge-sha', 'sha-a'),
+        ], $purge)->runOnce();
+
+        self::assertSame(1, $result->merged);
+        self::assertFalse($result->stoppedOnFailure);
+        self::assertSame(ChangePublicationStatus::MERGED->value, $this->publicationStatus($batchId));
     }
 }

--- a/phpunit_tests/Services/SourceData/MergePollRunnerTest.php
+++ b/phpunit_tests/Services/SourceData/MergePollRunnerTest.php
@@ -196,6 +196,20 @@ final class MergePollRunnerTest extends RepositoryTestCase
             static fn (string $p): bool => str_contains($p, '/pulls/')
         );
         self::assertCount(1, $pullPaths, 'one pull request, one poll');
+
+        // Pins the containment check's argument ORIENTATION. Both compare tests in this class
+        // return a canned status regardless of what was actually sent, so without asserting the
+        // URI, swapping isContained()'s call to compareCommits($mergeCommitSha, $batchCommitSha)
+        // would leave the whole suite green while inverting the exact branch that decides
+        // whether a batch's content is lost. `compareCommits($base, $head)` is called as
+        // `compareCommits($batchCommitSha, $mergeCommitSha)`, so base = the batch's commit
+        // (`sha-a`) and head = the merge commit (`merge-sha`).
+        $comparePaths = array_values(array_filter(
+            array_map(static fn ($r): string => $r->getUri()->getPath(), $this->sentRequests),
+            static fn (string $p): bool => str_contains($p, '/compare/')
+        ));
+        self::assertCount(1, $comparePaths, 'sha-b is the head and needs no compare; only sha-a does');
+        self::assertStringEndsWith('/compare/sha-a...merge-sha', $comparePaths[0]);
     }
 
     /**
@@ -254,6 +268,25 @@ final class MergePollRunnerTest extends RepositoryTestCase
         self::assertSame(ChangePublicationStatus::OPEN->value, $this->publicationStatus($head));
     }
 
+    /**
+     * GitHub contradicting itself: `merged: true` but no `merge_commit_sha`. Guessing a sha here
+     * would be worse than stopping, so `pollOne()` throws rather than reading anything either
+     * way; the batch is left `open` for the next tick, not merged and not reset.
+     */
+    public function testAMergedPullRequestWithNoMergeCommitShaStopsTheRunAndLeavesTheBatchOpen(): void
+    {
+        $batchId = $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+
+        $result = $this->runnerFor([
+            self::prJson('closed', true, null, 'sha-a'),
+        ])->runOnce();
+
+        self::assertTrue($result->stoppedOnFailure);
+        self::assertSame(0, $result->merged);
+        self::assertSame(0, $result->reset);
+        self::assertSame(ChangePublicationStatus::OPEN->value, $this->publicationStatus($batchId));
+    }
+
     public function testAFailedPollStopsTheRun(): void
     {
         $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
@@ -265,6 +298,17 @@ final class MergePollRunnerTest extends RepositoryTestCase
 
         self::assertTrue($result->stoppedOnFailure);
         self::assertSame(0, $result->merged);
+
+        // Proves "stop, don't hammer": if the run continued to the second pull request instead
+        // of stopping after the first 503, the mock queue would be empty and Guzzle would throw
+        // — a throw the same catch() would still turn into stoppedOnFailure=true, so the two
+        // assertions above would pass either way. Only counting the actual /pulls/ requests
+        // distinguishes "stopped after one poll" from "kept going and merely failed later".
+        $pullPaths = array_filter(
+            array_map(static fn ($r): string => $r->getUri()->getPath(), $this->sentRequests),
+            static fn (string $p): bool => str_contains($p, '/pulls/')
+        );
+        self::assertCount(1, $pullPaths, 'a failed poll must stop the run, not continue to the next pull request');
     }
 
     public function testUnpollableOpenBatchesAreCountedNotSkipped(): void

--- a/phpunit_tests/Services/SourceData/MergePollRunnerTest.php
+++ b/phpunit_tests/Services/SourceData/MergePollRunnerTest.php
@@ -211,6 +211,10 @@ final class MergePollRunnerTest extends RepositoryTestCase
 
         $result = $this->runnerFor([
             self::prJson('closed', true, 'merge-sha', 'sha-a'),
+            // Containment is ALWAYS verified with a compareCommits() call, even for the batch
+            // whose commit sha equals the reported head.sha — see MergePollRunner's own class
+            // docblock, "No zero-call fast path".
+            new GuzzleResponse(200, [], json_encode(['status' => 'identical'], JSON_THROW_ON_ERROR)),
         ])->runOnce();
 
         self::assertSame(1, $result->merged);
@@ -218,8 +222,12 @@ final class MergePollRunnerTest extends RepositoryTestCase
     }
 
     /**
-     * Two batches, one rolling pull request, ONE GitHub poll. The rolling branch is per resource,
-     * so polling per batch would ask the same question twice.
+     * Two batches, one rolling pull request, ONE GitHub `/pulls/` poll — the rolling branch is
+     * per resource, so polling per batch would ask the same question twice. Containment is a
+     * SEPARATE cost from the poll itself: both batches get their own `compareCommits()` call
+     * (see MergePollRunner's own class docblock, "No zero-call fast path" — there is no shortcut
+     * for the batch whose commit happens to equal the reported head.sha), so one `/pulls/` poll
+     * still costs two `/compare/` calls here.
      */
     public function testTwoBatchesOnOnePullRequestCostOnePollAndBothTransition(): void
     {
@@ -228,8 +236,9 @@ final class MergePollRunnerTest extends RepositoryTestCase
 
         $result = $this->runnerFor([
             self::prJson('closed', true, 'merge-sha', 'sha-b'),
-            // one compare, for `sha-a` only — `sha-b` IS the head and needs none
+            // one compare per batch: sha-a first (submitted first), then sha-b (the head sha)
             new GuzzleResponse(200, [], json_encode(['status' => 'ahead'], JSON_THROW_ON_ERROR)),
+            new GuzzleResponse(200, [], json_encode(['status' => 'identical'], JSON_THROW_ON_ERROR)),
         ])->runOnce();
 
         self::assertSame(2, $result->merged);
@@ -253,8 +262,9 @@ final class MergePollRunnerTest extends RepositoryTestCase
             array_map(static fn ($r): string => $r->getUri()->getPath(), $this->sentRequests),
             static fn (string $p): bool => str_contains($p, '/compare/')
         ));
-        self::assertCount(1, $comparePaths, 'sha-b is the head and needs no compare; only sha-a does');
+        self::assertCount(2, $comparePaths, 'every batch on the pull request gets its own compare, including the head sha');
         self::assertStringEndsWith('/compare/sha-a...merge-sha', $comparePaths[0]);
+        self::assertStringEndsWith('/compare/sha-b...merge-sha', $comparePaths[1]);
     }
 
     /**
@@ -269,6 +279,9 @@ final class MergePollRunnerTest extends RepositoryTestCase
 
         $result = $this->runnerFor([
             self::prJson('closed', true, 'merge-sha', 'sha-early'),
+            // `sha-early` IS the reported head, but it still gets its own compareCommits() call —
+            // see MergePollRunner's "No zero-call fast path" — which reports it identical/contained.
+            new GuzzleResponse(200, [], json_encode(['status' => 'identical'], JSON_THROW_ON_ERROR)),
             // `sha-late` is not an ancestor of the merge commit
             new GuzzleResponse(200, [], json_encode(['status' => 'diverged'], JSON_THROW_ON_ERROR)),
         ])->runOnce();
@@ -301,8 +314,11 @@ final class MergePollRunnerTest extends RepositoryTestCase
      */
     public function testAFailedContainmentCheckLeavesTheBatchOpen(): void
     {
-        $head  = $this->publishedBatch('editor-1', 'US', 11, 'sha-head');
-        $other = $this->publishedBatch('editor-2', 'US', 11, 'sha-other');
+        // Named for what it IS, not for what it is compared against: 'sha-not-head' is the
+        // batch whose commit is NOT the pull request's reported head.sha ('sha-other', below) —
+        // it is submitted first, so it is the one whose compareCommits() call fails.
+        $notHead = $this->publishedBatch('editor-1', 'US', 11, 'sha-not-head');
+        $other   = $this->publishedBatch('editor-2', 'US', 11, 'sha-other');
 
         $result = $this->runnerFor([
             self::prJson('closed', true, 'merge-sha', 'sha-other'),
@@ -310,7 +326,32 @@ final class MergePollRunnerTest extends RepositoryTestCase
         ])->runOnce();
 
         self::assertTrue($result->stoppedOnFailure);
-        self::assertSame(ChangePublicationStatus::OPEN->value, $this->publicationStatus($head));
+        self::assertSame(ChangePublicationStatus::OPEN->value, $this->publicationStatus($notHead));
+    }
+
+    /**
+     * A throw partway through ONE pull request's batches must not discard the transitions already
+     * COMMITTED (to the database) for earlier batches on that SAME pull request. The first batch's
+     * compare succeeds and `markBatchMerged()` runs for real before the second batch's compare
+     * fails — `MergePollRunResult::$merged` must report that real, already-committed transition,
+     * not zero, per {@see MergePollRunResult}'s own docblock: every count is reported on every
+     * run, "including runs that stopped early".
+     */
+    public function testAThrowPartwayThroughOnePullRequestReportsTheTransitionsAlreadyCommitted(): void
+    {
+        $first  = $this->publishedBatch('editor-1', 'US', 11, 'sha-first');
+        $second = $this->publishedBatch('editor-2', 'US', 11, 'sha-second');
+
+        $result = $this->runnerFor([
+            self::prJson('closed', true, 'merge-sha', 'sha-first'),
+            new GuzzleResponse(200, [], json_encode(['status' => 'identical'], JSON_THROW_ON_ERROR)),
+            new GuzzleResponse(500, [], json_encode(['message' => 'boom'], JSON_THROW_ON_ERROR)),
+        ])->runOnce();
+
+        self::assertTrue($result->stoppedOnFailure);
+        self::assertSame(1, $result->merged, 'the first batch was genuinely merged before the second batch threw');
+        self::assertSame(ChangePublicationStatus::MERGED->value, $this->publicationStatus($first));
+        self::assertSame(ChangePublicationStatus::OPEN->value, $this->publicationStatus($second));
     }
 
     /**
@@ -374,6 +415,7 @@ final class MergePollRunnerTest extends RepositoryTestCase
 
         $this->runnerFor([
             self::prJson('closed', true, 'merge-sha', 'sha-a'),
+            new GuzzleResponse(200, [], json_encode(['status' => 'identical'], JSON_THROW_ON_ERROR)),
         ], $purge)->runOnce();
 
         self::assertSame(['national_calendar:roman/US'], $purge->purged);
@@ -416,6 +458,7 @@ final class MergePollRunnerTest extends RepositoryTestCase
 
         $this->runnerFor([
             self::prJson('closed', true, 'merge-sha', 'sha-a'),
+            new GuzzleResponse(200, [], json_encode(['status' => 'identical'], JSON_THROW_ON_ERROR)),
         ], $purge)->runOnce();
 
         self::assertSame([], $purge->purged, 'a locale removal is not a resource deletion');
@@ -444,6 +487,7 @@ final class MergePollRunnerTest extends RepositoryTestCase
 
         $result = $this->runnerFor([
             self::prJson('closed', true, 'merge-sha', 'sha-a'),
+            new GuzzleResponse(200, [], json_encode(['status' => 'identical'], JSON_THROW_ON_ERROR)),
         ], $purge)->runOnce();
 
         self::assertSame(1, $result->merged);
@@ -495,6 +539,7 @@ final class MergePollRunnerTest extends RepositoryTestCase
 
         $this->runnerFor([
             self::prJson('closed', true, 'merge-sha', 'sha-a'),
+            new GuzzleResponse(200, [], json_encode(['status' => 'identical'], JSON_THROW_ON_ERROR)),
         ], $purge)->runOnce();
 
         self::assertSame([], $purge->purged, 'one unflagged row must block the purge, wherever it sorts');
@@ -537,6 +582,7 @@ final class MergePollRunnerTest extends RepositoryTestCase
 
         $this->runnerFor([
             self::prJson('closed', true, 'merge-sha', 'sha-a'),
+            new GuzzleResponse(200, [], json_encode(['status' => 'identical'], JSON_THROW_ON_ERROR)),
         ], $purge)->runOnce();
 
         self::assertSame([], $purge->purged, 'one unflagged row must block the purge even when a flagged row sorts first');
@@ -549,6 +595,7 @@ final class MergePollRunnerTest extends RepositoryTestCase
 
         $runner = $this->runnerFor([
             self::prJson('closed', true, 'merge-sha', 'sha-a'),
+            new GuzzleResponse(200, [], json_encode(['status' => 'identical'], JSON_THROW_ON_ERROR)),
         ], null, $auditLog);
 
         $runner->runOnce();

--- a/phpunit_tests/Services/SourceData/MergePollRunnerTest.php
+++ b/phpunit_tests/Services/SourceData/MergePollRunnerTest.php
@@ -134,8 +134,11 @@ final class MergePollRunnerTest extends RepositoryTestCase
     }
 
     /** @param list<GuzzleResponse> $responses */
-    private function runnerFor(array $responses, ?RecordingTuplePurgeService $purge = null): MergePollRunner
-    {
+    private function runnerFor(
+        array $responses,
+        ?RecordingTuplePurgeService $purge = null,
+        ?RecordingAuditLogRepository $auditLog = null
+    ): MergePollRunner {
         $mock  = new MockHandler($responses);
         $stack = HandlerStack::create($mock);
         $stack->push(function (callable $handler): callable {
@@ -149,7 +152,23 @@ final class MergePollRunnerTest extends RepositoryTestCase
 
         $client = new GitHubGitDataClient('Liturgical-Calendar', 'LiturgicalCalendarAPI', $this->auth(), $http);
 
-        return new MergePollRunner($this->repo, $client, $purge);
+        return new MergePollRunner($this->repo, $client, $purge, $auditLog);
+    }
+
+    /**
+     * Overwrites one row's persisted `metadata` directly. `submitBatch()`'s `$metadata` parameter
+     * applies uniformly to every row of a single call, so a genuinely mixed batch (some rows
+     * flagged `deletes_resource`, some not — the shape a stale carry-forward produces) cannot be
+     * built through the public API in one submission. Reaching into the row is this class's own
+     * convention for forcing a specific persisted state (see
+     * `testUnpollableOpenBatchesAreCountedNotSkipped`'s direct `pr_number` UPDATE).
+     */
+    private function setRowMetadata(string $batchId, string $path, string $metadataJson): void
+    {
+        $stmt = self::$pdo->prepare(
+            'UPDATE sourcedata_change_requests SET metadata = :metadata WHERE batch_id = :batch_id AND path = :path'
+        );
+        $stmt->execute(['metadata' => $metadataJson, 'batch_id' => $batchId, 'path' => $path]);
     }
 
     private static function prJson(string $state, bool $merged, ?string $mergeSha, string $headSha): GuzzleResponse
@@ -430,5 +449,151 @@ final class MergePollRunnerTest extends RepositoryTestCase
         self::assertSame(1, $result->merged);
         self::assertFalse($result->stoppedOnFailure);
         self::assertSame(ChangePublicationStatus::MERGED->value, $this->publicationStatus($batchId));
+    }
+
+    /**
+     * THE regression a `$rows[0]`-only read produces. `getBatch()` orders `BY path ASC` under the
+     * database's collation, so which row sorts first is an accident of string comparison, not a
+     * signal that it belongs to the submission that actually deleted the resource — and
+     * `submitBatch()`'s carry-forward UPDATE can leave an untouched row's `metadata` (and
+     * therefore its flag) exactly as an earlier, non-deleting submission left it. Pins the case
+     * where the row lacking the flag sorts FIRST, verified below before the poll runs so a
+     * differently-collated environment fails loudly here rather than silently exercising the
+     * wrong branch.
+     */
+    public function testAMergedDeletionPurgesNothingWhenAnUnflaggedRowSortsFirst(): void
+    {
+        $flaggedPath   = 'jsondata/sourcedata/rite/roman/calendars/nations/US/US.json';
+        $unflaggedPath = 'jsondata/sourcedata/rite/roman/calendars/nations/US/i18n/en.json';
+
+        $batchId = $this->repo->submitBatch(
+            ChangeResource::nationalCalendar(Rite::ROMAN, 'US'),
+            [
+                ['path' => $flaggedPath, 'operation' => ChangeOperation::DELETE, 'content' => null],
+                ['path' => $unflaggedPath, 'operation' => ChangeOperation::DELETE, 'content' => null],
+            ],
+            'editor-1',
+            'Editor',
+            'editor-1@example.test',
+            true,
+            ['authorizing_relation' => 'admin', 'deletes_resource' => true]
+        )['batch_id'];
+
+        // Force the mismatch a stale carry-forward would also produce: this row loses the flag
+        // every other row in the batch carries.
+        $this->setRowMetadata($batchId, $unflaggedPath, '{"authorizing_relation":"admin"}');
+
+        $this->repo->approveBatch($batchId, 'reviewer-1');
+        $claim = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claim);
+        $this->repo->recordPublication($batchId, 'litcal-data/national_calendar/roman/US', 'sha-a', 11, 'base');
+
+        $rows = $this->repo->getBatch($batchId);
+        self::assertSame($unflaggedPath, $rows[0]['path'], 'this test requires the unflagged row to sort first');
+
+        $purge = new RecordingTuplePurgeService();
+
+        $this->runnerFor([
+            self::prJson('closed', true, 'merge-sha', 'sha-a'),
+        ], $purge)->runOnce();
+
+        self::assertSame([], $purge->purged, 'one unflagged row must block the purge, wherever it sorts');
+    }
+
+    /**
+     * The inverse of the above: the flagged row sorts FIRST and the unflagged row sorts LATER.
+     * A position-based read (`$rows[0]`) would purge here — this is exactly the case it got
+     * "right" by accident, which is why unanimity, not position, is what must decide it.
+     */
+    public function testAMergedDeletionPurgesNothingWhenAFlaggedRowSortsFirst(): void
+    {
+        $unflaggedPath = 'jsondata/sourcedata/rite/roman/calendars/nations/US/US.json';
+        $flaggedPath   = 'jsondata/sourcedata/rite/roman/calendars/nations/US/i18n/en.json';
+
+        $batchId = $this->repo->submitBatch(
+            ChangeResource::nationalCalendar(Rite::ROMAN, 'US'),
+            [
+                ['path' => $unflaggedPath, 'operation' => ChangeOperation::DELETE, 'content' => null],
+                ['path' => $flaggedPath, 'operation' => ChangeOperation::DELETE, 'content' => null],
+            ],
+            'editor-1',
+            'Editor',
+            'editor-1@example.test',
+            true,
+            ['authorizing_relation' => 'admin', 'deletes_resource' => true]
+        )['batch_id'];
+
+        $this->setRowMetadata($batchId, $unflaggedPath, '{"authorizing_relation":"admin"}');
+
+        $this->repo->approveBatch($batchId, 'reviewer-1');
+        $claim = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claim);
+        $this->repo->recordPublication($batchId, 'litcal-data/national_calendar/roman/US', 'sha-a', 11, 'base');
+
+        $rows = $this->repo->getBatch($batchId);
+        self::assertSame($flaggedPath, $rows[0]['path'], 'this test requires the flagged row to sort first');
+
+        $purge = new RecordingTuplePurgeService();
+
+        $this->runnerFor([
+            self::prJson('closed', true, 'merge-sha', 'sha-a'),
+        ], $purge)->runOnce();
+
+        self::assertSame([], $purge->purged, 'one unflagged row must block the purge even when a flagged row sorts first');
+    }
+
+    public function testAMergedTransitionWritesAnAuditEntryOnlyOnce(): void
+    {
+        $batchId  = $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+        $auditLog = new RecordingAuditLogRepository(self::$pdo);
+
+        $runner = $this->runnerFor([
+            self::prJson('closed', true, 'merge-sha', 'sha-a'),
+        ], null, $auditLog);
+
+        $runner->runOnce();
+
+        self::assertSame([
+            [
+                'userId'       => null,
+                'action'       => 'change_request.merged',
+                'resourceType' => 'sourcedata_change_request',
+                'resourceId'   => $batchId,
+                'details'      => ['pr_number' => 11, 'merge_commit_sha' => 'merge-sha'],
+            ]
+        ], $auditLog->entries);
+
+        // The batch is no longer `open`, so listOpenPullRequestNumbers() returns nothing on a
+        // second poll and pollOne() is never invoked again for it — no further GitHub call is
+        // queued, and none should be needed.
+        $runner->runOnce();
+
+        self::assertCount(1, $auditLog->entries, 'an already-settled pull request must not be audited twice');
+    }
+
+    public function testAClosedUnmergedTransitionWritesAnAuditEntryOnlyOnce(): void
+    {
+        $batchId  = $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+        $auditLog = new RecordingAuditLogRepository(self::$pdo);
+
+        $runner = $this->runnerFor([
+            self::prJson('closed', false, null, 'sha-a'),
+        ], null, $auditLog);
+
+        $runner->runOnce();
+
+        self::assertSame([
+            [
+                'userId'       => null,
+                'action'       => 'change_request.closed_unmerged',
+                'resourceType' => 'sourcedata_change_request',
+                'resourceId'   => $batchId,
+                'details'      => ['pr_number' => 11],
+            ]
+        ], $auditLog->entries);
+
+        $runner->runOnce();
+
+        self::assertCount(1, $auditLog->entries, 'an already-settled pull request must not be audited twice');
     }
 }

--- a/phpunit_tests/Services/SourceData/MergePollRunnerTest.php
+++ b/phpunit_tests/Services/SourceData/MergePollRunnerTest.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use LiturgicalCalendar\Api\Enum\ChangeOperation;
+use LiturgicalCalendar\Api\Enum\ChangePublicationStatus;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\ChangeResource;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubAppAuth;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
+use LiturgicalCalendar\Api\Services\SourceData\MergePollRunner;
+use LiturgicalCalendar\Tests\Repositories\RepositoryTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Exercises `MergePollRunner` against a real `GitHubGitDataClient` wired to a mocked HTTP
+ * transport (same mock-first approach as {@see \LiturgicalCalendar\Tests\Services\GitHub\GitHubGitDataClientTest}
+ * and {@see \LiturgicalCalendar\Tests\Services\SourceData\SourceDataPublisherTest}) plus a real
+ * repository against Postgres.
+ *
+ * `GitHubAppAuth::installationToken()` is a real collaborator rather than a stub — it is
+ * `final`, so PHPUnit cannot double it — but its cache is pre-warmed with a fake token before
+ * each client is built, so its own (separately mocked, empty) HTTP queue is never touched. That
+ * keeps the queued responses in every test reserved for the pull-request / compare calls
+ * actually under test, with no app-token exchange consuming the first slot.
+ */
+#[CoversClass(MergePollRunner::class)]
+final class MergePollRunnerTest extends RepositoryTestCase
+{
+    /** Matches GitHubAppAuth::cacheKey() for installation id '67890'. */
+    private const AUTH_CACHE_KEY = 'github_app_installation_token_67890';
+
+    private SourceDataChangeRequestRepository $repo;
+
+    /** @var list<\Psr\Http\Message\RequestInterface> */
+    private array $sentRequests = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo         = new SourceDataChangeRequestRepository(self::$pdo);
+        $this->sentRequests = [];
+    }
+
+    // -- Fixtures ------------------------------------------------------------------------------
+
+    private function publishedBatch(string $sub, string $nation, int $prNumber, string $commitSha): string
+    {
+        $batchId = $this->repo->submitBatch(
+            ChangeResource::nationalCalendar(Rite::ROMAN, $nation),
+            [
+                [
+                    'path'      => "jsondata/sourcedata/rite/roman/calendars/nations/{$nation}/{$nation}.json",
+                    'operation' => ChangeOperation::CREATE,
+                    'content'   => '{"litcal":[]}',
+                ]
+            ],
+            $sub,
+            'Editor',
+            $sub . '@example.test',
+            true
+        )['batch_id'];
+
+        $this->repo->approveBatch($batchId, 'reviewer-1');
+        $claim = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claim);
+        self::assertSame($batchId, $claim->batchId);
+        $this->repo->recordPublication(
+            $batchId,
+            "litcal-data/national_calendar/roman/{$nation}",
+            $commitSha,
+            $prNumber,
+            'base-sha'
+        );
+
+        return $batchId;
+    }
+
+    /**
+     * Pre-seeds the installation token cache so `GitHubAppAuth::installationToken()` never
+     * exchanges over HTTP. See the class docblock: this repo's convention (matching
+     * `GitHubGitDataClientTest` and `SourceDataPublisherTest`) is to seed the token rather than
+     * queue a token-exchange response as the first mock response — queuing one would silently
+     * consume a response meant for the call actually under test, shifting every later
+     * assertion by one.
+     */
+    private function auth(): GitHubAppAuth
+    {
+        $cache = new ArrayAdapter();
+        $item  = $cache->getItem(self::AUTH_CACHE_KEY);
+        $item->set('ghs_test_token');
+        $cache->save($item);
+
+        // Empty queue: if installationToken() ever falls through to a real exchange instead of
+        // the cache hit above, this throws loudly ("mock queue is empty") instead of quietly
+        // consuming a response meant for the call under test.
+        $noHttp = new GuzzleClient(['handler' => HandlerStack::create(new MockHandler([]))]);
+
+        return new GitHubAppAuth('12345', '67890', '/nonexistent/should-not-be-read.pem', $noHttp, $cache);
+    }
+
+    /** @param list<GuzzleResponse> $responses */
+    private function runnerFor(array $responses): MergePollRunner
+    {
+        $mock  = new MockHandler($responses);
+        $stack = HandlerStack::create($mock);
+        $stack->push(function (callable $handler): callable {
+            return function ($request, array $options) use ($handler) {
+                $this->sentRequests[] = $request;
+
+                return $handler($request, $options);
+            };
+        });
+        $http = new GuzzleClient(['handler' => $stack]);
+
+        $client = new GitHubGitDataClient('Liturgical-Calendar', 'LiturgicalCalendarAPI', $this->auth(), $http);
+
+        return new MergePollRunner($this->repo, $client);
+    }
+
+    private static function prJson(string $state, bool $merged, ?string $mergeSha, string $headSha): GuzzleResponse
+    {
+        return new GuzzleResponse(200, [], json_encode([
+            'state'            => $state,
+            'merged'           => $merged,
+            'merge_commit_sha' => $mergeSha,
+            'head'             => ['sha' => $headSha],
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    private function publicationStatus(string $batchId): string
+    {
+        $stmt = self::$pdo->prepare('SELECT publication_status FROM sourcedata_change_requests WHERE batch_id = :b LIMIT 1');
+        $stmt->execute(['b' => $batchId]);
+
+        return (string) $stmt->fetchColumn();
+    }
+
+    // -- Tests ---------------------------------------------------------------------------------
+
+    public function testAnOpenPullRequestChangesNothing(): void
+    {
+        $batchId = $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+
+        $result = $this->runnerFor([
+            self::prJson('open', false, null, 'sha-a'),
+        ])->runOnce();
+
+        self::assertSame(0, $result->merged);
+        self::assertSame(0, $result->closed);
+        self::assertFalse($result->stoppedOnFailure);
+        self::assertSame(ChangePublicationStatus::OPEN->value, $this->publicationStatus($batchId));
+    }
+
+    public function testAMergedPullRequestMarksTheHeadBatchMerged(): void
+    {
+        $batchId = $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+
+        $result = $this->runnerFor([
+            self::prJson('closed', true, 'merge-sha', 'sha-a'),
+        ])->runOnce();
+
+        self::assertSame(1, $result->merged);
+        self::assertSame(ChangePublicationStatus::MERGED->value, $this->publicationStatus($batchId));
+    }
+
+    /**
+     * Two batches, one rolling pull request, ONE GitHub poll. The rolling branch is per resource,
+     * so polling per batch would ask the same question twice.
+     */
+    public function testTwoBatchesOnOnePullRequestCostOnePollAndBothTransition(): void
+    {
+        $first  = $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+        $second = $this->publishedBatch('editor-2', 'US', 11, 'sha-b');
+
+        $result = $this->runnerFor([
+            self::prJson('closed', true, 'merge-sha', 'sha-b'),
+            // one compare, for `sha-a` only — `sha-b` IS the head and needs none
+            new GuzzleResponse(200, [], json_encode(['status' => 'ahead'], JSON_THROW_ON_ERROR)),
+        ])->runOnce();
+
+        self::assertSame(2, $result->merged);
+        self::assertSame(ChangePublicationStatus::MERGED->value, $this->publicationStatus($first));
+        self::assertSame(ChangePublicationStatus::MERGED->value, $this->publicationStatus($second));
+
+        $pullPaths = array_filter(
+            array_map(static fn ($r): string => $r->getUri()->getPath(), $this->sentRequests),
+            static fn (string $p): bool => str_contains($p, '/pulls/')
+        );
+        self::assertCount(1, $pullPaths, 'one pull request, one poll');
+    }
+
+    /**
+     * THE defect this containment check exists for. A reviewer merged concurrently with a publish,
+     * so `sha-late` is on the branch but outside the merge. Marking it merged would make the
+     * publisher skip it forever and lose its content silently.
+     */
+    public function testABatchNotContainedInTheMergeIsResetRatherThanMarkedMerged(): void
+    {
+        $early = $this->publishedBatch('editor-1', 'US', 11, 'sha-early');
+        $late  = $this->publishedBatch('editor-2', 'US', 11, 'sha-late');
+
+        $result = $this->runnerFor([
+            self::prJson('closed', true, 'merge-sha', 'sha-early'),
+            // `sha-late` is not an ancestor of the merge commit
+            new GuzzleResponse(200, [], json_encode(['status' => 'diverged'], JSON_THROW_ON_ERROR)),
+        ])->runOnce();
+
+        self::assertSame(1, $result->merged);
+        self::assertSame(1, $result->reset);
+        self::assertSame(ChangePublicationStatus::MERGED->value, $this->publicationStatus($early));
+        self::assertSame(
+            ChangePublicationStatus::NONE->value,
+            $this->publicationStatus($late),
+            'a batch outside the merge must go back to claimable, never to merged'
+        );
+    }
+
+    public function testAClosedUnmergedPullRequestClosesAndRejects(): void
+    {
+        $batchId = $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+
+        $result = $this->runnerFor([
+            self::prJson('closed', false, null, 'sha-a'),
+        ])->runOnce();
+
+        self::assertSame(1, $result->closed);
+        self::assertSame(ChangePublicationStatus::CLOSED->value, $this->publicationStatus($batchId));
+    }
+
+    /**
+     * A failed compare must NOT be read either way: assuming contained loses content, assuming not
+     * contained republishes work already in the repository. The batch stays `open` for the next tick.
+     */
+    public function testAFailedContainmentCheckLeavesTheBatchOpen(): void
+    {
+        $head  = $this->publishedBatch('editor-1', 'US', 11, 'sha-head');
+        $other = $this->publishedBatch('editor-2', 'US', 11, 'sha-other');
+
+        $result = $this->runnerFor([
+            self::prJson('closed', true, 'merge-sha', 'sha-other'),
+            new GuzzleResponse(500, [], json_encode(['message' => 'boom'], JSON_THROW_ON_ERROR)),
+        ])->runOnce();
+
+        self::assertTrue($result->stoppedOnFailure);
+        self::assertSame(ChangePublicationStatus::OPEN->value, $this->publicationStatus($head));
+    }
+
+    public function testAFailedPollStopsTheRun(): void
+    {
+        $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+        $this->publishedBatch('editor-2', 'IT', 22, 'sha-b');
+
+        $result = $this->runnerFor([
+            new GuzzleResponse(503, [], json_encode(['message' => 'unavailable'], JSON_THROW_ON_ERROR)),
+        ])->runOnce();
+
+        self::assertTrue($result->stoppedOnFailure);
+        self::assertSame(0, $result->merged);
+    }
+
+    public function testUnpollableOpenBatchesAreCountedNotSkipped(): void
+    {
+        $batchId = $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+        self::$pdo->exec("UPDATE sourcedata_change_requests SET pr_number = NULL WHERE batch_id = '{$batchId}'");
+
+        $result = $this->runnerFor([])->runOnce();
+
+        self::assertSame(1, $result->unpollable);
+        self::assertFalse($result->stoppedOnFailure, 'an unexplained row is reported, not an outage');
+    }
+}

--- a/phpunit_tests/Services/SourceData/PollSourceDataMergesScriptTest.php
+++ b/phpunit_tests/Services/SourceData/PollSourceDataMergesScriptTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Runs `scripts/poll-sourcedata-merges.php` as a real process — mirrors
+ * {@see PublishSourceDataScriptTest}, and for the same reason: the wiring both scripts now share
+ * lives in {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisherFactory}, but
+ * only a subprocess proves that the LOGGER it hands back does not itself blow up the moment this
+ * entry point calls it, since a fatal is not catchable in-process.
+ */
+#[CoversNothing]
+final class PollSourceDataMergesScriptTest extends TestCase
+{
+    /**
+     * @param array<string, string> $githubEnv Overrides for the GITHUB_* variables.
+     *
+     * @return array{stdout: string, stderr: string, exitCode: int}
+     */
+    private function runScript(array $githubEnv = []): array
+    {
+        $script = dirname(__DIR__, 3) . '/scripts/poll-sourcedata-merges.php';
+        self::assertFileExists($script);
+
+        // Empty strings, not absent keys: the script's Dotenv loader is IMMUTABLE, so a
+        // variable already present in the environment wins over whatever a developer's local
+        // .env* files say. This is what guarantees the run stops at "not configured" instead of
+        // reaching for a real GitHub App on someone's workstation — see
+        // PublishSourceDataScriptTest::runScript()'s identical comment.
+        $env = array_merge(
+            [
+                'PATH'                        => getenv('PATH') === false ? '/usr/bin:/bin' : getenv('PATH'),
+                'HOME'                        => getenv('HOME') === false ? sys_get_temp_dir() : getenv('HOME'),
+                'GITHUB_APP_ID'               => '',
+                'GITHUB_APP_INSTALLATION_ID'  => '',
+                'GITHUB_APP_PRIVATE_KEY_PATH' => '',
+                'GITHUB_REPOSITORY'           => '',
+            ],
+            $githubEnv
+        );
+
+        $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+        $process     = proc_open([PHP_BINARY, $script], $descriptors, $pipes, null, $env);
+        self::assertIsResource($process, 'could not start the poll script');
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        return ['stdout' => $stdout, 'stderr' => $stderr, 'exitCode' => proc_close($process)];
+    }
+
+    /**
+     * A GitHub App credential complete enough to get PAST
+     * `SourceDataPublisherFactory::mergePollRunner()`'s own configuration checks — the same
+     * shape `PublishSourceDataScriptTest::testAMalformedRepositoryIsReportedRatherThanFatal()`
+     * uses to reach the repository split without any network call.
+     *
+     * @return array<string, string>
+     */
+    private function configuredGithubEnv(): array
+    {
+        return [
+            'GITHUB_APP_ID'               => '12345',
+            'GITHUB_APP_INSTALLATION_ID'  => '67890',
+            'GITHUB_APP_PRIVATE_KEY_PATH' => '/nonexistent/github-app.pem',
+            'GITHUB_REPOSITORY'           => 'Liturgical-Calendar/LiturgicalCalendarAPI',
+        ];
+    }
+
+    public function testItExitsOneAndSaysWhyWhenTheGithubAppIsUnconfigured(): void
+    {
+        $result = $this->runScript(['GITHUB_REPOSITORY' => '']);
+
+        self::assertSame(
+            1,
+            $result['exitCode'],
+            "expected a reported error, got:\nSTDOUT: {$result['stdout']}\nSTDERR: {$result['stderr']}"
+        );
+
+        // Same either-legitimate-stopping-point reasoning as
+        // PublishSourceDataScriptTest::testTheScriptRunsAndReportsMisconfigurationInsteadOfCrashing():
+        // which message is reached depends on where THIS host keeps its database credentials.
+        self::assertMatchesRegularExpression(
+            '/not configured|database unavailable/',
+            $result['stderr'],
+            'the script must name what stopped it'
+        );
+
+        // The signature of the logger defect this factory exists to prevent: the script got far
+        // enough to write its first log record before either error could be reported, and that
+        // record did not blow up. A regression here is a PHP fatal, exit 255, not a failed
+        // assertion — which is precisely why this runs out of process.
+        self::assertStringNotContainsString('Uncaught', $result['stderr']);
+        self::assertStringNotContainsString('Cannot process either request or response', $result['stderr']);
+    }
+
+    public function testItReportsASummaryLine(): void
+    {
+        $result = $this->runScript($this->configuredGithubEnv());
+
+        self::assertMatchesRegularExpression(
+            '/^poll-sourcedata-merges merged=\d+ closed=\d+ reset=\d+ unpollable=\d+ stopped_on_failure=(true|false)$/m',
+            $result['stdout'],
+            "expected a summary line, got:\nSTDOUT: {$result['stdout']}\nSTDERR: {$result['stderr']}"
+        );
+        self::assertContains($result['exitCode'], [0, 1]);
+    }
+}

--- a/phpunit_tests/Services/SourceData/PublishConsumerLoopTest.php
+++ b/phpunit_tests/Services/SourceData/PublishConsumerLoopTest.php
@@ -250,6 +250,70 @@ final class PublishConsumerLoopTest extends RepositoryTestCase
         self::assertSame(1, $auditPub->calls, 'the second message finds an empty queue, not a second batch');
     }
 
+    // -- Tests: publish-failure backoff ----------------------------------------------------------
+
+    /**
+     * A stream-driven publish run that stops on failure must suppress a SECOND stream-driven
+     * run arriving inside the backoff window — otherwise a backlog of queued `XADD`s, each
+     * waking `tick()` with no block between them, burns `publish_attempts` far faster than the
+     * cron interval `MAX_PUBLISH_ATTEMPTS` was sized against. See the class docblock's
+     * "Publish-failure backoff" section.
+     */
+    public function testASecondMessageInsideTheBackoffWindowDoesNotTriggerASecondPublishRun(): void
+    {
+        $this->approveOne('editor-1');
+        $throwingPublisher = new FakeSourceDataPublisher($this->repo, new \RuntimeException('GitHub down'));
+        $publisher         = new PublishRunner($this->repo, $throwingPublisher);
+
+        $loop = new PublishConsumerLoop(
+            new ScriptedStreamConsumer([['batch-1'], ['batch-2']]),
+            $publisher,
+            blockMs: 0,
+            mergePollIntervalSeconds: 3600
+        );
+
+        $loop->tick();
+        self::assertSame(1, $throwingPublisher->calls, 'the first message runs and fails');
+
+        $loop->tick();
+        self::assertSame(
+            1,
+            $throwingPublisher->calls,
+            'a second message inside the backoff window must not trigger a second publish run'
+        );
+    }
+
+    /**
+     * The other edge of the same window: once it has elapsed, a stream-driven message must run
+     * a publish attempt again — the backoff is temporary, not a one-way latch, and cron is only
+     * the backstop, not the sole path back to trying.
+     */
+    public function testAMessageAfterTheBackoffWindowTriggersAnotherPublishRun(): void
+    {
+        $this->approveOne('editor-1');
+        $throwingPublisher = new FakeSourceDataPublisher($this->repo, new \RuntimeException('GitHub down'));
+        $publisher         = new PublishRunner($this->repo, $throwingPublisher);
+
+        $loop = new PublishConsumerLoop(
+            new ScriptedStreamConsumer([['batch-1'], ['batch-2']]),
+            $publisher,
+            blockMs: 0,
+            mergePollIntervalSeconds: 1
+        );
+
+        $loop->tick();
+        self::assertSame(1, $throwingPublisher->calls, 'the first message runs and fails');
+
+        sleep(2);
+
+        $loop->tick();
+        self::assertSame(
+            2,
+            $throwingPublisher->calls,
+            'a message after the backoff window has elapsed must trigger another publish run'
+        );
+    }
+
     // -- Tests: ensureGroup is memoised ---------------------------------------------------------
 
     public function testEnsureGroupRunsOnceAcrossManyTicks(): void
@@ -372,6 +436,10 @@ final class PublishConsumerLoopTest extends RepositoryTestCase
                     'merge_commit_sha' => 'merge-sha',
                     'head'             => ['sha' => 'sha-a'],
                 ], JSON_THROW_ON_ERROR)),
+                // Containment is always verified with a compareCommits() call, even for the
+                // batch whose commit sha equals the reported head.sha — see MergePollRunner's
+                // own class docblock, "No zero-call fast path".
+                new GuzzleResponse(200, [], json_encode(['status' => 'identical'], JSON_THROW_ON_ERROR)),
             ]),
             blockMs: 0,
             mergePollIntervalSeconds: 0

--- a/phpunit_tests/Services/SourceData/PublishConsumerLoopTest.php
+++ b/phpunit_tests/Services/SourceData/PublishConsumerLoopTest.php
@@ -19,7 +19,9 @@ use LiturgicalCalendar\Api\Services\SourceData\MergePollRunner;
 use LiturgicalCalendar\Api\Services\SourceData\PublishConsumerLoop;
 use LiturgicalCalendar\Api\Services\SourceData\PublishRunner;
 use LiturgicalCalendar\Tests\Repositories\RepositoryTestCase;
+use LiturgicalCalendar\Tests\Support\ThrowingLogger;
 use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
@@ -32,18 +34,21 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
  * {@see \LiturgicalCalendar\Tests\Services\SourceData\MergePollRunnerTest}, which already solve
  * this same problem for their own subjects.
  *
- * Two behaviours from the original test sketch are NOT covered here —
- * "a publish-run failure doesn't kill the consumer" and "a merge-poll failure doesn't kill the
- * consumer" — because they are provably unreachable with real collaborators. Every external
- * call inside {@see PublishRunner::runOnce()} and {@see MergePollRunner::runOnce()} (repository,
- * publisher, GitHub client, purge service, audit log) is already wrapped in its OWN
- * `catch (\Throwable)` inside those classes — see their docblocks — so no repository/publisher/
- * client double, however broken, can make either `runOnce()` call propagate an exception.
- * `PublishConsumerLoop`'s own `try`/`catch` around both calls is therefore defense-in-depth for
- * a future change to those classes (or a genuine PHP engine `\Error`), not a path this test
- * suite can exercise honestly without weakening a `final` class or changing
- * `PublishConsumerLoop`'s constructor away from the concrete types it is required to take. See
- * the task report for the full analysis.
+ * `PublishConsumerLoop`'s own `try`/`catch` around each `runOnce()` call is NOT dead
+ * defense-in-depth. A first pass at this suite tried to make `PublishRunner::runOnce()` /
+ * `MergePollRunner::runOnce()` throw via the repository, publisher, GitHub client, purge
+ * service, and audit log, and concluded that was impossible because every call to those four
+ * collaborators is already wrapped in the runner's own `catch (\Throwable)`. That inventory
+ * missed a fifth, ordinary constructor collaborator on both classes: `?LoggerInterface $logger`.
+ * Every one of those `catch` blocks calls the logger from INSIDE itself, and
+ * {@see MergePollRunner::unpollableCountSafely()}'s `warning()` call (fired when
+ * `countOpenBatchesWithoutPullRequest()` is non-zero) sits entirely outside any `try`/`catch`,
+ * at the very top of `runOnce()` — so a logger whose write throws propagates straight out,
+ * exactly the escape the `PublishConsumerLoop` catch exists to stop. See
+ * {@see testAPublishRunFailureDoesNotKillTheConsumer} and
+ * {@see testAMergePollFailureDoesNotKillTheConsumer}, and the task report for the falsification
+ * evidence (removing `PublishConsumerLoop`'s own catch makes both fail with the escaped
+ * exception).
  */
 #[CoversClass(PublishConsumerLoop::class)]
 final class PublishConsumerLoopTest extends RepositoryTestCase
@@ -144,7 +149,7 @@ final class PublishConsumerLoopTest extends RepositoryTestCase
     }
 
     /** @param list<GuzzleResponse> $responses */
-    private function mergePollRunnerFor(array $responses): MergePollRunner
+    private function mergePollRunnerFor(array $responses, ?LoggerInterface $logger = null): MergePollRunner
     {
         $mock  = new MockHandler($responses);
         $stack = HandlerStack::create($mock);
@@ -159,7 +164,14 @@ final class PublishConsumerLoopTest extends RepositoryTestCase
 
         $client = new GitHubGitDataClient('Liturgical-Calendar', 'LiturgicalCalendarAPI', $this->auth(), $http);
 
-        return new MergePollRunner($this->repo, $client);
+        return new MergePollRunner($this->repo, $client, logger: $logger);
+    }
+
+    /** Marks an already-open batch `open` with no `pr_number` — the "unpollable" state. */
+    private function makeUnpollable(string $batchId): void
+    {
+        $stmt = self::$pdo->prepare('UPDATE sourcedata_change_requests SET pr_number = NULL WHERE batch_id = :b');
+        $stmt->execute(['b' => $batchId]);
     }
 
     private static function openPrJson(string $headSha): GuzzleResponse
@@ -368,5 +380,55 @@ final class PublishConsumerLoopTest extends RepositoryTestCase
         $loop->tick();
 
         self::assertSame(ChangePublicationStatus::MERGED->value, $this->publicationStatus($batchId));
+    }
+
+    // -- Tests: nothing here may kill the consumer ----------------------------------------------
+
+    /**
+     * `PublishRunner`'s own `catch (\Throwable)` around `$this->publisher->publish()` calls
+     * `$this->logger->error()` as ITS FIRST statement, before `releaseClaimSafely()` runs — and
+     * that call is not itself wrapped by anything inside `PublishRunner`. A logger whose write
+     * throws (see {@see ThrowingLogger}'s own docblock: this is not hypothetical —
+     * `LoggerFactory::create()` and Monolog's stream handlers both throw for reachable
+     * production conditions) therefore propagates straight out of `runOnce()`. Without
+     * `PublishConsumerLoop`'s own catch around that call, this test fails with the escaped
+     * `\RuntimeException` — see the task report for that falsification run.
+     */
+    public function testAPublishRunFailureDoesNotKillTheConsumer(): void
+    {
+        $this->approveOne('editor-1');
+        $throwingPublisher = new FakeSourceDataPublisher($this->repo, new \RuntimeException('GitHub down'));
+        $publisher         = new PublishRunner($this->repo, $throwingPublisher, logger: new ThrowingLogger());
+
+        $loop = new PublishConsumerLoop(new ScriptedStreamConsumer([['batch-1']]), $publisher);
+
+        $loop->tick();
+
+        self::assertTrue(true, 'tick() returned rather than propagating the logger\'s own throw');
+    }
+
+    /**
+     * The cleanest trigger: {@see MergePollRunner::unpollableCountSafely()} calls
+     * `$this->logger->warning()` on a non-zero unpollable count entirely OUTSIDE any
+     * `try`/`catch` — and it runs at the very top of `runOnce()`, before the method's own first
+     * `try` block even opens. A throwing logger there escapes `runOnce()` immediately and
+     * completely. Without `PublishConsumerLoop`'s own catch around the idle-tick merge-poll
+     * call, this test fails with the escaped `\RuntimeException` — see the task report.
+     */
+    public function testAMergePollFailureDoesNotKillTheConsumer(): void
+    {
+        $batchId = $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+        $this->makeUnpollable($batchId);
+
+        $loop = new PublishConsumerLoop(
+            new ScriptedStreamConsumer([[]]),
+            $this->publishRunner(),
+            $this->mergePollRunnerFor([], new ThrowingLogger()),
+            blockMs: 0
+        );
+
+        $loop->tick();
+
+        self::assertTrue(true, 'tick() returned rather than propagating the logger\'s own throw');
     }
 }

--- a/phpunit_tests/Services/SourceData/PublishConsumerLoopTest.php
+++ b/phpunit_tests/Services/SourceData/PublishConsumerLoopTest.php
@@ -499,4 +499,78 @@ final class PublishConsumerLoopTest extends RepositoryTestCase
 
         self::assertTrue(true, 'tick() returned rather than propagating the logger\'s own throw');
     }
+
+    /**
+     * `ensureGroup()` and `readOnce()` sit OUTSIDE the inner try/catch that only ever guards
+     * `$this->publisher->runOnce()` — see the class docblock's newest section. A `\RedisException`
+     * from either (a dropped connection, a Redis restart) must not propagate out of `tick()`.
+     *
+     * Falsified by temporarily removing the outer `catch (\Throwable)` around `ensureGroup()` +
+     * `readOnce()` in `PublishConsumerLoop::tick()`: this test then fails with the escaped
+     * `RedisException` — see the task report for that run's output.
+     */
+    public function testAStreamReadFailureDoesNotKillTheConsumer(): void
+    {
+        $loop = new PublishConsumerLoop(
+            new ThrowingReadStreamConsumer(),
+            $this->publishRunner(),
+            blockMs: 0
+        );
+
+        $loop->tick();
+
+        self::assertTrue(true, 'tick() returned rather than propagating the RedisException');
+    }
+
+    /**
+     * The connection may have dropped, so the group may no longer exist on whatever connection
+     * replaces it — `groupEnsured` must reset to `false` on a stream-read failure so the NEXT
+     * tick re-runs `ensureGroup()` rather than trusting a group that was only ever confirmed on
+     * the now-broken connection.
+     */
+    public function testAStreamReadFailureResetsGroupEnsuredSoTheNextTickReEnsuresIt(): void
+    {
+        $consumer = new ThrowingReadStreamConsumer();
+        $loop     = new PublishConsumerLoop($consumer, $this->publishRunner(), blockMs: 0);
+
+        $loop->tick();
+        $loop->tick();
+
+        self::assertSame(2, $consumer->ensureGroupCalls, 'a failed read must not leave the group considered ensured');
+    }
+
+    /**
+     * The idle merge poll depends on Postgres and GitHub, not Redis — a stream outage is not a
+     * reason to stop finding merged pull requests, and it stays useful throughout one. `$woken`
+     * never becomes `true` when `readOnce()` throws before invoking its callback, so the normal
+     * `if (!$woken)` branch already reaches `pollMergesIfDue()` on this path.
+     */
+    public function testAStreamReadFailureStillRunsTheIdleMergePoll(): void
+    {
+        $batchId = $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+
+        $loop = new PublishConsumerLoop(
+            new ThrowingReadStreamConsumer(),
+            $this->publishRunner(),
+            $this->mergePollRunnerFor([
+                new GuzzleResponse(200, [], json_encode([
+                    'state'            => 'closed',
+                    'merged'           => true,
+                    'merge_commit_sha' => 'merge-sha',
+                    'head'             => ['sha' => 'sha-a'],
+                ], JSON_THROW_ON_ERROR)),
+                new GuzzleResponse(200, [], json_encode(['status' => 'identical'], JSON_THROW_ON_ERROR)),
+            ]),
+            blockMs: 0,
+            mergePollIntervalSeconds: 0
+        );
+
+        $loop->tick();
+
+        self::assertSame(
+            ChangePublicationStatus::MERGED->value,
+            $this->publicationStatus($batchId),
+            'a stream-read failure must not skip the idle merge poll'
+        );
+    }
 }

--- a/phpunit_tests/Services/SourceData/PublishConsumerLoopTest.php
+++ b/phpunit_tests/Services/SourceData/PublishConsumerLoopTest.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use LiturgicalCalendar\Api\Enum\ChangeOperation;
+use LiturgicalCalendar\Api\Enum\ChangePublicationStatus;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\ChangeResource;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubAppAuth;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
+use LiturgicalCalendar\Api\Services\SourceData\MergePollRunner;
+use LiturgicalCalendar\Api\Services\SourceData\PublishConsumerLoop;
+use LiturgicalCalendar\Api\Services\SourceData\PublishRunner;
+use LiturgicalCalendar\Tests\Repositories\RepositoryTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Exercises `PublishConsumerLoop` against REAL `PublishRunner` / `MergePollRunner` instances —
+ * both `final`, so neither can be subclassed into a call-counting spy the way the original
+ * design for this test sketched. Every assertion here is therefore on an OBSERVABLE OUTCOME of
+ * a real run (a batch's `publication_status` changing, an actual HTTP request landing on a
+ * recording middleware) rather than on a call count, mirroring
+ * {@see \LiturgicalCalendar\Tests\Services\SourceData\PublishRunnerTest} and
+ * {@see \LiturgicalCalendar\Tests\Services\SourceData\MergePollRunnerTest}, which already solve
+ * this same problem for their own subjects.
+ *
+ * Two behaviours from the original test sketch are NOT covered here —
+ * "a publish-run failure doesn't kill the consumer" and "a merge-poll failure doesn't kill the
+ * consumer" — because they are provably unreachable with real collaborators. Every external
+ * call inside {@see PublishRunner::runOnce()} and {@see MergePollRunner::runOnce()} (repository,
+ * publisher, GitHub client, purge service, audit log) is already wrapped in its OWN
+ * `catch (\Throwable)` inside those classes — see their docblocks — so no repository/publisher/
+ * client double, however broken, can make either `runOnce()` call propagate an exception.
+ * `PublishConsumerLoop`'s own `try`/`catch` around both calls is therefore defense-in-depth for
+ * a future change to those classes (or a genuine PHP engine `\Error`), not a path this test
+ * suite can exercise honestly without weakening a `final` class or changing
+ * `PublishConsumerLoop`'s constructor away from the concrete types it is required to take. See
+ * the task report for the full analysis.
+ */
+#[CoversClass(PublishConsumerLoop::class)]
+final class PublishConsumerLoopTest extends RepositoryTestCase
+{
+    /** Matches GitHubAppAuth::cacheKey() for installation id '67890'. */
+    private const AUTH_CACHE_KEY = 'github_app_installation_token_67890';
+
+    private SourceDataChangeRequestRepository $repo;
+
+    /** @var list<\Psr\Http\Message\RequestInterface> */
+    private array $sentRequests = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo         = new SourceDataChangeRequestRepository(self::$pdo);
+        $this->sentRequests = [];
+    }
+
+    // -- Fixtures -----------------------------------------------------------------------------
+
+    private function approveOne(string $sub, string $nation = 'US'): string
+    {
+        $submission = $this->repo->submitBatch(
+            ChangeResource::nationalCalendar(Rite::ROMAN, $nation),
+            [
+                [
+                    'path'      => "jsondata/sourcedata/rite/roman/calendars/nations/{$nation}/{$nation}.json",
+                    'operation' => ChangeOperation::CREATE,
+                    'content'   => '{"litcal":[]}',
+                ],
+            ],
+            $sub,
+            'Editor',
+            $sub . '@example.test',
+            true
+        );
+
+        $batchId = $submission['batch_id'];
+        $this->repo->approveBatch($batchId, 'reviewer-1');
+
+        return $batchId;
+    }
+
+    /** An approved-and-published batch, with an open pull request left for the merge poller. */
+    private function publishedBatch(string $sub, string $nation, int $prNumber, string $commitSha): string
+    {
+        $batchId = $this->repo->submitBatch(
+            ChangeResource::nationalCalendar(Rite::ROMAN, $nation),
+            [
+                [
+                    'path'      => "jsondata/sourcedata/rite/roman/calendars/nations/{$nation}/{$nation}.json",
+                    'operation' => ChangeOperation::CREATE,
+                    'content'   => '{"litcal":[]}',
+                ],
+            ],
+            $sub,
+            'Editor',
+            $sub . '@example.test',
+            true
+        )['batch_id'];
+
+        $this->repo->approveBatch($batchId, 'reviewer-1');
+        $claim = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claim);
+        $this->repo->recordPublication($batchId, "litcal-data/national_calendar/roman/{$nation}", $commitSha, $prNumber, 'base-sha');
+
+        return $batchId;
+    }
+
+    private function publicationStatus(string $batchId): string
+    {
+        $stmt = self::$pdo->prepare('SELECT publication_status FROM sourcedata_change_requests WHERE batch_id = :b LIMIT 1');
+        $stmt->execute(['b' => $batchId]);
+
+        return (string) $stmt->fetchColumn();
+    }
+
+    private function publishRunner(): PublishRunner
+    {
+        return new PublishRunner($this->repo, new FakeSourceDataPublisher($this->repo));
+    }
+
+    /**
+     * Pre-seeds the installation token cache so `GitHubAppAuth::installationToken()` never
+     * exchanges over HTTP. Same convention as {@see MergePollRunnerTest::auth()}.
+     */
+    private function auth(): GitHubAppAuth
+    {
+        $cache = new ArrayAdapter();
+        $item  = $cache->getItem(self::AUTH_CACHE_KEY);
+        $item->set('ghs_test_token');
+        $cache->save($item);
+
+        $noHttp = new GuzzleClient(['handler' => HandlerStack::create(new MockHandler([]))]);
+
+        return new GitHubAppAuth('12345', '67890', '/nonexistent/should-not-be-read.pem', $noHttp, $cache);
+    }
+
+    /** @param list<GuzzleResponse> $responses */
+    private function mergePollRunnerFor(array $responses): MergePollRunner
+    {
+        $mock  = new MockHandler($responses);
+        $stack = HandlerStack::create($mock);
+        $stack->push(function (callable $handler): callable {
+            return function ($request, array $options) use ($handler) {
+                $this->sentRequests[] = $request;
+
+                return $handler($request, $options);
+            };
+        });
+        $http = new GuzzleClient(['handler' => $stack]);
+
+        $client = new GitHubGitDataClient('Liturgical-Calendar', 'LiturgicalCalendarAPI', $this->auth(), $http);
+
+        return new MergePollRunner($this->repo, $client);
+    }
+
+    private static function openPrJson(string $headSha): GuzzleResponse
+    {
+        return new GuzzleResponse(200, [], json_encode([
+            'state'            => 'open',
+            'merged'           => false,
+            'merge_commit_sha' => null,
+            'head'             => ['sha' => $headSha],
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    /** @return list<string> Request paths containing '/pulls/', in order sent. */
+    private function pullRequestPollPaths(): array
+    {
+        return array_values(array_filter(
+            array_map(static fn ($r): string => $r->getUri()->getPath(), $this->sentRequests),
+            static fn (string $p): bool => str_contains($p, '/pulls/')
+        ));
+    }
+
+    // -- Tests: the message is a hint, never a work item ---------------------------------------
+
+    public function testAMessageTriggersAPublishRunThatClaimsFromPostgres(): void
+    {
+        $batchId = $this->approveOne('editor-1');
+
+        $loop = new PublishConsumerLoop(
+            new ScriptedStreamConsumer([['batch-1']]),
+            $this->publishRunner()
+        );
+
+        $loop->tick();
+
+        self::assertSame(ChangePublicationStatus::OPEN->value, $this->publicationStatus($batchId));
+    }
+
+    /**
+     * `PublishRunner::runOnce()` takes no batch id argument at all — it claims whatever is
+     * oldest and claimable in Postgres. So a message carrying an id that matches NOTHING in the
+     * database still results in the real, approved batch being published: the message id is
+     * read only for the log line, never used to decide what gets worked.
+     */
+    public function testAGarbageBatchIdInTheMessageStillPublishesTheRealApprovedBatch(): void
+    {
+        $realBatchId = $this->approveOne('editor-1');
+
+        $loop = new PublishConsumerLoop(
+            new ScriptedStreamConsumer([['00000000-0000-0000-0000-000000000000']]),
+            $this->publishRunner()
+        );
+
+        $loop->tick();
+
+        self::assertSame(ChangePublicationStatus::OPEN->value, $this->publicationStatus($realBatchId));
+    }
+
+    /**
+     * A duplicated message (two ids in the same tick, or the same batch id sent twice) must
+     * cost at most one wasted claim against an empty queue, not a duplicate publish — proving
+     * the queue, not the message count, decides how much work happens.
+     */
+    public function testTwoMessagesInOneTickPublishOnlyTheOneApprovedBatch(): void
+    {
+        $batchId  = $this->approveOne('editor-1');
+        $auditPub = new FakeSourceDataPublisher($this->repo);
+
+        $loop = new PublishConsumerLoop(
+            new ScriptedStreamConsumer([['batch-1', 'batch-1']]),
+            new PublishRunner($this->repo, $auditPub)
+        );
+
+        $loop->tick();
+
+        self::assertSame(ChangePublicationStatus::OPEN->value, $this->publicationStatus($batchId));
+        self::assertSame(1, $auditPub->calls, 'the second message finds an empty queue, not a second batch');
+    }
+
+    // -- Tests: ensureGroup is memoised ---------------------------------------------------------
+
+    public function testEnsureGroupRunsOnceAcrossManyTicks(): void
+    {
+        $consumer = new ScriptedStreamConsumer([[], [], []]);
+        $loop     = new PublishConsumerLoop($consumer, $this->publishRunner());
+
+        $loop->tick();
+        $loop->tick();
+        $loop->tick();
+
+        self::assertSame(1, $consumer->ensureGroupCalls);
+    }
+
+    // -- Tests: the idle merge poll ---------------------------------------------------------
+
+    /**
+     * `blockMs` is 5000, so an unrated idle tick would poll GitHub 720 times an hour to watch
+     * for a transition nobody is waiting on. Three idle ticks with a one-hour interval must
+     * cost exactly one GitHub `/pulls/` request, not three.
+     */
+    public function testTheIdleMergePollIsRateLimited(): void
+    {
+        $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+
+        $loop = new PublishConsumerLoop(
+            new ScriptedStreamConsumer([[], [], []]),
+            $this->publishRunner(),
+            $this->mergePollRunnerFor([self::openPrJson('sha-a')]),
+            blockMs: 0,
+            mergePollIntervalSeconds: 3600
+        );
+
+        $loop->tick();
+        $loop->tick();
+        $loop->tick();
+
+        self::assertCount(1, $this->pullRequestPollPaths(), 'three idle ticks, one poll');
+    }
+
+    /**
+     * The inverse edge: a zero-second interval never blocks a poll, so every idle tick polls.
+     * Pins the boundary condition ( `< $mergePollIntervalSeconds` ) from the other direction —
+     * a suite that only ever exercised the rate-limited case could not tell an "always skip"
+     * bug from a correctly-rate-limited one.
+     */
+    public function testAZeroSecondIntervalPollsOnEveryIdleTick(): void
+    {
+        $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+
+        $loop = new PublishConsumerLoop(
+            new ScriptedStreamConsumer([[], []]),
+            $this->publishRunner(),
+            $this->mergePollRunnerFor([self::openPrJson('sha-a'), self::openPrJson('sha-a')]),
+            blockMs: 0,
+            mergePollIntervalSeconds: 0
+        );
+
+        $loop->tick();
+        $loop->tick();
+
+        self::assertCount(2, $this->pullRequestPollPaths(), 'a zero-second interval never withholds a poll');
+    }
+
+    /**
+     * Merge detection only runs on the idle tick. A tick woken by an actual message must not
+     * also spend a GitHub call on merge polling — the mock queue is left empty, so a stray poll
+     * would surface as an exception, but `MergePollRunner` would swallow that too; only counting
+     * the real requests distinguishes "never polled" from "polled and happened to fail".
+     */
+    public function testAWokenTickDoesNotAlsoPollMerges(): void
+    {
+        $batchId = $this->approveOne('editor-1');
+
+        $loop = new PublishConsumerLoop(
+            new ScriptedStreamConsumer([['batch-1']]),
+            $this->publishRunner(),
+            $this->mergePollRunnerFor([]),
+            blockMs: 0,
+            mergePollIntervalSeconds: 0
+        );
+
+        $loop->tick();
+
+        self::assertSame(ChangePublicationStatus::OPEN->value, $this->publicationStatus($batchId));
+        self::assertCount(0, $this->pullRequestPollPaths(), 'a message tick must not spend a merge poll');
+    }
+
+    public function testIdleTicksWithoutAMergePollerDoNotThrow(): void
+    {
+        $loop = new PublishConsumerLoop(
+            new ScriptedStreamConsumer([[], [], []]),
+            $this->publishRunner(),
+            mergePoller: null,
+            blockMs: 0
+        );
+
+        $loop->tick();
+        $loop->tick();
+        $loop->tick();
+
+        self::assertTrue(true, 'no merge poller configured; idle ticks must be inert, not fatal');
+    }
+
+    /**
+     * A merge poll that actually settles a batch is a real, end-to-end observable outcome of the
+     * idle tick — not just "an HTTP request was sent", but the batch's own status changing.
+     */
+    public function testAnIdleMergePollThatFindsAMergedPrSettlesTheBatch(): void
+    {
+        $batchId = $this->publishedBatch('editor-1', 'US', 11, 'sha-a');
+
+        $loop = new PublishConsumerLoop(
+            new ScriptedStreamConsumer([[]]),
+            $this->publishRunner(),
+            $this->mergePollRunnerFor([
+                new GuzzleResponse(200, [], json_encode([
+                    'state'            => 'closed',
+                    'merged'           => true,
+                    'merge_commit_sha' => 'merge-sha',
+                    'head'             => ['sha' => 'sha-a'],
+                ], JSON_THROW_ON_ERROR)),
+            ]),
+            blockMs: 0,
+            mergePollIntervalSeconds: 0
+        );
+
+        $loop->tick();
+
+        self::assertSame(ChangePublicationStatus::MERGED->value, $this->publicationStatus($batchId));
+    }
+}

--- a/phpunit_tests/Services/SourceData/PublishRunnerTest.php
+++ b/phpunit_tests/Services/SourceData/PublishRunnerTest.php
@@ -259,7 +259,7 @@ final class PublishRunnerTest extends RepositoryTestCase
         }
 
         // "Becomes claimable again", not merely "back to none" as a status side effect.
-        self::assertSame($batchId, $this->repo->claimNextPublishableBatch());
+        self::assertSame($batchId, $this->repo->claimNextPublishableBatch()?->batchId);
     }
 
     /**

--- a/phpunit_tests/Services/SourceData/PublishRunnerTest.php
+++ b/phpunit_tests/Services/SourceData/PublishRunnerTest.php
@@ -436,6 +436,101 @@ final class PublishRunnerTest extends RepositoryTestCase
     }
 
     /**
+     * Fix-round-2 finding: CLAIM_LOST reaching the branch-contention path must continue, not
+     * stop, and the earlier fix (excluding CLAIM_LOST from the continue gate) was wrong on the
+     * merits. Inside a lost branch race (a GitHub 422), CLAIM_LOST is doubly benign — the 422
+     * itself is proof GitHub is healthy and answering (see the class docblock's "Contention is
+     * not an outage"), and the release outcome is a POSITIVE observation that a different
+     * runner holds a live, freshly-issued claim on this exact batch and is actively working
+     * it. That is the opposite of BATCH_MISSING, which stays excluded because nothing is known
+     * about a vanished row. {@see ClaimStolenSourceDataPublisher} reproduces the sequence
+     * releaseClaim()'s own docblock narrates (A claims, the grace period elapses, B claims
+     * with a fresh token, A's own doomed call finally returns) directly against the row.
+     */
+    public function testClaimLostUnderBranchContentionContinuesTheRun(): void
+    {
+        $contended = $this->approveOne('editor-1', 'US');
+        $nextBatch = $this->approveOne('editor-2', 'DE');
+
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test', [$testHandler]);
+        $publisher   = new ClaimStolenSourceDataPublisher(
+            $this->repo,
+            self::$pdo,
+            $contended,
+            new GitHubApiException(422, 'Update is not a fast forward')
+        );
+        $runner      = new PublishRunner($this->repo, $publisher, logger: $logger);
+
+        $result = $runner->runOnce();
+
+        self::assertFalse(
+            $result->stoppedOnFailure,
+            'a batch actively held by another runner\'s live claim, lost only to a benign branch race, must not stop the run'
+        );
+        self::assertSame(1, $result->published, 'the queue must drain past the CLAIM_LOST batch to the next one');
+        self::assertTrue($testHandler->hasWarningThatContains('lost a race'));
+        self::assertFalse(
+            $testHandler->hasWarningThatContains('the batch stays claimable'),
+            'CLAIM_LOST is not "stays claimable": another runner already holds it'
+        );
+        self::assertTrue(
+            $testHandler->hasWarningThatContains('another runner holds a live claim'),
+            'the message must say the batch is spoken for, not merely available again'
+        );
+
+        // Untouched by this runner's release: still queued, under the "second runner"'s token,
+        // exactly as a live claim actually being worked would be.
+        foreach ($this->repo->getBatch($contended) as $row) {
+            self::assertSame(ChangePublicationStatus::QUEUED->value, $row['publication_status']);
+        }
+
+        // The rest of the queue drained rather than being abandoned for the tick.
+        foreach ($this->repo->getBatch($nextBatch) as $row) {
+            self::assertSame(ChangePublicationStatus::OPEN->value, $row['publication_status']);
+        }
+    }
+
+    /**
+     * The sibling of the test above, and the one that pins the spec's actual sentence
+     * ("PublishRunner treats it as a failure and stops the run"): that sentence is about the
+     * fall-through default OUTSIDE of branch contention, which this test reaches by using a
+     * non-422 failure. CLAIM_LOST here gets no positive "another runner is healthy and
+     * working it, and GitHub just proved it" reading to lean on, so the run must stop exactly
+     * as it would for RELEASED or NOT_CLAIMED. This is the sentence the branch-contention
+     * exception above must not be allowed to quietly widen into a blanket "CLAIM_LOST never
+     * stops" rule.
+     */
+    public function testClaimLostWithoutBranchContentionStopsTheRun(): void
+    {
+        $batchId = $this->approveOne('editor-1', 'US');
+
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test', [$testHandler]);
+        $publisher   = new ClaimStolenSourceDataPublisher(
+            $this->repo,
+            self::$pdo,
+            $batchId,
+            new GitHubApiException(500, 'Server Error')
+        );
+        $runner      = new PublishRunner($this->repo, $publisher, logger: $logger);
+
+        $result = $runner->runOnce();
+
+        self::assertTrue(
+            $result->stoppedOnFailure,
+            'CLAIM_LOST outside a benign branch race is a genuine failure and must stop the run'
+        );
+        self::assertSame(0, $result->published);
+        self::assertTrue($testHandler->hasWarningThatContains('Stopping this run after a failed publish attempt.'));
+
+        // Untouched by this runner's release: still queued, under the "second runner"'s token.
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::QUEUED->value, $row['publication_status']);
+        }
+    }
+
+    /**
      * `claimNextPublishableBatch()` was the one unwrapped DB call in `runOnce()`, inside a
      * method whose own docblock justifies wrapping its two siblings so a DB outage cannot
      * escape as a raw fatal with no summary line for the cron script to report. Same

--- a/phpunit_tests/Services/SourceData/PublishSourceDataConsumerScriptTest.php
+++ b/phpunit_tests/Services/SourceData/PublishSourceDataConsumerScriptTest.php
@@ -20,35 +20,45 @@ use PHPUnit\Framework\TestCase;
  * is unreachable in CI and in local development without Redis. It is chosen deliberately narrow:
  * the one thing this test pins is the single most dangerous mistake in this file — passing
  * `RedisStreamConsumer`'s DEFAULT payload field ('row_id', correct for the OpenFGA outbox)
- * instead of this stream's actual field ('batch_id', the only key
+ * instead of this stream's actual field,
+ * {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier::BATCH_ID_FIELD}
+ * ('batch_id'), the only field key
  * {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier::notify()}
- * writes). Getting that wrong makes every message on this stream look malformed to
+ * writes. Getting that wrong makes every message on this stream look malformed to
  * `RedisStreamConsumer`, which ACKs it away silently — a "bad message" log line and no other
  * symptom — so the consumer would run forever, waking on every notification and doing nothing
  * with any of them, while the cron backstop quietly did all the real work and nothing ever
  * surfaced the difference.
  *
- * A plain `assertStringContainsString("'batch_id'", $source)` is NOT enough to pin that: the
- * entry point's own explanatory comment immediately above the `RedisStreamConsumer` construction
- * also contains the literal `'batch_id'` (it has to, to explain what the argument is for), so
- * that assertion would keep passing even if the real sixth argument regressed to `'row_id'` and
- * the comment above it were left behind, unedited — comments rot independently of code. This was
- * found during review of this feature (both occurrences existed in the same file at the same
- * time) and closed by anchoring the regex to the `new RedisStreamConsumer(...)` call's own
- * argument list instead of the whole file — see the test method's own docblock.
+ * The field name used to be a bare `'batch_id'` string literal in both the notifier and this
+ * entry point, tied together by nothing the type system could check. It is now
+ * `SourceDataPublishNotifier::BATCH_ID_FIELD`, a public class constant referenced from both
+ * sides — but promoting it to a constant does not retire the anchoring problem this test was
+ * already fixed for once: the entry point's own explanatory comment immediately above the
+ * `RedisStreamConsumer` construction ALSO names `SourceDataPublishNotifier::BATCH_ID_FIELD` (it
+ * has to, to explain what the argument is for), so a plain
+ * `assertStringContainsString('SourceDataPublishNotifier::BATCH_ID_FIELD', $source)` would keep
+ * passing even if the real sixth argument regressed to a bare `'row_id'` and the comment above
+ * it were left behind, unedited — comments rot independently of code. This was found during
+ * review of this feature when the argument was still the literal `'batch_id'` (both occurrences
+ * existed in the same file at the same time) and closed by anchoring the regex to the
+ * `new RedisStreamConsumer(...)` call's own argument list instead of the whole file — see the
+ * test method's own docblock, updated here to match the constant reference.
  */
 #[CoversNothing]
 final class PublishSourceDataConsumerScriptTest extends TestCase
 {
     /**
      * Anchored to the `new RedisStreamConsumer(...)` CALL, not merely to the file containing the
-     * string `'batch_id'` somewhere. The file's own explanatory comment immediately above that
-     * call also contains the literal `'batch_id'` (it has to, to explain what the argument does)
-     * — so a plain `assertStringContainsString("'batch_id'", $source)` would keep passing even
-     * if the real sixth argument regressed to `'row_id'` and the comment above it were simply
-     * left behind, unedited. That is not a hypothetical: it is exactly what this file looked
-     * like when this test was first written, and the review that caught it is why this regex is
-     * scoped to the constructor call's own argument list instead of the whole source string.
+     * string `SourceDataPublishNotifier::BATCH_ID_FIELD` somewhere. The file's own explanatory
+     * comment immediately above that call also names the constant (it has to, to explain what
+     * the argument does) — so a plain `assertStringContainsString(...)` over the whole file
+     * would keep passing even if the real sixth argument regressed to the class default
+     * (`'row_id'`, or a bare `'batch_id'` literal) and the comment above it were simply left
+     * behind, unedited. That is not a hypothetical: it is exactly what this file looked like
+     * (with the bare string literal) when this test was first written, and the review that
+     * caught it is why this regex stays scoped to the constructor call's own argument list
+     * instead of the whole source string.
      */
     public function testTheConsumerEntryPointReadsTheBatchIdField(): void
     {
@@ -56,13 +66,13 @@ final class PublishSourceDataConsumerScriptTest extends TestCase
         self::assertIsString($source);
 
         self::assertMatchesRegularExpression(
-            '/new\s+RedisStreamConsumer\([^)]*\'batch_id\'\s*\)/s',
+            '/new\s+RedisStreamConsumer\([^)]*SourceDataPublishNotifier::BATCH_ID_FIELD\s*\)/s',
             $source,
             "bin/publish-sourcedata-consumer's `new RedisStreamConsumer(...)` call must pass "
-                . "'batch_id' as the payload field argument; the class default is 'row_id' "
-                . '(correct for the OpenFGA outbox, wrong here), and getting this wrong makes '
-                . 'every message on this stream look malformed and be ACKed away silently — a '
-                . '"bad message" log line and no other symptom'
+                . 'SourceDataPublishNotifier::BATCH_ID_FIELD as the payload field argument; the '
+                . "class default is 'row_id' (correct for the OpenFGA outbox, wrong here), and "
+                . 'getting this wrong makes every message on this stream look malformed and be '
+                . 'ACKed away silently — a "bad message" log line and no other symptom'
         );
     }
 }

--- a/phpunit_tests/Services/SourceData/PublishSourceDataConsumerScriptTest.php
+++ b/phpunit_tests/Services/SourceData/PublishSourceDataConsumerScriptTest.php
@@ -15,33 +15,54 @@ use PHPUnit\Framework\TestCase;
  * and {@see \LiturgicalCalendar\Api\Services\SourceData\PublishConsumerLoop} is NOT exercised at
  * runtime by this suite.
  *
- * This is a poor substitute for actually running the consumer against a real stream — a source
- * -text assertion cannot catch a wiring mistake that still happens to mention the right string
- * elsewhere, and proves nothing about `PublishConsumerLoop`'s own behaviour. It exists only
- * because the runtime path is unreachable in CI and in local development without Redis, and it
- * is chosen deliberately narrow: the one thing this test pins is the single most dangerous
- * mistake in this file — passing `RedisStreamConsumer`'s DEFAULT payload field ('row_id',
- * correct for the OpenFGA outbox) instead of this stream's actual field ('batch_id', the only
- * key {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier::notify()}
+ * This is a poor substitute for actually running the consumer against a real stream — it proves
+ * nothing about `PublishConsumerLoop`'s own behaviour, and exists only because the runtime path
+ * is unreachable in CI and in local development without Redis. It is chosen deliberately narrow:
+ * the one thing this test pins is the single most dangerous mistake in this file — passing
+ * `RedisStreamConsumer`'s DEFAULT payload field ('row_id', correct for the OpenFGA outbox)
+ * instead of this stream's actual field ('batch_id', the only key
+ * {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier::notify()}
  * writes). Getting that wrong makes every message on this stream look malformed to
  * `RedisStreamConsumer`, which ACKs it away silently — a "bad message" log line and no other
  * symptom — so the consumer would run forever, waking on every notification and doing nothing
  * with any of them, while the cron backstop quietly did all the real work and nothing ever
  * surfaced the difference.
+ *
+ * A plain `assertStringContainsString("'batch_id'", $source)` is NOT enough to pin that: the
+ * entry point's own explanatory comment immediately above the `RedisStreamConsumer` construction
+ * also contains the literal `'batch_id'` (it has to, to explain what the argument is for), so
+ * that assertion would keep passing even if the real sixth argument regressed to `'row_id'` and
+ * the comment above it were left behind, unedited — comments rot independently of code. This was
+ * found during review of this feature (both occurrences existed in the same file at the same
+ * time) and closed by anchoring the regex to the `new RedisStreamConsumer(...)` call's own
+ * argument list instead of the whole file — see the test method's own docblock.
  */
 #[CoversNothing]
 final class PublishSourceDataConsumerScriptTest extends TestCase
 {
+    /**
+     * Anchored to the `new RedisStreamConsumer(...)` CALL, not merely to the file containing the
+     * string `'batch_id'` somewhere. The file's own explanatory comment immediately above that
+     * call also contains the literal `'batch_id'` (it has to, to explain what the argument does)
+     * — so a plain `assertStringContainsString("'batch_id'", $source)` would keep passing even
+     * if the real sixth argument regressed to `'row_id'` and the comment above it were simply
+     * left behind, unedited. That is not a hypothetical: it is exactly what this file looked
+     * like when this test was first written, and the review that caught it is why this regex is
+     * scoped to the constructor call's own argument list instead of the whole source string.
+     */
     public function testTheConsumerEntryPointReadsTheBatchIdField(): void
     {
         $source = file_get_contents(__DIR__ . '/../../../bin/publish-sourcedata-consumer');
         self::assertIsString($source);
 
-        self::assertStringContainsString(
-            "'batch_id'",
+        self::assertMatchesRegularExpression(
+            '/new\s+RedisStreamConsumer\([^)]*\'batch_id\'\s*\)/s',
             $source,
-            "bin/publish-sourcedata-consumer must pass 'batch_id' as RedisStreamConsumer's payload field; "
-                . "the default is 'row_id', which would make every message look malformed and be ACKed away"
+            "bin/publish-sourcedata-consumer's `new RedisStreamConsumer(...)` call must pass "
+                . "'batch_id' as the payload field argument; the class default is 'row_id' "
+                . '(correct for the OpenFGA outbox, wrong here), and getting this wrong makes '
+                . 'every message on this stream look malformed and be ACKed away silently — a '
+                . '"bad message" log line and no other symptom'
         );
     }
 }

--- a/phpunit_tests/Services/SourceData/PublishSourceDataConsumerScriptTest.php
+++ b/phpunit_tests/Services/SourceData/PublishSourceDataConsumerScriptTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `bin/publish-sourcedata-consumer` cannot be run end to end in this environment: it requires
+ * `ext-redis` (see the entry point's own guard, which exits 2 and is exercised manually — see
+ * the phase 3 task 13 report) and, beyond the extension, a reachable Redis server. Neither is
+ * available here, so its wiring to {@see \LiturgicalCalendar\Api\Services\Outbox\RedisStreamConsumer}
+ * and {@see \LiturgicalCalendar\Api\Services\SourceData\PublishConsumerLoop} is NOT exercised at
+ * runtime by this suite.
+ *
+ * This is a poor substitute for actually running the consumer against a real stream — a source
+ * -text assertion cannot catch a wiring mistake that still happens to mention the right string
+ * elsewhere, and proves nothing about `PublishConsumerLoop`'s own behaviour. It exists only
+ * because the runtime path is unreachable in CI and in local development without Redis, and it
+ * is chosen deliberately narrow: the one thing this test pins is the single most dangerous
+ * mistake in this file — passing `RedisStreamConsumer`'s DEFAULT payload field ('row_id',
+ * correct for the OpenFGA outbox) instead of this stream's actual field ('batch_id', the only
+ * key {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier::notify()}
+ * writes). Getting that wrong makes every message on this stream look malformed to
+ * `RedisStreamConsumer`, which ACKs it away silently — a "bad message" log line and no other
+ * symptom — so the consumer would run forever, waking on every notification and doing nothing
+ * with any of them, while the cron backstop quietly did all the real work and nothing ever
+ * surfaced the difference.
+ */
+#[CoversNothing]
+final class PublishSourceDataConsumerScriptTest extends TestCase
+{
+    public function testTheConsumerEntryPointReadsTheBatchIdField(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../../bin/publish-sourcedata-consumer');
+        self::assertIsString($source);
+
+        self::assertStringContainsString(
+            "'batch_id'",
+            $source,
+            "bin/publish-sourcedata-consumer must pass 'batch_id' as RedisStreamConsumer's payload field; "
+                . "the default is 'row_id', which would make every message look malformed and be ACKed away"
+        );
+    }
+}

--- a/phpunit_tests/Services/SourceData/RecordingAuditLogRepository.php
+++ b/phpunit_tests/Services/SourceData/RecordingAuditLogRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Repositories\AuditLogRepository;
+
+/**
+ * Records every `log()` call in memory instead of writing to `audit_log`, so a test can assert
+ * on the exact action/resource/details written without a second read-path query. Mirrors
+ * {@see \LiturgicalCalendar\Tests\Support\CollectingLogger}'s recording-spy shape, applied to
+ * `AuditLogRepository` (not `final`, so overriding `log()` is enough — no HTTP/PSR-3 seam here).
+ */
+final class RecordingAuditLogRepository extends AuditLogRepository
+{
+    /** @var list<array{userId: ?string, action: string, resourceType: string, resourceId: ?string, details: ?array<string, mixed>}> */
+    public array $entries = [];
+
+    public function log(
+        ?string $userId,
+        string $action,
+        string $resourceType,
+        ?string $resourceId = null,
+        ?array $details = null,
+        ?string $ipAddress = null,
+        ?string $userAgent = null,
+        bool $success = true
+    ): string {
+        $this->entries[] = [
+            'userId'       => $userId,
+            'action'       => $action,
+            'resourceType' => $resourceType,
+            'resourceId'   => $resourceId,
+            'details'      => $details,
+        ];
+
+        return 'test-audit-entry-' . count($this->entries);
+    }
+}

--- a/phpunit_tests/Services/SourceData/RecordingTuplePurgeService.php
+++ b/phpunit_tests/Services/SourceData/RecordingTuplePurgeService.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Services\ResourceTuplePurgeServiceInterface;
+
+/**
+ * Records which FGA objects were purged, so a test can assert on the exact object string — the
+ * thing that goes wrong here is a double-qualified id (`roman/roman/US`), and only the string
+ * shows that.
+ */
+final class RecordingTuplePurgeService implements ResourceTuplePurgeServiceInterface
+{
+    /** @var list<string> */
+    public array $purged = [];
+
+    public function __construct(private readonly ?\Throwable $throws = null)
+    {
+    }
+
+    public function purgeForObject(string $fgaObject): int
+    {
+        $this->purged[] = $fgaObject;
+
+        if (null !== $this->throws) {
+            throw $this->throws;
+        }
+
+        return 1;
+    }
+}

--- a/phpunit_tests/Services/SourceData/ScriptedStreamConsumer.php
+++ b/phpunit_tests/Services/SourceData/ScriptedStreamConsumer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Services\Outbox\StreamConsumerInterface;
+
+/**
+ * A stream consumer that replays a fixed script of messages, one `readOnce()` at a time. An
+ * empty array for a tick means "blocked and nothing arrived" — the idle tick.
+ *
+ * This is our own test-only implementation of {@see StreamConsumerInterface} (an interface, not
+ * a `final` class), so doubling it here is ordinary and does not run into the problem described
+ * in {@see PublishConsumerLoopTest}'s own docblock, which is about `PublishRunner` and
+ * `MergePollRunner` — concrete `final` classes used directly by `PublishConsumerLoop`.
+ */
+final class ScriptedStreamConsumer implements StreamConsumerInterface
+{
+    public int $ensureGroupCalls = 0;
+
+    /** @param list<list<string>> $script */
+    public function __construct(private array $script)
+    {
+    }
+
+    public function ensureGroup(): void
+    {
+        $this->ensureGroupCalls++;
+    }
+
+    public function readOnce(int $blockMs, callable $process): void
+    {
+        foreach (array_shift($this->script) ?? [] as $id) {
+            $process($id);
+        }
+    }
+}

--- a/phpunit_tests/Services/SourceData/SourceDataPublishNotifierTest.php
+++ b/phpunit_tests/Services/SourceData/SourceDataPublishNotifierTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SourceDataPublishNotifier::class)]
+final class SourceDataPublishNotifierTest extends TestCase
+{
+    // NO `extension_loaded('redis')` guard on any test in this file, deliberately.
+    // `phpunit_tests/bootstrap.php` loads `stubs/Redis.php` whenever the extension is absent, so
+    // `\Redis` and `\RedisException` always exist under PHPUnit. A skip guard here would silently
+    // skip this class's two most important tests on any machine without ext-redis — which is every
+    // developer machine AND CI.
+
+    public function testANullRedisIsAQuietNoOp(): void
+    {
+        // A self-hoster running cron only has no Redis. This must not throw and must not log.
+        $handler  = new TestHandler();
+        $notifier = new SourceDataPublishNotifier(null, 'litcal:publish-stream', new Logger('t', [$handler]));
+
+        $notifier->notify('batch-1');
+
+        self::assertSame([], $handler->getRecords());
+    }
+
+    public function testItXaddsTheBatchId(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('xAdd')
+            ->with('litcal:publish-stream', '*', ['batch_id' => 'batch-1'])
+            ->willReturn('1-0');
+
+        ( new SourceDataPublishNotifier($redis, 'litcal:publish-stream') )->notify('batch-1');
+    }
+
+    /**
+     * The whole contract: the batch is already durable in Postgres and cron is the backstop, so a
+     * Redis failure costs latency and never correctness. It must never propagate into the approval
+     * the caller has already committed.
+     */
+    public function testARedisFailureIsLoggedAndSwallowed(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())->method('xAdd')->willThrowException(new \RedisException('connection refused'));
+
+        $handler = new TestHandler();
+        ( new SourceDataPublishNotifier($redis, 'litcal:publish-stream', new Logger('t', [$handler])) )
+            ->notify('batch-1');
+
+        self::assertTrue($handler->hasWarningThatContains('sourcedata.redis.notify_failed'));
+    }
+}

--- a/phpunit_tests/Services/SourceData/SourceDataPublisherFactoryTest.php
+++ b/phpunit_tests/Services/SourceData/SourceDataPublisherFactoryTest.php
@@ -162,4 +162,68 @@ final class SourceDataPublisherFactoryTest extends TestCase
             }
         }
     }
+
+    /**
+     * `envString()` must read BOTH layers. Dotenv fills `$_ENV` from the `.env*` files, but PHP CLI
+     * commonly runs with `variables_order` excluding `E`, so a variable set by a systemd
+     * `Environment=` directive reaches `getenv()` and NEVER `$_ENV` — and the change-request
+     * runbook ships exactly such a unit for `bin/publish-sourcedata-consumer`. Reading only `$_ENV`
+     * would silently ignore it and fall back to the defaults.
+     */
+    public function testEnvStringReadsTheProcessEnvironmentWhenEnvArrayIsAbsent(): void
+    {
+        unset($_ENV['LITCAL_ENVSTRING_PROBE']);
+        putenv('LITCAL_ENVSTRING_PROBE=from-getenv');
+
+        try {
+            self::assertSame('from-getenv', SourceDataPublisherFactory::envString('LITCAL_ENVSTRING_PROBE'));
+        } finally {
+            putenv('LITCAL_ENVSTRING_PROBE');
+        }
+    }
+
+    public function testEnvStringPrefersTheEnvArrayAndTrimsIt(): void
+    {
+        $_ENV['LITCAL_ENVSTRING_PROBE'] = '  from-env-array  ';
+        putenv('LITCAL_ENVSTRING_PROBE=from-getenv');
+
+        try {
+            self::assertSame('from-env-array', SourceDataPublisherFactory::envString('LITCAL_ENVSTRING_PROBE'));
+        } finally {
+            unset($_ENV['LITCAL_ENVSTRING_PROBE']);
+            putenv('LITCAL_ENVSTRING_PROBE');
+        }
+    }
+
+    /**
+     * An EMPTY value is treated as unset, in both layers. `.env.example` ships
+     * `REDIS_SOURCEDATA_PUBLISH_CONSUMER` with an empty value and the comment "default: hostname",
+     * so following the documented configuration must reach the fallback, not hand an empty consumer
+     * name to `RedisStreamConsumer`.
+     */
+    public function testEnvStringTreatsAnEmptyValueAsUnsetInBothLayers(): void
+    {
+        $_ENV['LITCAL_ENVSTRING_PROBE'] = '   ';
+        putenv('LITCAL_ENVSTRING_PROBE=');
+
+        try {
+            self::assertSame('', SourceDataPublisherFactory::envString('LITCAL_ENVSTRING_PROBE'));
+        } finally {
+            unset($_ENV['LITCAL_ENVSTRING_PROBE']);
+            putenv('LITCAL_ENVSTRING_PROBE');
+        }
+    }
+
+    public function testEnvStringFallsThroughAnEmptyEnvArrayValueToTheProcessEnvironment(): void
+    {
+        $_ENV['LITCAL_ENVSTRING_PROBE'] = '';
+        putenv('LITCAL_ENVSTRING_PROBE=from-getenv');
+
+        try {
+            self::assertSame('from-getenv', SourceDataPublisherFactory::envString('LITCAL_ENVSTRING_PROBE'));
+        } finally {
+            unset($_ENV['LITCAL_ENVSTRING_PROBE']);
+            putenv('LITCAL_ENVSTRING_PROBE');
+        }
+    }
 }

--- a/phpunit_tests/Services/SourceData/SourceDataPublisherFactoryTest.php
+++ b/phpunit_tests/Services/SourceData/SourceDataPublisherFactoryTest.php
@@ -119,10 +119,19 @@ final class SourceDataPublisherFactoryTest extends TestCase
         });
     }
 
+    /**
+     * Restores BOTH `$_ENV` and `getenv()` for `REDIS_SOCKET`/`REDIS_HOST`, mirroring
+     * {@see withGithubAppEnv()} above and for the identical reason: a variable set only via
+     * `putenv()` (no `$_ENV` entry) would otherwise be left cleared by this test's `finally` for
+     * every test that runs after it in the same process.
+     */
     public function testPublishNotifierIsANoOpWithoutRedisConfiguration(): void
     {
-        $previousSocket = $_ENV['REDIS_SOCKET'] ?? null;
-        $previousHost   = $_ENV['REDIS_HOST'] ?? null;
+        $previousEnvSocket    = $_ENV['REDIS_SOCKET'] ?? null;
+        $previousEnvHost      = $_ENV['REDIS_HOST'] ?? null;
+        $previousGetenvSocket = getenv('REDIS_SOCKET');
+        $previousGetenvHost   = getenv('REDIS_HOST');
+
         unset($_ENV['REDIS_SOCKET'], $_ENV['REDIS_HOST']);
         putenv('REDIS_SOCKET');
         putenv('REDIS_HOST');
@@ -133,11 +142,23 @@ final class SourceDataPublisherFactoryTest extends TestCase
 
             self::assertTrue(true);
         } finally {
-            if (null !== $previousSocket) {
-                $_ENV['REDIS_SOCKET'] = $previousSocket;
+            if (null !== $previousEnvSocket) {
+                $_ENV['REDIS_SOCKET'] = $previousEnvSocket;
             }
-            if (null !== $previousHost) {
-                $_ENV['REDIS_HOST'] = $previousHost;
+            if (null !== $previousEnvHost) {
+                $_ENV['REDIS_HOST'] = $previousEnvHost;
+            }
+
+            if (false === $previousGetenvSocket) {
+                putenv('REDIS_SOCKET');
+            } else {
+                putenv("REDIS_SOCKET={$previousGetenvSocket}");
+            }
+
+            if (false === $previousGetenvHost) {
+                putenv('REDIS_HOST');
+            } else {
+                putenv("REDIS_HOST={$previousGetenvHost}");
             }
         }
     }

--- a/phpunit_tests/Services/SourceData/SourceDataPublisherFactoryTest.php
+++ b/phpunit_tests/Services/SourceData/SourceDataPublisherFactoryTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Services\SourceData\MergePollRunner;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisherFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins the wiring itself, not the runners it builds — those are covered by
+ * {@see PublishRunnerTest} and {@see MergePollRunnerTest}. What matters here is that this class
+ * is the ONE place that wiring lives, and that it gets the load-bearing details right: the
+ * non-throwing logger, a real {@see MergePollRunner} when the GitHub App is configured, a
+ * rejection (not a fatal) for a malformed `GITHUB_REPOSITORY`, and a quiet no-op notifier when
+ * Redis is not configured.
+ */
+#[CoversClass(SourceDataPublisherFactory::class)]
+final class SourceDataPublisherFactoryTest extends TestCase
+{
+    private const GITHUB_APP_ENV_KEYS = [
+        'GITHUB_APP_ID',
+        'GITHUB_APP_INSTALLATION_ID',
+        'GITHUB_APP_PRIVATE_KEY_PATH',
+        'GITHUB_REPOSITORY',
+    ];
+
+    /**
+     * Sets a well-formed GitHub App credential and `GITHUB_REPOSITORY` in BOTH `$_ENV` and
+     * `putenv()`, runs `$callback`, then restores both in a `finally` — regardless of whether
+     * either was previously set. Both are set (not just `$_ENV`) because `GITHUB_REPOSITORY` is
+     * a GitHub Actions built-in injected into every job via the process environment: clearing
+     * only `$_ENV` would leave `getenv()` still serving CI's real value, passing locally and
+     * failing in CI every time.
+     */
+    private function withGithubAppEnv(callable $callback): void
+    {
+        $previousEnv    = [];
+        $previousGetenv = [];
+        foreach (self::GITHUB_APP_ENV_KEYS as $key) {
+            $previousEnv[$key]    = $_ENV[$key] ?? null;
+            $previousGetenv[$key] = getenv($key);
+        }
+
+        $values = [
+            'GITHUB_APP_ID'               => '12345',
+            'GITHUB_APP_INSTALLATION_ID'  => '67890',
+            'GITHUB_APP_PRIVATE_KEY_PATH' => '/nonexistent/github-app.pem',
+            'GITHUB_REPOSITORY'           => 'Liturgical-Calendar/LiturgicalCalendarAPI',
+        ];
+        foreach ($values as $key => $value) {
+            $_ENV[$key] = $value;
+            putenv("{$key}={$value}");
+        }
+
+        try {
+            $callback();
+        } finally {
+            foreach (self::GITHUB_APP_ENV_KEYS as $key) {
+                if (null === $previousEnv[$key]) {
+                    unset($_ENV[$key]);
+                } else {
+                    $_ENV[$key] = $previousEnv[$key];
+                }
+
+                if (false === $previousGetenv[$key]) {
+                    putenv($key);
+                } else {
+                    putenv("{$key}={$previousGetenv[$key]}");
+                }
+            }
+        }
+    }
+
+    /**
+     * The defect this factory exists to prevent, pinned directly. LoggerFactory's default
+     * attaches RequestResponseProcessor, which THROWS on any record whose context lacks
+     * type => request|response — and the runners log batch ids. If this ever regresses, every
+     * log call in production throws, including the ones inside the catch blocks, stranding the
+     * batch.
+     */
+    public function testTheLoggerDoesNotThrowOnARunnerShapedRecord(): void
+    {
+        $logger = ( new SourceDataPublisherFactory() )->logger('publish-sourcedata-test');
+
+        $logger->info('a runner-shaped record', ['batch_id' => 'batch-1', 'exception' => 'RuntimeException']);
+
+        self::assertTrue(true, 'no exception was thrown');
+    }
+
+    public function testMergePollRunnerIsBuiltWhenTheGithubAppIsConfigured(): void
+    {
+        $this->withGithubAppEnv(function (): void {
+            $factory = new SourceDataPublisherFactory();
+            self::assertInstanceOf(
+                MergePollRunner::class,
+                $factory->mergePollRunner($factory->logger('poll-sourcedata-merges-test'))
+            );
+        });
+    }
+
+    /**
+     * GITHUB_REPOSITORY is a GitHub Actions built-in injected into every job as owner/repo.
+     * Clearing only $_ENV leaves getenv() serving it, which passes locally and fails CI — every
+     * time.
+     */
+    public function testAMalformedRepositoryIsRejectedRatherThanFatal(): void
+    {
+        $this->withGithubAppEnv(function (): void {
+            $_ENV['GITHUB_REPOSITORY'] = 'https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI';
+            putenv('GITHUB_REPOSITORY=https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI');
+
+            $factory = new SourceDataPublisherFactory();
+
+            $this->expectException(\InvalidArgumentException::class);
+            $factory->mergePollRunner($factory->logger('poll-sourcedata-merges-test'));
+        });
+    }
+
+    public function testPublishNotifierIsANoOpWithoutRedisConfiguration(): void
+    {
+        $previousSocket = $_ENV['REDIS_SOCKET'] ?? null;
+        $previousHost   = $_ENV['REDIS_HOST'] ?? null;
+        unset($_ENV['REDIS_SOCKET'], $_ENV['REDIS_HOST']);
+        putenv('REDIS_SOCKET');
+        putenv('REDIS_HOST');
+
+        try {
+            // Must not throw, must not connect.
+            ( new SourceDataPublisherFactory() )->publishNotifier()->notify('batch-1');
+
+            self::assertTrue(true);
+        } finally {
+            if (null !== $previousSocket) {
+                $_ENV['REDIS_SOCKET'] = $previousSocket;
+            }
+            if (null !== $previousHost) {
+                $_ENV['REDIS_HOST'] = $previousHost;
+            }
+        }
+    }
+}

--- a/phpunit_tests/Services/SourceData/ThrowingClaimRepository.php
+++ b/phpunit_tests/Services/SourceData/ThrowingClaimRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests\Services\SourceData;
 
 use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\SourceData\PublishClaim;
 
 /**
  * A real, Postgres-backed {@see SourceDataChangeRequestRepository} whose
@@ -23,7 +24,7 @@ final class ThrowingClaimRepository extends SourceDataChangeRequestRepository
     /**
      * @param list<string> $skipBatchIds
      */
-    public function claimNextPublishableBatch(array $skipBatchIds = []): ?string
+    public function claimNextPublishableBatch(array $skipBatchIds = []): ?PublishClaim
     {
         throw new \RuntimeException('simulated outage: claimNextPublishableBatch failed');
     }

--- a/phpunit_tests/Services/SourceData/ThrowingReadStreamConsumer.php
+++ b/phpunit_tests/Services/SourceData/ThrowingReadStreamConsumer.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Services\Outbox\StreamConsumerInterface;
+
+/**
+ * A stream consumer whose `readOnce()` always throws — stands in for a `\RedisException` from
+ * `xReadGroup` (a dropped connection, a Redis restart) reaching {@see \LiturgicalCalendar\Api\Services\SourceData\PublishConsumerLoop::tick()}.
+ *
+ * `ensureGroup()` can also be made to throw, for the same reason on the other collaborator call
+ * that sits outside `PublishConsumerLoop`'s inner try/catch.
+ */
+final class ThrowingReadStreamConsumer implements StreamConsumerInterface
+{
+    public int $ensureGroupCalls = 0;
+
+    public int $readOnceCalls = 0;
+
+    public function __construct(
+        private readonly \Throwable $toThrow = new \RedisException('connection lost'),
+        private readonly bool $throwOnEnsureGroup = false
+    ) {
+    }
+
+    public function ensureGroup(): void
+    {
+        $this->ensureGroupCalls++;
+
+        if ($this->throwOnEnsureGroup) {
+            throw $this->toThrow;
+        }
+    }
+
+    public function readOnce(int $blockMs, callable $process): void
+    {
+        $this->readOnceCalls++;
+
+        throw $this->toThrow;
+    }
+}

--- a/phpunit_tests/Services/SourceData/ThrowingReleaseClaimRepository.php
+++ b/phpunit_tests/Services/SourceData/ThrowingReleaseClaimRepository.php
@@ -19,7 +19,7 @@ use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
  */
 final class ThrowingReleaseClaimRepository extends SourceDataChangeRequestRepository
 {
-    public function releaseClaim(string $batchId): ClaimReleaseOutcome
+    public function releaseClaim(string $batchId, string $token): ClaimReleaseOutcome
     {
         throw new \RuntimeException('simulated outage: releaseClaim failed too');
     }

--- a/phpunit_tests/fixtures/claim-race-worker.php
+++ b/phpunit_tests/fixtures/claim-race-worker.php
@@ -43,12 +43,12 @@ $repo = new SourceDataChangeRequestRepository($pdo);
 
 $consecutiveMisses = 0;
 while ($consecutiveMisses < 3) {
-    $batchId = $repo->claimNextPublishableBatch();
-    if ($batchId === null) {
+    $claim = $repo->claimNextPublishableBatch();
+    if ($claim === null) {
         $consecutiveMisses++;
         usleep(1000);
         continue;
     }
     $consecutiveMisses = 0;
-    echo $batchId, "\n";
+    echo $claim->batchId, "\n";
 }

--- a/scripts/poll-sourcedata-merges.php
+++ b/scripts/poll-sourcedata-merges.php
@@ -1,0 +1,210 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Cron entry point for the source-data merge poller.
+ *
+ * ROLE: polls the rolling pull requests that carry published source-data change-request batches
+ * and records what became of them — merged, closed unmerged, or merged without one of the
+ * batches recorded against it (a review that landed concurrently with a publish). See
+ * {@see \LiturgicalCalendar\Api\Services\SourceData\MergePollRunner} for the polling contract
+ * this relies on, and in particular why this is polling rather than a webhook.
+ *
+ * `bin/publish-sourcedata-consumer` also runs a merge poll, on its own idle tick — this script
+ * is what runs when the consumer is not up, exactly as `scripts/publish-sourcedata.php` is now
+ * the backstop behind that same consumer's stream-driven publish path.
+ *
+ * Exit codes:
+ *   0  Every open pull request was polled, or there were none.
+ *   1  Misconfiguration (GitHub App or GITHUB_REPOSITORY unset OR malformed — GITHUB_REPOSITORY
+ *      must be exactly "owner/repo"), a database failure, OR a poll failed and the run stopped
+ *      early.
+ *
+ * The summary line also reports `reset=N` and `unpollable=N`. `reset` counts batches whose pull
+ * request merged WITHOUT them (a review that landed concurrently with a publish); they are
+ * claimable again and the next publish opens a fresh pull request carrying them, so this is not a
+ * failure — but a value that keeps climbing means publishes and merges are racing routinely.
+ * `unpollable` counts `open` batches with no pull request number, which should always be zero;
+ * a non-zero value is an unexplained state that needs an operator, and it does NOT affect the
+ * exit code, so monitor the line and GET /health, not the exit code alone.
+ *
+ * Usage:
+ *   php scripts/poll-sourcedata-merges.php
+ *
+ * Required environment variables (loaded from .env* files if present):
+ *   DB_HOST, DB_NAME, DB_USER, DB_PASSWORD (DB_PORT optional, defaults to 5432)
+ *   GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, GITHUB_APP_PRIVATE_KEY_PATH, GITHUB_REPOSITORY
+ *
+ * Optional:
+ *   OPENFGA_API_URL, OPENFGA_STORE_ID, OPENFGA_MODEL_ID — when configured, a merged batch that
+ *   deleted a resource has its operational OpenFGA tuples purged; see
+ *   {@see \LiturgicalCalendar\Api\Services\SourceData\MergePollRunner::purgeIfResourceDeletion()}.
+ *   Left unconfigured, merge detection still works — the purge step is a quiet no-op.
+ */
+
+declare(strict_types=1);
+
+// Refuse any entry that is not the CLI — see the identical guard in every other scripts/*.php
+// for why this is not redundant with the shebang line above it.
+if (PHP_SAPI !== 'cli') {
+    http_response_code(404);
+    exit(1);
+}
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+use Dotenv\Dotenv;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisherFactory;
+
+// ---------------------------------------------------------------------------
+// Bootstrap: load environment from .env* files if present. Same chain as
+// bin/reconcile-outbox and scripts/publish-sourcedata.php, for the same reason — CLI's
+// variables_order may not include "E", so a systemd EnvironmentFile or exported shell vars
+// would not reach $_ENV; Dotenv reading the files directly is what makes configuration reach
+// this script regardless.
+// ---------------------------------------------------------------------------
+$projectRoot = dirname(__DIR__);
+Dotenv::createImmutable(
+    $projectRoot,
+    ['.env', '.env.local', '.env.development', '.env.test', '.env.staging', '.env.production'],
+    false
+)->safeLoad();
+
+// ---------------------------------------------------------------------------
+// Logging
+//
+// Set up FIRST, before anything that can fail, so that every failure below has somewhere to
+// go besides stderr — a cron job's stderr is seen only if something is capturing it.
+//
+// includeProcessors: FALSE is baked into SourceDataPublisherFactory::logger() — see that
+// method's own docblock. MergePollRunner logs batch ids and pull request numbers, so without
+// it every log call this run makes — including the ones inside its own catch blocks — would
+// throw under LoggerFactory's default processors. This is the exact defect
+// scripts/publish-sourcedata.php shipped with in phase 2; the factory exists so a second entry
+// point cannot repeat it.
+// ---------------------------------------------------------------------------
+$factory = new SourceDataPublisherFactory();
+try {
+    $logger = $factory->logger('poll-sourcedata-merges');
+} catch (\Throwable $e) {
+    // Nothing to log WITH, so this is the one failure that can only reach stderr. Still not a
+    // raw fatal: an operator gets one line naming the cause instead of a stack trace.
+    fwrite(STDERR, 'Error: could not open the poll-sourcedata-merges log: ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+// Opens the log handlers NOW, under the ordinary umask, before the restrictive one set below
+// around the installation-token cache. Monolog's RotatingFileHandler creates its file lazily
+// on the first record, so without this the log files would be created mid-run at 0600 and
+// become unreadable to anything that is not the cron user — a side effect of protecting the
+// token cache, on files that are not secrets.
+$logger->info('poll-sourcedata-merges run starting.');
+
+// ---------------------------------------------------------------------------
+// Dependency wiring
+//
+// All environment-variable reads (the GitHub App credential, GITHUB_REPOSITORY, OpenFGA, and
+// their optional companions) are routed through SourceDataPublisherFactory, in src/, not read
+// directly here — see scripts/publish-sourcedata.php's identical comment for why.
+//
+// The database bootstrap is wrapped for the same reason the run below is: MergePollRunner
+// catches every DB failure that happens DURING a run, but a database that is already down when
+// the cron job starts fails here instead — earlier than anything MergePollRunner can see — and
+// would escape as an uncaught RuntimeException with no log entry and no summary line.
+// ---------------------------------------------------------------------------
+try {
+    $factory->repository();
+} catch (\Throwable $e) {
+    $logger->error(
+        'poll-sourcedata-merges could not reach the database; nothing was polled.',
+        ['exception' => $e::class, 'message' => $e->getMessage()]
+    );
+    fwrite(STDERR, 'Error: database unavailable: ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Installation-token cache — the umask window
+//
+// SourceDataPublisherFactory::mergePollRunner() below builds a filesystem-backed cache for the
+// GitHub App installation token. It does NOT touch the process umask, deliberately: the token
+// is fetched LAZILY, the first time the built GitHubGitDataClient actually talks to GitHub,
+// which happens inside runOnce() below, not inside the factory call. So the restrictive umask
+// has to stay in effect across BOTH the factory call and the run that follows it, and this
+// script — the caller — is what owns that window. See
+// scripts/publish-sourcedata.php's identical comment for the full rationale (what lands on
+// disk, and why the umask and the factory's own directory chmod are independent layers).
+// ---------------------------------------------------------------------------
+$previousUmask = umask(0o077);
+
+try {
+    $runner = $factory->mergePollRunner($logger);
+} catch (\Throwable $e) {
+    // Unconfigured GitHub App or GITHUB_REPOSITORY: merged and closed pull requests accumulate
+    // unpolled — silently, since nothing about an `open` batch looks like an error on its own.
+    // Fail loudly here instead.
+    //
+    // \Throwable, not \RuntimeException: SourceDataPublisherFactory::mergePollRunner() throws
+    // InvalidArgumentException — a LogicException, not a RuntimeException — when
+    // GITHUB_REPOSITORY is set but is not an "owner/repo" pair, which is one pasted repository
+    // URL or one trailing slash away for any operator. A narrower catch is what made phase 2's
+    // publisher exit 255 with nothing logged past "run starting"; this script does not repeat
+    // that mistake for its own configuration surface.
+    umask($previousUmask);
+    // The class goes in the context because this catch is \Throwable: the reachable surface
+    // today is only the two configuration exceptions, but that is a property of
+    // mergePollRunner() not doing I/O beyond the token cache directory, not a guarantee.
+    // Without it, a future TypeError here would read as "not configured" and send an operator
+    // auditing four correct variables.
+    $logger->error(
+        'poll-sourcedata-merges is not configured; nothing was polled.',
+        ['exception' => $e::class, 'message' => $e->getMessage()]
+    );
+    fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Run
+//
+// Wrapped for the same reason MergePollRunner wraps every one of its own DB and GitHub calls: a
+// failure that escapes here is a raw PHP fatal on a cron job's stderr, with no summary line and
+// no structured log entry. Nothing inside runOnce() is expected to throw (it catches
+// \Throwable at every fallible call and reports the failure in its own result), which is
+// exactly why an exception reaching this point deserves to be reported rather than splashed.
+// ---------------------------------------------------------------------------
+try {
+    $result = $runner->runOnce();
+} catch (\Throwable $e) {
+    umask($previousUmask);
+    $logger->error(
+        'poll-sourcedata-merges run failed with an unhandled exception.',
+        ['exception' => $e::class, 'message' => $e->getMessage()]
+    );
+    fwrite(STDERR, 'Error: ' . $e::class . ': ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+umask($previousUmask);
+
+fwrite(
+    STDOUT,
+    sprintf(
+        "poll-sourcedata-merges merged=%d closed=%d reset=%d unpollable=%d stopped_on_failure=%s\n",
+        $result->merged,
+        $result->closed,
+        $result->reset,
+        $result->unpollable,
+        $result->stoppedOnFailure ? 'true' : 'false'
+    )
+);
+
+// A stopped-early run means the rest of the open pull requests were not polled this tick — that
+// must be visible in the exit code, not just a log line nothing watches, or a stale credential
+// or a GitHub outage silently stops merge detection indefinitely.
+//
+// `reset` and `unpollable` deliberately do NOT affect the exit code, for the same reason
+// `parked` does not in scripts/publish-sourcedata.php: both are states an operator should
+// monitor over time (via this summary line and GET /health), not failures of THIS run — a run
+// that resets a batch, or reports a stubbornly non-zero `unpollable`, has still done its job.
+exit($result->stoppedOnFailure ? 1 : 0);

--- a/scripts/publish-sourcedata.php
+++ b/scripts/publish-sourcedata.php
@@ -2,7 +2,14 @@
 <?php
 
 /**
- * Cron entry point for the source-data change-request publisher (phase 2).
+ * Cron entry point for the source-data change-request publisher.
+ *
+ * ROLE (phase 3): this is now the BACKSTOP behind `bin/publish-sourcedata-consumer`, the Redis
+ * stream consumer that reacts to an approval within seconds. This script exists for what the
+ * stream cannot guarantee — a lost `XADD` (see
+ * {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier}, which never
+ * throws and so can silently lose a notification) or a dead consumer process — so it still runs
+ * on its own cron schedule, just less urgently than in phase 2, when it was the only path.
  *
  * One-shot: reclaims any batch stranded `queued` past the grace period, then claims up to a
  * limit of approved-and-unpublished batches and publishes each as a commit plus rolling pull
@@ -57,13 +64,7 @@ if (PHP_SAPI !== 'cli') {
 require_once dirname(__DIR__) . '/vendor/autoload.php';
 
 use Dotenv\Dotenv;
-use GuzzleHttp\Client as GuzzleClient;
-use LiturgicalCalendar\Api\Database\Connection;
-use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
-use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
-use LiturgicalCalendar\Api\Services\SourceData\PublishRunner;
-use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisherFactory;
 
 // ---------------------------------------------------------------------------
 // Bootstrap: load environment from .env* files if present. Same chain as
@@ -96,18 +97,15 @@ if (isset($argv[1])) {
 //
 // Set up FIRST, before anything that can fail, so that every failure below has somewhere to
 // go besides stderr — a cron job's stderr is seen only if something is capturing it.
+//
+// includeProcessors: FALSE is baked into SourceDataPublisherFactory::logger() — see that
+// method's own docblock for why it is load-bearing rather than cosmetic. This is precisely the
+// wiring that used to live here, inline, and was the phase 2 defect: a script CONSTRUCTING
+// what every test INJECTED.
 // ---------------------------------------------------------------------------
+$factory = new SourceDataPublisherFactory();
 try {
-    // includeProcessors: FALSE — the sixth argument, and it is load-bearing rather than
-    // cosmetic. LoggerFactory's default attaches RequestResponseProcessor, which THROWS a
-    // RuntimeException for any record whose context does not carry type => request|response.
-    // PublishRunner logs batch ids and exception classes, so with the default every single
-    // log call it makes — including the ones inside its catch blocks — would throw from
-    // inside the failure handling, before releaseClaim() ever ran, stranding the batch and
-    // killing the process. Every other non-HTTP caller of this factory passes false for the
-    // same reason; only the HTTP error middleware, which really does log requests and
-    // responses, passes true.
-    $logger = LoggerFactory::create('publish-sourcedata', null, 30, false, true, false);
+    $logger = $factory->logger('publish-sourcedata');
 } catch (\Throwable $e) {
     // Nothing to log WITH, so this is the one failure that can only reach stderr. Still not a
     // raw fatal: an operator gets one line naming the cause instead of a stack trace.
@@ -115,21 +113,21 @@ try {
     exit(1);
 }
 
-// Opens the log handlers NOW, under the ordinary umask, before the restrictive one below.
-// Monolog's RotatingFileHandler creates its file lazily on the first record, so without this
-// the log files would be created mid-run at 0600 and become unreadable to anything that is not
-// the cron user — a side effect of protecting the token cache, on files that are not secrets.
+// Opens the log handlers NOW, under the ordinary umask, before the restrictive one set below
+// around the installation-token cache. Monolog's RotatingFileHandler creates its file lazily
+// on the first record, so without this the log files would be created mid-run at 0600 and
+// become unreadable to anything that is not the cron user — a side effect of protecting the
+// token cache, on files that are not secrets.
 $logger->info('publish-sourcedata run starting.', ['limit' => $limit]);
 
 // ---------------------------------------------------------------------------
 // Dependency wiring
 //
 // All environment-variable reads (the GitHub App credential, GITHUB_REPOSITORY, and their
-// optional companions) are routed through SourceDataPublisher::fromEnv() /
-// GitHubAppAuth::fromEnv() in src/, not read directly here. phpstan.neon.dist scans
-// `paths: [src]` only, so a script-level `(string) $_ENV[...]` blind cast would be invisible
-// to `composer analyse`; going through src/ keeps this script covered by the same PHPStan
-// level 10 pass as everything else.
+// optional companions) are routed through SourceDataPublisherFactory, in src/, not read
+// directly here. phpstan.neon.dist scans `paths: [src]` only, so a script-level
+// `(string) $_ENV[...]` blind cast would be invisible to `composer analyse`; going through
+// src/ keeps this script covered by the same PHPStan level 10 pass as everything else.
 //
 // The database bootstrap is wrapped for the same reason the run below is, and it is the
 // SIBLING of that one rather than a duplicate of it: PublishRunner catches every DB failure
@@ -138,8 +136,7 @@ $logger->info('publish-sourcedata run starting.', ['limit' => $limit]);
 // uncaught RuntimeException with no log entry and no summary line.
 // ---------------------------------------------------------------------------
 try {
-    $pdo  = Connection::getInstance();
-    $repo = new SourceDataChangeRequestRepository($pdo);
+    $factory->repository();
 } catch (\Throwable $e) {
     $logger->error(
         'publish-sourcedata could not reach the database; no batch was claimed.',
@@ -149,77 +146,51 @@ try {
     exit(1);
 }
 
-// Explicit timeouts, not Guzzle's default (no timeout at all — a hung TCP handshake or a
-// GitHub response that never completes would otherwise run indefinitely). This is what keeps
-// PublishRunner's "still running" and "abandoned" distinguishable at all: without a bound
-// here, a whole publish can silently outlive PublishRunner::DEFAULT_GRACE_SECONDS, making it
-// the common case — not the rare one — that a second cron tick reclaims a batch whose first
-// publish attempt is still genuinely in flight (see PublishRunner's class docblock, "A merely
-// SLOW process is not a dead one"). connect_timeout: 10s is generous for TLS+DNS to
-// api.github.com. timeout: 30s per request is generous for any single Git Data call.
-//
-// The quantity that must stay under the grace period is the WHOLE publish, not one request.
-// A batch issues one createBlob per changed file, serially, then six fixed calls. The widest
-// batch this repository can produce is the decrees corpus — decrees.json plus 14 i18n locales
-// plus 7 lectionary locales — so 22 blob writes plus 6 is 28 requests, or 840s if every one
-// hit its full ceiling. That is dozens of requests, not a handful, and it is why the grace
-// period is 1800 rather than the 600 an earlier draft of this comment assumed. If either the
-// timeout here or the widest batch grows, the grace period must grow with them.
-$httpClient = new GuzzleClient(['connect_timeout' => 10, 'timeout' => 30]);
-
-
 // ---------------------------------------------------------------------------
-// Installation-token cache
+// Installation-token cache — the umask window
 //
-// Installation tokens are cached (PSR-6) for 50 minutes against GitHub's one-hour token life —
-// see GitHubAppAuth's own class docblock. A cron-invoked, short-lived CLI process needs that
-// cache to be filesystem-backed, not in-memory, or every single invocation would re-authenticate.
+// SourceDataPublisherFactory::publishRunner() below builds a filesystem-backed cache for the
+// GitHub App installation token (see that factory's own docblocks for the Guzzle timeout and
+// token-cache rationale — the object construction itself now lives there). What it does NOT do
+// is touch the process umask, deliberately: the token is fetched LAZILY, the first time the
+// built PublishRunner's publisher actually talks to GitHub, which happens inside runOnce()
+// below, not inside the factory call. So the restrictive umask has to stay in effect across
+// BOTH the factory call and the run that follows it, and this script — the caller — is what
+// owns that window.
 //
 // What lands on disk is a BEARER CREDENTIAL carrying `contents: write` and
-// `pull_requests: write` on the repository, valid for up to 50 minutes. The private key it is
-// derived from is handled carefully (a path in the environment, never the key bytes; never
-// logged); the token derived from it must be too, and Symfony's FilesystemAdapter creates its
-// directory and its entries with 0777/0666 masked by the process umask — 0755/0644 under the
-// usual 0022, i.e. readable by every local user.
-//
-// So: a restrictive umask for the whole window in which cache entries are written (the token
-// is fetched lazily, during the run, not here), plus an explicit chmod of the namespace
-// directory, which also repairs a directory an earlier, laxer run created. Either alone would
-// do — 0600 entries are unreadable, and entries of any mode inside a 0700 directory are
-// unreachable — but they fail in different ways (a umask does nothing to what already exists;
-// a directory mode can be widened by a well-meaning `chmod -R`), so both are set.
+// `pull_requests: write` on the repository, valid for up to 50 minutes. Symfony's
+// FilesystemAdapter creates its directory and its entries with 0777/0666 masked by the process
+// umask — 0755/0644 under the usual 0022, i.e. readable by every local user, unless the umask
+// is narrowed first. `publishRunner()`'s own explicit chmod of the cache directory is the
+// second, independent layer (entries inside a 0700 directory are unreachable regardless of
+// their own mode) but is a no-op on the very first run, before the directory exists — this
+// umask is what protects exactly that gap.
 // ---------------------------------------------------------------------------
 $previousUmask = umask(0o077);
-$tokenCache    = new FilesystemAdapter('github_app_tokens', 0, $projectRoot . '/cache');
-$tokenCacheDir = $projectRoot . '/cache/github_app_tokens';
-if (is_dir($tokenCacheDir) && !@chmod($tokenCacheDir, 0o700)) {
-    $logger->warning(
-        'Could not restrict permissions on the GitHub App token cache directory; the '
-            . 'installation token it holds may be readable by other local users.',
-        ['directory' => $tokenCacheDir]
-    );
-}
 
 try {
-    $publisher = SourceDataPublisher::fromEnv($repo, $httpClient, $tokenCache);
+    $runner = $factory->publishRunner($logger);
 } catch (\Throwable $e) {
     // Unconfigured GitHub App or GITHUB_REPOSITORY: approved batches accumulate unpublished —
     // silently, since nothing about that state looks like an error to an editor. Fail loudly
     // here instead.
     //
     // \Throwable, not \RuntimeException, and this is the difference between an alarm and
-    // silence. fromEnv() also throws InvalidArgumentException — a LogicException, not a
-    // RuntimeException — when GITHUB_REPOSITORY is set but is not an "owner/repo" pair, which
-    // is one pasted repository URL or one trailing slash away for any operator. A narrower
-    // catch let that escape as an uncaught fatal: exit 255 (a code this script's own table does
-    // not list), a stack trace on a cron job's stderr that usually goes nowhere, and not one
-    // log line past "run starting". Same reasoning as the two sibling wraps around this one:
-    // whatever goes wrong, the operator gets a message and an exit code, never a stack trace.
+    // silence. SourceDataPublisherFactory::publishRunner() also throws InvalidArgumentException
+    // — a LogicException, not a RuntimeException — when GITHUB_REPOSITORY is set but is not an
+    // "owner/repo" pair, which is one pasted repository URL or one trailing slash away for any
+    // operator. A narrower catch let that escape as an uncaught fatal: exit 255 (a code this
+    // script's own table does not list), a stack trace on a cron job's stderr that usually goes
+    // nowhere, and not one log line past "run starting". Same reasoning as the two sibling
+    // wraps around this one: whatever goes wrong, the operator gets a message and an exit code,
+    // never a stack trace.
     umask($previousUmask);
     // The class goes in the context because this catch is now \Throwable: the reachable
     // surface today is only the two configuration exceptions, but that is a property of
-    // fromEnv() not doing I/O, not a guarantee. Without it, a future TypeError here would
-    // read as "not configured" and send an operator auditing four correct variables.
+    // publishRunner() not doing I/O beyond the token cache directory, not a guarantee. Without
+    // it, a future TypeError here would read as "not configured" and send an operator auditing
+    // four correct variables.
     $logger->error(
         'publish-sourcedata is not configured; nothing was published.',
         ['exception' => $e::class, 'message' => $e->getMessage()]
@@ -227,8 +198,6 @@ try {
     fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");
     exit(1);
 }
-
-$runner = new PublishRunner($repo, $publisher, logger: $logger);
 
 // ---------------------------------------------------------------------------
 // Run

--- a/src/Enum/ClaimReleaseOutcome.php
+++ b/src/Enum/ClaimReleaseOutcome.php
@@ -9,14 +9,16 @@ namespace LiturgicalCalendar\Api\Enum;
  * actually observed, as opposed to how many rows it happened to touch.
  *
  * This type exists because a row count cannot answer the only question the caller has. A
- * release is guarded on `publication_status = 'queued'`, so it affects zero rows for
- * MULTIPLE, semantically opposite reasons:
+ * release is guarded on `publication_status = 'queued' AND publish_claim_token = :token`, so
+ * it affects zero rows for MULTIPLE, semantically opposite reasons:
  *
  * - the batch is `open`/`merged`/`closed` — another runner genuinely published it, and this
  *   runner's failed attempt is a harmless duplicate of finished work;
  * - the batch is `none` — another runner's publish failed too (a GitHub outage fails every
  *   runner identically), or {@see \LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository::reclaimStaleClaims()}
  *   released it. Nothing is published anywhere, and the failure is real;
+ * - the batch is still `queued`, but under a DIFFERENT claim token — another runner holds the
+ *   live claim right now, and this caller's own claim was already reclaimed out from under it;
  * - the batch is gone entirely.
  *
  * Collapsing those into `0` and reading it as "already published elsewhere" is exactly the

--- a/src/Enum/ClaimReleaseOutcome.php
+++ b/src/Enum/ClaimReleaseOutcome.php
@@ -62,11 +62,30 @@ enum ClaimReleaseOutcome: string
     case BATCH_MISSING = 'batch_missing';
 
     /**
+     * The batch is still `queued`, but under a DIFFERENT claim token — another runner holds it.
+     *
+     * Semantically distinct from both neighbours, which is why it is not folded into either.
+     * Not {@see SETTLED_ELSEWHERE}: nothing is published, so this is no evidence the work is
+     * done. Not {@see NOT_CLAIMED}: the batch is not lying around unclaimed, it is actively
+     * being published by someone else.
+     *
+     * Reached by the sequence `releaseClaim()`'s docblock describes: this runner was merely
+     * slow, the grace period elapsed, `reclaimStaleClaims()` freed the batch, and another
+     * runner claimed it before this runner's own doomed call returned. The release correctly
+     * does nothing — and, the point of the token, spends none of the batch's bounded attempts
+     * on a claim it does not hold.
+     */
+    case CLAIM_LOST = 'claim_lost';
+
+    /**
      * True when the batch's work is known to be finished on GitHub — the ONLY outcome a failed
      * publish attempt may treat as a non-failure.
      */
     public function isSettled(): bool
     {
+        // CLAIM_LOST is not settled: nothing is published, another runner simply holds the
+        // live claim. Falls through to the default `false` below, same as NOT_CLAIMED and
+        // BATCH_MISSING.
         return self::SETTLED_ELSEWHERE === $this;
     }
 }

--- a/src/Handlers/Admin/ChangeRequestAdminHandler.php
+++ b/src/Handlers/Admin/ChangeRequestAdminHandler.php
@@ -101,11 +101,11 @@ final class ChangeRequestAdminHandler extends AbstractHandler
                 try {
                     $redis = new \Redis();
                     if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
-                        $redis->connect((string) $_ENV['REDIS_SOCKET']);
+                        $redis->connect((string) $_ENV['REDIS_SOCKET'], 0, 2.0); // 2 second timeout
                     } else {
                         $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
                         $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
-                        $redis->connect($redisHost, $redisPort);
+                        $redis->connect($redisHost, $redisPort, 2.0); // 2 second timeout
                     }
                     if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
                         $redis->auth((string) $_ENV['REDIS_PASSWORD']);

--- a/src/Handlers/Admin/ChangeRequestAdminHandler.php
+++ b/src/Handlers/Admin/ChangeRequestAdminHandler.php
@@ -23,6 +23,7 @@ use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
 use LiturgicalCalendar\Api\Services\ChangeRequestReview;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Api\Services\ResourceAdminService;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -53,6 +54,7 @@ final class ChangeRequestAdminHandler extends AbstractHandler
 
     private ?SourceDataChangeRequestRepository $repository;
     private ?AuditLogRepository $auditLog = null;
+    private ?SourceDataPublishNotifier $publishNotifier;
 
     /**
      * @param string[] $requestPathParams Segments after `/admin`. Index 0 is
@@ -62,12 +64,14 @@ final class ChangeRequestAdminHandler extends AbstractHandler
     public function __construct(
         array $requestPathParams = [],
         ?SourceDataChangeRequestRepository $repository = null,
-        ?OpenFgaClient $fgaClient = null
+        ?OpenFgaClient $fgaClient = null,
+        ?SourceDataPublishNotifier $publishNotifier = null
     ) {
         parent::__construct($requestPathParams);
 
-        $this->repository = $repository;
-        $this->fgaClient  = $fgaClient;
+        $this->repository      = $repository;
+        $this->fgaClient       = $fgaClient;
+        $this->publishNotifier = $publishNotifier;
 
         $this->allowedRequestMethods      = [RequestMethod::GET, RequestMethod::POST];
         $this->allowedAcceptHeaders       = [AcceptHeader::JSON];
@@ -81,6 +85,41 @@ final class ChangeRequestAdminHandler extends AbstractHandler
             $this->repository = new SourceDataChangeRequestRepository(Connection::getInstance());
         }
         return $this->repository;
+    }
+
+    /**
+     * Lazily resolved the same way {@see getRepository()} is: production builds it from
+     * env on first use, tests inject one via the constructor. Redis resolution mirrors
+     * {@see \LiturgicalCalendar\Api\Handlers\Admin\AccessRequestAdminHandler::getOutboxNotifier()} —
+     * null when ext-redis is missing or neither `REDIS_SOCKET` nor `REDIS_HOST` is set.
+     */
+    private function getPublishNotifier(): SourceDataPublishNotifier
+    {
+        if ($this->publishNotifier === null) {
+            $redis = null;
+            if (extension_loaded('redis') && ( isset($_ENV['REDIS_HOST']) || isset($_ENV['REDIS_SOCKET']) )) {
+                try {
+                    $redis = new \Redis();
+                    if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
+                        $redis->connect((string) $_ENV['REDIS_SOCKET']);
+                    } else {
+                        $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
+                        $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
+                        $redis->connect($redisHost, $redisPort);
+                    }
+                    if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
+                        $redis->auth((string) $_ENV['REDIS_PASSWORD']);
+                    }
+                } catch (\Throwable) {
+                    $redis = null; // Best-effort; fall back to PG-only durability.
+                }
+            }
+            $streamName            = is_string($_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM'] ?? null)
+                ? $_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM']
+                : 'litcal:sourcedata-publish-stream';
+            $this->publishNotifier = new SourceDataPublishNotifier($redis, $streamName);
+        }
+        return $this->publishNotifier;
     }
 
     private function getAuditLog(): AuditLogRepository
@@ -309,6 +348,12 @@ final class ChangeRequestAdminHandler extends AbstractHandler
         }
 
         $this->audit('change_request.approve', $sub, $batchId, $firstRow, []);
+
+        // AFTER the status UPDATE has committed, never before: a consumer that wakes on this
+        // message claims from Postgres, so announcing an approval the database has not recorded
+        // would send it looking for work that is not yet there. Same ordering constraint the
+        // OpenFGA outbox already documents.
+        $this->getPublishNotifier()->notify($batchId);
 
         return $this->encodeResponseBody($response, [
             'success'  => true,

--- a/src/Handlers/Auth/NotificationsHandler.php
+++ b/src/Handlers/Auth/NotificationsHandler.php
@@ -23,8 +23,17 @@ use Psr\Http\Message\ServerRequestInterface;
  * - POST /auth/notifications/seen   — Mark inbox seen (bookmark).
  *
  * OIDC-gated via OidcAuthMiddleware (wired in Router.php). The user
- * identifier is the Zitadel sub from oidc_user, which keys both the
- * access_requests query and the user_notification_state row.
+ * identifier is the Zitadel sub from oidc_user, which keys the
+ * access_requests query, the sourcedata_change_requests query, and the
+ * user_notification_state row.
+ *
+ * The GET response's `items` is a DISCRIMINATED list: each item carries a
+ * `type` of either `access_request_reviewed` (an editor's own access
+ * request was approved, rejected or revoked) or `change_request_published`
+ * (one of an editor's submitted source-data change-request batches merged
+ * or was closed, unmerged, on GitHub). The two shapes share only `type` and
+ * `unread` — clients MUST switch on `type` before reading any other key.
+ * See UserNotificationRepository::fetchInbox() for the full item shapes.
  */
 final class NotificationsHandler extends AbstractHandler
 {

--- a/src/Handlers/Concerns/WritesSourceData.php
+++ b/src/Handlers/Concerns/WritesSourceData.php
@@ -58,9 +58,9 @@ trait WritesSourceData
     /**
      * @return array<string, mixed> Always carries a `disposition` key.
      */
-    protected function commitStagedFiles(ChangeResource $resource): array
+    protected function commitStagedFiles(ChangeResource $resource, bool $deletesResource = false): array
     {
-        return $this->sourceDataWriter()->commit($resource);
+        return $this->sourceDataWriter()->commit($resource, $deletesResource);
     }
 
     /**

--- a/src/Handlers/Concerns/WritesSourceData.php
+++ b/src/Handlers/Concerns/WritesSourceData.php
@@ -12,6 +12,7 @@ use LiturgicalCalendar\Api\Services\ChangeResource;
 use LiturgicalCalendar\Api\Services\ResourceAdminService;
 use LiturgicalCalendar\Api\Services\SourceData\ChangeRequestSourceDataWriter;
 use LiturgicalCalendar\Api\Services\SourceData\DiskSourceDataWriter;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriter;
 use Psr\Http\Message\ServerRequestInterface;
@@ -29,6 +30,8 @@ use Psr\Log\LoggerInterface;
 trait WritesSourceData
 {
     private ?SourceDataWriter $sourceDataWriter = null;
+
+    private ?SourceDataPublishNotifier $sourceDataPublishNotifier = null;
 
     /** @var array<string, mixed>|null */
     private ?array $submitterOidcUser = null;
@@ -131,7 +134,9 @@ trait WritesSourceData
             ? new ChangeRequestSourceDataWriter(
                 new SourceDataChangeRequestRepository(),
                 new ChangeRequestReview(new ResourceAdminService($this->getFgaClient())),
-                $this->submitterOidcUser ?? []
+                $this->submitterOidcUser ?? [],
+                null,
+                $this->sourceDataPublishNotifier()
             )
             : new DiskSourceDataWriter();
     }
@@ -139,5 +144,44 @@ trait WritesSourceData
     private function sourceDataWriteLogger(): LoggerInterface
     {
         return $this->sourceDataWriteLogger ??= LoggerFactory::create('audit', null, 90, false, true, false);
+    }
+
+    /**
+     * Lazily resolved, mirroring {@see \LiturgicalCalendar\Api\Handlers\Admin\AccessRequestAdminHandler::getOutboxNotifier()}:
+     * null when ext-redis is missing or neither `REDIS_SOCKET` nor `REDIS_HOST` is configured, which
+     * is the ordinary state for a self-hoster (both are commented out in `.env.example`). A null
+     * `\Redis` makes {@see SourceDataPublishNotifier::notify()} a quiet no-op, so this never blocks
+     * the auto-approval path it feeds — it only costs the latency of waiting for cron instead.
+     */
+    private function sourceDataPublishNotifier(): SourceDataPublishNotifier
+    {
+        if ($this->sourceDataPublishNotifier !== null) {
+            return $this->sourceDataPublishNotifier;
+        }
+
+        $redis = null;
+        if (extension_loaded('redis') && ( isset($_ENV['REDIS_HOST']) || isset($_ENV['REDIS_SOCKET']) )) {
+            try {
+                $redis = new \Redis();
+                if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
+                    $redis->connect((string) $_ENV['REDIS_SOCKET']);
+                } else {
+                    $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
+                    $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
+                    $redis->connect($redisHost, $redisPort);
+                }
+                if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
+                    $redis->auth((string) $_ENV['REDIS_PASSWORD']);
+                }
+            } catch (\Throwable) {
+                $redis = null; // Best-effort; fall back to PG-only durability.
+            }
+        }
+
+        $streamName = is_string($_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM'] ?? null)
+            ? $_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM']
+            : 'litcal:sourcedata-publish-stream';
+
+        return $this->sourceDataPublishNotifier = new SourceDataPublishNotifier($redis, $streamName);
     }
 }

--- a/src/Handlers/Concerns/WritesSourceData.php
+++ b/src/Handlers/Concerns/WritesSourceData.php
@@ -164,11 +164,11 @@ trait WritesSourceData
             try {
                 $redis = new \Redis();
                 if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
-                    $redis->connect((string) $_ENV['REDIS_SOCKET']);
+                    $redis->connect((string) $_ENV['REDIS_SOCKET'], 0, 2.0); // 2 second timeout
                 } else {
                     $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
                     $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
-                    $redis->connect($redisHost, $redisPort);
+                    $redis->connect($redisHost, $redisPort, 2.0); // 2 second timeout
                 }
                 if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
                     $redis->auth((string) $_ENV['REDIS_PASSWORD']);

--- a/src/Handlers/RegionalDataHandler.php
+++ b/src/Handlers/RegionalDataHandler.php
@@ -1076,7 +1076,7 @@ final class RegionalDataHandler extends AbstractHandler
                 $this->stageFile($file, ChangeOperation::DELETE, null);
             }
 
-            $changeRequest = $this->commitStagedFiles($this->changeResourceForRequest());
+            $changeRequest = $this->commitStagedFiles($this->changeResourceForRequest(), deletesResource: true);
 
             // The physical files (and therefore the folders that contain them) are
             // only actually gone once the deletion lands on disk. In queue mode the

--- a/src/Handlers/TestsHandler.php
+++ b/src/Handlers/TestsHandler.php
@@ -267,7 +267,7 @@ final class TestsHandler extends AbstractHandler
         }
 
         $this->stageFile($this->testFilePath($testName), ChangeOperation::DELETE, null);
-        $changeRequest = $this->commitStagedFiles($this->changeResourceForTest($scope));
+        $changeRequest = $this->commitStagedFiles($this->changeResourceForTest($scope), deletesResource: true);
 
         // Best-effort purge of operational (editor/viewer) tuples orphaned by the
         // deletion. Gated on the deletion having actually landed: in queue mode the

--- a/src/Health.php
+++ b/src/Health.php
@@ -5345,13 +5345,19 @@ class Health implements MessageComponentInterface
      * database that is down must degrade this block to zero, not break the endpoint monitoring
      * relies on.
      *
-     * @return array{status: 'ok'|'warning', message: string, parked_batches: int}
+     * It also reports `open_batches` and `oldest_open_age_seconds` ({@see
+     * SourceDataChangeRequestRepository::openBatchStats()}), and warns once the oldest open
+     * batch outlives {@see STALE_OPEN_BATCH_SECONDS} — see that constant for why an open batch
+     * is not itself a problem and what the age threshold actually catches.
+     *
+     * @return array{status: 'ok'|'warning', message: string, parked_batches: int, open_batches: int, oldest_open_age_seconds: int}
      */
     public static function buildSourceDataPublisherStatus(): array
     {
         $queueModeOn = SourceDataWriteMode::changeRequestsEnabled();
         $configured  = SourceDataPublisher::isConfigured();
         $parked      = self::parkedChangeRequestBatches();
+        $open        = self::openChangeRequestBatchStats();
 
         if ($queueModeOn && !$configured) {
             return [
@@ -5361,6 +5367,7 @@ class Health implements MessageComponentInterface
                     . 'in the form owner/repo — a value that is set but malformed counts as unconfigured, because no '
                     . 'run can publish with it); approved change requests are accumulating unpublished',
                 'parked_batches' => $parked,
+                ...$open,
             ];
         }
 
@@ -5375,6 +5382,23 @@ class Health implements MessageComponentInterface
                     SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS
                 ),
                 'parked_batches' => $parked,
+                ...$open,
+            ];
+        }
+
+        if ($open['oldest_open_age_seconds'] > self::STALE_OPEN_BATCH_SECONDS) {
+            return [
+                'status'         => 'warning',
+                'message'        => sprintf(
+                    'A source data change request batch has been awaiting a merge decision for %d days. Either a '
+                        . 'reviewer has not reached its pull request, or nothing is detecting merges — check that '
+                        . 'scripts/poll-sourcedata-merges.php runs on a schedule, or that the publish consumer is up. '
+                        . 'An undetected merge is invisible from this side: it looks exactly like an unreviewed one, '
+                        . 'and every editor waiting on it is told it is still open',
+                    intdiv($open['oldest_open_age_seconds'], 86400)
+                ),
+                'parked_batches' => $parked,
+                ...$open,
             ];
         }
 
@@ -5386,6 +5410,7 @@ class Health implements MessageComponentInterface
                     : 'source data publisher is configured, but change request queue mode is off, so there is '
                         . 'nothing to publish',
                 'parked_batches' => $parked,
+                ...$open,
             ];
         }
 
@@ -5394,8 +5419,25 @@ class Health implements MessageComponentInterface
             'message'        => 'source data publisher is not configured (change request queue mode is off, so there is '
                 . 'nothing to publish)',
             'parked_batches' => $parked,
+            ...$open,
         ];
     }
+
+    /**
+     * How long a batch may sit `open` before `/health` says something.
+     *
+     * Thirty days, deliberately generous, because this number does NOT measure a fault: a pull
+     * request awaiting review is the ordinary state, and a reviewer who has not got to one in a
+     * fortnight is a reviewer, not an outage. What it catches is the case where the age keeps
+     * climbing because nothing is polling at all — no cron entry for
+     * `scripts/poll-sourcedata-merges.php`, no consumer running — which is otherwise INVISIBLE:
+     * a merged pull request whose merge is never detected looks exactly like an unreviewed one
+     * from this side, and every editor is told their change is still awaiting review forever.
+     *
+     * The message says both readings out loud rather than accusing the poller, because at this
+     * threshold either is genuinely possible.
+     */
+    public const STALE_OPEN_BATCH_SECONDS = 2_592_000;
 
     /**
      * Approved batches the publisher has given up on, or 0 when there is no database to ask.
@@ -5415,6 +5457,29 @@ class Health implements MessageComponentInterface
             return ( new SourceDataChangeRequestRepository(Connection::getInstance()) )->countParkedBatches();
         } catch (\Throwable) {
             return 0;
+        }
+    }
+
+    /**
+     * How many batches are awaiting a merge decision, and how long the oldest has waited, or
+     * zeroes when there is no database to ask.
+     *
+     * Read through the same `Connection::isConfigured()` + catch-everything guard
+     * {@see parkedChangeRequestBatches()} uses: a database that is down must degrade this block
+     * to zeroes, not break the endpoint monitoring relies on.
+     *
+     * @return array{open_batches: int, oldest_open_age_seconds: int}
+     */
+    private static function openChangeRequestBatchStats(): array
+    {
+        if (!Connection::isConfigured()) {
+            return ['open_batches' => 0, 'oldest_open_age_seconds' => 0];
+        }
+
+        try {
+            return ( new SourceDataChangeRequestRepository(Connection::getInstance()) )->openBatchStats();
+        } catch (\Throwable) {
+            return ['open_batches' => 0, 'oldest_open_age_seconds' => 0];
         }
     }
 

--- a/src/Migrations/Version20260830120000.php
+++ b/src/Migrations/Version20260830120000.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Phase 3: claim ownership, and a stable cursor for publication notifications.
+ *
+ * `publish_claim_token` closes the hole `releaseClaim()`'s own docblock describes: its
+ * `publication_status = 'queued'` guard identifies *a* claim, not *whose*, so a runner whose
+ * publish failed late can release a claim a DIFFERENT runner has since taken — spending a second
+ * attempt against `MAX_PUBLISH_ATTEMPTS` and parking a merely-slow batch in three cycles instead
+ * of five. Comparing a token in the `WHERE` makes a stale release match nothing, which costs the
+ * batch nothing.
+ *
+ * `publication_settled_at` is the notification cursor. `updated_at` cannot be: it moves on every
+ * claim, release, reclaim and record, so it answers "when was this row last touched" rather than
+ * "when did this become news for the submitter". This column is written once, by the transition to
+ * `merged` or `closed`, and is compared against `user_notification_state.last_notification_seen_at`.
+ */
+final class Version20260830120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add sourcedata_change_requests.publish_claim_token and .publication_settled_at (phase 3)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql('ALTER TABLE sourcedata_change_requests ADD COLUMN publish_claim_token UUID NULL');
+        $this->addSql('ALTER TABLE sourcedata_change_requests ADD COLUMN publication_settled_at TIMESTAMPTZ NULL');
+
+        $this->addSql(
+            'COMMENT ON COLUMN sourcedata_change_requests.publish_claim_token IS '
+            . "'Identifies WHICH runner holds the queued claim; compared in releaseClaim() so a stale release is a no-op'"
+        );
+        $this->addSql(
+            'COMMENT ON COLUMN sourcedata_change_requests.publication_settled_at IS '
+            . "'Written once, by the transition to merged or closed; the notification cursor (updated_at is not)'"
+        );
+
+        // The merge poller scans DISTINCT pr_number among open rows.
+        $this->addSql(
+            'CREATE INDEX idx_scr_open_pr ON sourcedata_change_requests (pr_number) '
+            . "WHERE publication_status = 'open'"
+        );
+
+        // The notifications inbox reads a submitter's settled batches, newest first.
+        $this->addSql(
+            'CREATE INDEX idx_scr_settled_for_submitter ON sourcedata_change_requests '
+            . '(submitted_by_sub, publication_settled_at DESC) WHERE publication_settled_at IS NOT NULL'
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql('DROP INDEX IF EXISTS idx_scr_settled_for_submitter');
+        $this->addSql('DROP INDEX IF EXISTS idx_scr_open_pr');
+        $this->addSql('ALTER TABLE sourcedata_change_requests DROP COLUMN IF EXISTS publication_settled_at');
+        $this->addSql('ALTER TABLE sourcedata_change_requests DROP COLUMN IF EXISTS publish_claim_token');
+    }
+}

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -177,6 +177,25 @@ class SourceDataChangeRequestRepository
      * widening one without the other regresses either the content half or the enumeration
      * half of the same defect. See the class docblock for why this is deliberately wider
      * than the supersede DELETE's `review_status = 'submitted'`.
+     *
+     * # Why `closed` is admitted here, and what actually excludes it
+     *
+     * `chk_scr_publication_status` also allows `closed`, which phase 3 writes when a pull request
+     * is closed unmerged. This predicate excludes only `merged`, so a `closed` row is ADMITTED by
+     * the publication half — and that is correct, not an oversight. The publication axis answers
+     * "is this row's content in the repository?", and for a pull request closed unmerged the
+     * answer is no.
+     *
+     * What excludes it is the review half: phase 3 writes `review_status = 'rejected'` alongside
+     * `closed`, and a rejected batch is no longer a proposal whatever became of its pull request.
+     * Two axes answering two different questions — the parent design's own reason for keeping them
+     * as two columns rather than one flattened enum.
+     *
+     * Decided in `docs/superpowers/specs/2026-08-30-sourcedata-merge-detection-design.md` and
+     * pinned by `SourceDataChangeRequestRepositoryTest::testClosedAndRejectedRowIsExcludedFromTheAccumulationBase()`
+     * and its deliberate mirror image `…ClosedButStillApprovedRowRemainsInTheAccumulationBase()`.
+     * Do NOT "fix" this by adding `closed` to the exclusion: that would drop an editor's un-merged
+     * work from their next submission on the strength of content that never reached the repository.
      */
     private const UNPUBLISHED_PREDICATE = 'review_status IN (:submitted, :approved)
                 AND publication_status <> :merged';
@@ -216,6 +235,10 @@ class SourceDataChangeRequestRepository
      * directly, the same way the ORDER BY's own tie tests do. Given a choice between a demonstrated,
      * reachable bug and a not-reachable one, and given the row-id alternative does not reliably close
      * either, `>=` is the correct edge.
+     *
+     * The floor is `publication_status = 'merged'` ALONE, never `IN ('merged','closed')`. A closed
+     * batch published nothing, so letting it set the floor would exclude older rows on the strength
+     * of content that is not in the repository. Pinned by `testClosedRowIsNotASupersessionFloor()`.
      */
     private const NOT_SUPERSEDED_BY_PUBLISHED = 'created_at >= COALESCE((
                     SELECT MAX(m.created_at)

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -915,7 +915,29 @@ class SourceDataChangeRequestRepository
      * from each row's own `base_sha`, which is per-file accumulation-base bookkeeping set
      * at submission time.
      *
-     * @return int Rows transitioned.
+     * `WHERE ... AND publication_status = queued` guards a reachable overwrite: a slow runner
+     * A can be outlived by {@see reclaimStaleClaims()} freeing its claim on the grace period,
+     * letting a runner B claim, publish, and record the SAME batch first (`open`, with B's own
+     * `commit_sha`/`pr_number`). If A's own publish then also succeeds — reachable when A pushed
+     * first and B fast-forwarded past it — A calling this method afterward would otherwise
+     * overwrite B's identifiers with A's older ones, and merge detection would then poll
+     * whichever record won, against a pull request whose git history may not even contain A's
+     * commit. The guard makes the FIRST recorder win and blocks the second: once a batch is no
+     * longer `queued`, no later `recordPublication()` call can touch it.
+     *
+     * This is the MINIMAL fix, not the complete one: it identifies that SOME claim already
+     * recorded a publish, not WHICH runner's identifiers are the correct ones to keep — the two
+     * recorders are otherwise indistinguishable to this method, since it never sees a claim
+     * token. The complete fix threads the claim token from {@see claimNextPublishableBatch()}
+     * through {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisherInterface::publish()}
+     * and into this method's own `WHERE`, so only the run holding the CURRENT claim can record —
+     * deliberately not implemented here, to keep this change to a single added condition. The
+     * caller ({@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher}) logs a
+     * warning when this method reports zero rows, so a blocked second recorder is visible rather
+     * than silent, but does not (and today cannot) attribute the block to the two identifiers.
+     *
+     * @return int Rows transitioned. Zero means no row was still `queued` for this batch id —
+     *             either it does not exist, or another runner already recorded a publish for it.
      */
     public function recordPublication(
         string $batchId,
@@ -934,7 +956,8 @@ class SourceDataChangeRequestRepository
                     publish_attempts    = 0,
                     publish_claim_token = NULL,
                     updated_at          = NOW()
-              WHERE batch_id = :batch_id'
+              WHERE batch_id = :batch_id
+                AND publication_status = :queued'
         );
         $stmt->execute([
             'open'       => ChangePublicationStatus::OPEN->value,
@@ -943,6 +966,7 @@ class SourceDataChangeRequestRepository
             'pr_number'  => $prNumber,
             'base_sha'   => $baseSha,
             'batch_id'   => $batchId,
+            'queued'     => ChangePublicationStatus::QUEUED->value,
         ]);
 
         return $stmt->rowCount();

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -932,27 +932,32 @@ class SourceDataChangeRequestRepository
      * Deliberately NOT built on {@see markBatchPublicationStatus()} — that method is
      * unconditional by design (it is also how `merged`/`closed` get set later, which must
      * stay unconditional) and this call must NOT be. This method carries its own guard,
-     * `AND publication_status = 'queued'`, so it releases only a batch that is under SOME
-     * claim. Do not "simplify" this back into a delegating call to
-     * `markBatchPublicationStatus()` — that is the exact regression this guard exists to
+     * `AND publication_status = 'queued' AND publish_claim_token = :token`, so it releases
+     * only a batch that is under OUR claim. Do not "simplify" this back into a delegating call
+     * to `markBatchPublicationStatus()` — that is the exact regression this guard exists to
      * prevent.
      *
-     * # What the guard does NOT provide: ownership
+     * # The guard identifies WHOSE claim, not merely that one exists
      *
-     * `queued` identifies *a* claim, not *whose*. There is no claim token, so a runner whose
-     * publish failed late can release a claim a DIFFERENT runner has since taken. Reachable
-     * without anything exotic: A claims -> the grace period elapses and {@see reclaimStaleClaims()}
-     * releases A's claim (spending an attempt) -> B claims and starts publishing -> A's own
-     * call finally fails and A releases, which now revokes B's LIVE claim (spending a second
-     * attempt) and puts the batch back to `none` while B is still working. Consequences, both
-     * bounded and visible: a legitimately slow batch can spend TWO of its
-     * {@see MAX_PUBLISH_ATTEMPTS} per cycle rather than one, so it parks in three cycles
-     * rather than five; and a third runner can claim and publish concurrently with B without a
-     * second reclaim being involved — which lands on the benign double-publish
+     * `queued` alone identifies *a* claim, not *whose* — that used to be the whole guard, and
+     * it meant a runner whose publish failed late could release a claim a DIFFERENT runner had
+     * since taken. Reachable without anything exotic: A claims -> the grace period elapses and
+     * {@see reclaimStaleClaims()} releases A's claim (spending an attempt) -> B claims and
+     * starts publishing -> A's own call finally fails and A releases. Before the token existed,
+     * that last release matched on `queued` alone, revoking B's LIVE claim (spending a second
+     * attempt) and putting the batch back to `none` while B was still working — up to TWO of
+     * {@see MAX_PUBLISH_ATTEMPTS} spent per cycle instead of one.
+     *
+     * `publish_claim_token` closes that: {@see \LiturgicalCalendar\Api\Services\SourceData\PublishClaim}
+     * carries the token `claimNextPublishableBatch()` generated for THIS claim, and the guard
+     * above now requires it to match the token on the row. In the same A/B sequence, A's stale
+     * release now matches zero rows — the row is still `queued`, but under B's token, not A's —
+     * so it spends no attempt and returns {@see ClaimReleaseOutcome::CLAIM_LOST} rather than
+     * {@see ClaimReleaseOutcome::RELEASED}. B's claim, and B's publish, are untouched. A third
+     * runner can still claim and publish concurrently with B without a second reclaim being
+     * involved, but that was always a separate, benign case — it lands on
      * ({@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher}'s `force: false`
-     * plus a retry), never on lost work. Closing it properly means a claim token compared on
-     * release, not a stricter status guard; that is a schema change, and it is deliberately
-     * NOT made here. Do not read the guard as ownership in the meantime.
+     * plus a retry), never on lost work, and the token does nothing to change that.
      *
      * Why the guard matters: a caller here is, by construction, a runner whose OWN publish
      * attempt just failed — but "failed" can mean the process was merely SLOW, not dead. If
@@ -970,20 +975,30 @@ class SourceDataChangeRequestRepository
      *
      * # Why this returns a status and not a row count
      *
-     * The guard makes "zero rows" ambiguous, and the two readings are opposites. `open` means
-     * another runner genuinely published this batch, so this runner's failure was redundant
-     * work. `none` means nothing is published anywhere — another runner's publish failed too
-     * (a GitHub outage fails every runner identically), or {@see reclaimStaleClaims()}
-     * released this batch out from under a merely-slow runner. Reading the second as the first
-     * is precisely the critical defect the final review of this feature found: a real outage
-     * reported success and re-claimed the same batch every iteration of the loop that exists
-     * to stop hammering. So this reports {@see ClaimReleaseOutcome}, and the caller branches on
-     * the observed state rather than on an integer.
+     * The guard makes "zero rows" ambiguous, and the readings are not all the same failure.
+     * `open` means another runner genuinely published this batch, so this runner's failure was
+     * redundant work. `none` means nothing is published anywhere — another runner's publish
+     * failed too (a GitHub outage fails every runner identically), or {@see reclaimStaleClaims()}
+     * released this batch out from under a merely-slow runner; this IS a real failure. `queued`
+     * under a different token means another runner holds the live claim right now — also not a
+     * failure of the OBSERVING call, but distinct from both: see {@see ClaimReleaseOutcome::CLAIM_LOST}.
+     * Reading `none` as "settled elsewhere" is precisely the critical defect the final review of
+     * this feature found: a real outage reported success and re-claimed the same batch every
+     * iteration of the loop that exists to stop hammering. So this reports {@see ClaimReleaseOutcome},
+     * and the caller branches on the observed state rather than on an integer.
      *
      * The observation and the release are ONE statement, deliberately. A `SELECT` after a
      * zero-row `UPDATE` would report a status the row may already have left; a data-modifying
      * CTE reads the pre-`UPDATE` version from the same snapshot the `UPDATE` evaluates against,
      * so the reported status is the one the release actually acted on.
+     *
+     * @param string $token The token from the {@see \LiturgicalCalendar\Api\Services\SourceData\PublishClaim}
+     *                      this caller was handed by `claimNextPublishableBatch()`. Compared
+     *                      against the row's current `publish_claim_token` so a release only
+     *                      ever affects the claim the caller actually holds.
+     *
+     * @return ClaimReleaseOutcome What this call observed — see that enum for the full set of
+     *                             readings and why a row count cannot distinguish them.
      */
     public function releaseClaim(string $batchId, string $token): ClaimReleaseOutcome
     {

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -10,6 +10,7 @@ use LiturgicalCalendar\Api\Enum\ChangePublicationStatus;
 use LiturgicalCalendar\Api\Enum\ChangeReviewStatus;
 use LiturgicalCalendar\Api\Enum\ClaimReleaseOutcome;
 use LiturgicalCalendar\Api\Services\ChangeResource;
+use LiturgicalCalendar\Api\Services\SourceData\PublishClaim;
 use PDO;
 
 /**
@@ -786,8 +787,12 @@ class SourceDataChangeRequestRepository
      * than against a hand-copied query, so a regression here is what that test would catch.
      *
      * @param list<string> $skipBatchIds Batch ids to pass over, however claimable they look.
+     *
+     * @return PublishClaim|null The claimed batch id together with a freshly generated claim
+     *                           token — see {@see PublishClaim} and {@see releaseClaim()} for
+     *                           why the token exists — or null if nothing is claimable.
      */
-    public function claimNextPublishableBatch(array $skipBatchIds = []): ?string
+    public function claimNextPublishableBatch(array $skipBatchIds = []): ?PublishClaim
     {
         $this->db->beginTransaction();
         try {
@@ -843,20 +848,24 @@ class SourceDataChangeRequestRepository
                     continue;
                 }
 
+                $token = $this->newBatchId(); // gen_random_uuid(); same generator, different purpose
+
                 $claim = $this->db->prepare(
                     'UPDATE sourcedata_change_requests
-                        SET publication_status = :queued,
-                            updated_at = NOW()
+                        SET publication_status  = :queued,
+                            publish_claim_token = :token,
+                            updated_at          = NOW()
                       WHERE batch_id = :batch_id'
                 );
                 $claim->execute([
                     'queued'   => ChangePublicationStatus::QUEUED->value,
+                    'token'    => $token,
                     'batch_id' => $batchId,
                 ]);
 
                 $this->db->commit();
 
-                return $batchId;
+                return new PublishClaim($batchId, $token);
             }
 
             $this->db->commit();
@@ -889,13 +898,14 @@ class SourceDataChangeRequestRepository
     ): int {
         $stmt = $this->db->prepare(
             'UPDATE sourcedata_change_requests
-                SET publication_status = :open,
-                    branch             = :branch,
-                    commit_sha         = :commit_sha,
-                    pr_number          = :pr_number,
-                    base_sha           = :base_sha,
-                    publish_attempts   = 0,
-                    updated_at         = NOW()
+                SET publication_status  = :open,
+                    branch              = :branch,
+                    commit_sha          = :commit_sha,
+                    pr_number           = :pr_number,
+                    base_sha            = :base_sha,
+                    publish_attempts    = 0,
+                    publish_claim_token = NULL,
+                    updated_at          = NOW()
               WHERE batch_id = :batch_id'
         );
         $stmt->execute([
@@ -975,30 +985,34 @@ class SourceDataChangeRequestRepository
      * CTE reads the pre-`UPDATE` version from the same snapshot the `UPDATE` evaluates against,
      * so the reported status is the one the release actually acted on.
      */
-    public function releaseClaim(string $batchId): ClaimReleaseOutcome
+    public function releaseClaim(string $batchId, string $token): ClaimReleaseOutcome
     {
         $stmt = $this->db->prepare(
             'WITH observed AS (
-                 SELECT publication_status
+                 SELECT publication_status, publish_claim_token
                    FROM sourcedata_change_requests
                   WHERE batch_id = :batch_id
                   LIMIT 1
              ),
              released AS (
                  UPDATE sourcedata_change_requests
-                    SET publication_status = :none,
-                        publish_attempts   = publish_attempts + 1,
-                        updated_at = NOW()
+                    SET publication_status  = :none,
+                        publish_claim_token = NULL,
+                        publish_attempts    = publish_attempts + 1,
+                        updated_at          = NOW()
                   WHERE batch_id = :batch_id
-                    AND publication_status = :queued
+                    AND publication_status  = :queued
+                    AND publish_claim_token = :token
                  RETURNING id
              )
-             SELECT ( SELECT publication_status FROM observed ) AS observed_status,
-                    ( SELECT COUNT(*) FROM released )          AS released_rows'
+             SELECT ( SELECT publication_status  FROM observed ) AS observed_status,
+                    ( SELECT publish_claim_token FROM observed ) AS observed_token,
+                    ( SELECT COUNT(*) FROM released )            AS released_rows'
         );
         $stmt->execute([
             'none'     => ChangePublicationStatus::NONE->value,
             'queued'   => ChangePublicationStatus::QUEUED->value,
+            'token'    => $token,
             'batch_id' => $batchId,
         ]);
 
@@ -1015,6 +1029,19 @@ class SourceDataChangeRequestRepository
         $observed = $row['observed_status'] ?? null;
         if (!is_string($observed)) {
             return ClaimReleaseOutcome::BATCH_MISSING;
+        }
+
+        $observedToken = $row['observed_token'] ?? null;
+
+        // Still queued, but not under OUR token: another runner holds a live claim. Reported
+        // distinctly so the caller neither treats it as published (SETTLED_ELSEWHERE) nor as
+        // unclaimed work (NOT_CLAIMED) — and, critically, so no attempt is spent above.
+        if (
+            ChangePublicationStatus::QUEUED === ChangePublicationStatus::tryFrom($observed)
+            && is_string($observedToken)
+            && $observedToken !== $token
+        ) {
+            return ClaimReleaseOutcome::CLAIM_LOST;
         }
 
         // A `queued` observation that released nothing means a concurrent transaction moved
@@ -1072,9 +1099,10 @@ class SourceDataChangeRequestRepository
     {
         $stmt = $this->db->prepare(
             'UPDATE sourcedata_change_requests
-                SET publication_status = :none,
-                    publish_attempts   = publish_attempts + 1,
-                    updated_at = NOW()
+                SET publication_status  = :none,
+                    publish_claim_token = NULL,
+                    publish_attempts    = publish_attempts + 1,
+                    updated_at          = NOW()
               WHERE publication_status = :queued
                 AND updated_at < :cutoff'
         );

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -944,6 +944,234 @@ class SourceDataChangeRequestRepository
     }
 
     /**
+     * The DISTINCT pull request numbers among rows still `open`, oldest first.
+     *
+     * DISTINCT, not one row per batch, because the rolling branch is per RESOURCE: several
+     * batches for one resource are published onto one branch and reuse one open pull request via
+     * `findOpenPullRequest()`. Polling per batch would ask GitHub the same question N times and
+     * get the same answer N times.
+     *
+     * `MIN(created_at)` orders it, so the oldest unresolved pull request is polled first and a
+     * long queue cannot starve it.
+     *
+     * Rows with a NULL `pr_number` are deliberately NOT returned here — they are unpollable — and
+     * are counted separately by {@see countOpenBatchesWithoutPullRequest()} so they cannot be
+     * silently skipped.
+     *
+     * @return list<int>
+     */
+    public function listOpenPullRequestNumbers(): array
+    {
+        $stmt = $this->db->prepare(
+            'SELECT pr_number
+               FROM sourcedata_change_requests
+              WHERE publication_status = :open
+                AND pr_number IS NOT NULL
+              GROUP BY pr_number
+              ORDER BY MIN(created_at) ASC'
+        );
+        $stmt->execute(['open' => ChangePublicationStatus::OPEN->value]);
+
+        /** @var list<int|string> $numbers */
+        $numbers = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+        return array_map(static fn (int|string $n): int => (int) $n, $numbers);
+    }
+
+    /**
+     * How many batches are `open` with no pull request number to poll.
+     *
+     * Never non-zero in practice: `SourceDataPublisher` opens a pull request whenever
+     * `findOpenPullRequest()` returns null, and `openPullRequest()` returns an `int` or throws. So
+     * a non-zero count here is an UNEXPLAINED state — a batch that is stuck forever, since nothing
+     * will ever poll it. Counted rather than filtered out of the poller's query, because a row
+     * quietly excluded from a `WHERE` is exactly as invisible as one stranded `queued`, which is
+     * the defect class this feature keeps rediscovering.
+     */
+    public function countOpenBatchesWithoutPullRequest(): int
+    {
+        $stmt = $this->db->prepare(
+            'SELECT COUNT(DISTINCT batch_id) AS unpollable
+               FROM sourcedata_change_requests
+              WHERE publication_status = :open
+                AND pr_number IS NULL'
+        );
+        $stmt->execute(['open' => ChangePublicationStatus::OPEN->value]);
+
+        /** @var array<string, mixed>|false $row */
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return false === $row ? 0 : self::requireInt($row['unpollable'] ?? null, 'unpollable');
+    }
+
+    /**
+     * Every `open` batch recorded against this pull request, with the commit it was published as.
+     *
+     * One row per BATCH, not per file: `recordPublication()` writes one commit sha across the
+     * whole batch, so `MIN(commit_sha)` over the group is that single value, not an arbitrary
+     * pick. Ordered by `MIN(created_at)` so the caller sees them in publication order.
+     *
+     * @return list<array{batch_id: string, commit_sha: ?string}>
+     */
+    public function listOpenBatchesForPullRequest(int $prNumber): array
+    {
+        $stmt = $this->db->prepare(
+            'SELECT batch_id, MIN(commit_sha) AS commit_sha
+               FROM sourcedata_change_requests
+              WHERE publication_status = :open
+                AND pr_number = :pr
+              GROUP BY batch_id
+              ORDER BY MIN(created_at) ASC'
+        );
+        $stmt->execute(['open' => ChangePublicationStatus::OPEN->value, 'pr' => $prNumber]);
+
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(
+            static fn (array $row): array => [
+                'batch_id'   => self::requireString($row['batch_id'] ?? null, 'batch_id'),
+                'commit_sha' => is_string($row['commit_sha'] ?? null) ? $row['commit_sha'] : null,
+            ],
+            $rows
+        );
+    }
+
+    /**
+     * Record that a batch's content reached the base branch.
+     *
+     * Guarded on `publication_status = 'open'`, unlike {@see markBatchPublicationStatus()} which is
+     * deliberately unconditional. The guard makes two racing pollers produce one transition and one
+     * no-op instead of two writes of possibly-different merge shas — which is why the poller needs
+     * no claim protocol of its own.
+     *
+     * `review_status` is untouched: a merge is not a review, and the batch was already approved.
+     *
+     * @return int Rows transitioned.
+     */
+    public function markBatchMerged(string $batchId, string $mergeCommitSha): int
+    {
+        $stmt = $this->db->prepare(
+            'UPDATE sourcedata_change_requests
+                SET publication_status     = :merged,
+                    merge_commit_sha       = :merge_commit_sha,
+                    publication_settled_at = NOW(),
+                    updated_at             = NOW()
+              WHERE batch_id = :batch_id
+                AND publication_status = :open'
+        );
+        $stmt->execute([
+            'merged'           => ChangePublicationStatus::MERGED->value,
+            'merge_commit_sha' => $mergeCommitSha,
+            'batch_id'         => $batchId,
+            'open'             => ChangePublicationStatus::OPEN->value,
+        ]);
+
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Record that a batch's pull request was closed without merging.
+     *
+     * Writes `review_status = 'rejected'` with it, which is what keeps the batch out of the
+     * accumulation base — see `UNPUBLISHED_PREDICATE`'s docblock, where that pairing is a decision
+     * rather than a coincidence. `rejected_reason` is generated rather than left null so an
+     * editor's history explains why a batch they never withdrew is rejected.
+     *
+     * Nothing needs reverting: the change was never live anywhere.
+     *
+     * @return int Rows transitioned.
+     */
+    public function markBatchClosedUnmerged(string $batchId, string $reason): int
+    {
+        $stmt = $this->db->prepare(
+            'UPDATE sourcedata_change_requests
+                SET publication_status     = :closed,
+                    review_status          = :rejected,
+                    rejected_reason        = :reason,
+                    publication_settled_at = NOW(),
+                    updated_at             = NOW()
+              WHERE batch_id = :batch_id
+                AND publication_status = :open'
+        );
+        $stmt->execute([
+            'closed'   => ChangePublicationStatus::CLOSED->value,
+            'rejected' => ChangeReviewStatus::REJECTED->value,
+            'reason'   => $reason,
+            'batch_id' => $batchId,
+            'open'     => ChangePublicationStatus::OPEN->value,
+        ]);
+
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Put an `open` batch back to claimable, because its pull request merged WITHOUT it.
+     *
+     * Reachable whenever a reviewer merges concurrently with a publish: the batch's commit lands
+     * on the branch, the merge takes the head it had a moment earlier, and the batch is left
+     * pointing at a pull request that closed without carrying it. Marking it `merged` would assert
+     * it reached the repository and make the publisher skip it forever, losing its content
+     * silently — the same failure the age-based ancestor exclusion exists to avoid.
+     *
+     * `publish_attempts` is cleared: the batch spent no attempt, it was simply overtaken. The git
+     * identifiers (`branch`, `commit_sha`, `pr_number`) are deliberately KEPT, so an operator
+     * asking "what happened to this batch" can see which pull request passed it by.
+     *
+     * @return int Rows transitioned.
+     */
+    public function returnBatchToUnpublished(string $batchId): int
+    {
+        $stmt = $this->db->prepare(
+            'UPDATE sourcedata_change_requests
+                SET publication_status  = :none,
+                    publish_attempts    = 0,
+                    publish_claim_token = NULL,
+                    updated_at          = NOW()
+              WHERE batch_id = :batch_id
+                AND publication_status = :open'
+        );
+        $stmt->execute([
+            'none'     => ChangePublicationStatus::NONE->value,
+            'batch_id' => $batchId,
+            'open'     => ChangePublicationStatus::OPEN->value,
+        ]);
+
+        return $stmt->rowCount();
+    }
+
+    /**
+     * How many batches are awaiting a merge decision, and how long the oldest has waited.
+     *
+     * Reported by `GET /health`. An open batch is NOT an error — a pull request awaiting review is
+     * the ordinary state — so the age is what carries the signal: a value that keeps climbing past
+     * any plausible review time means the poller is not running at all.
+     *
+     * @return array{open_batches: int, oldest_open_age_seconds: int}
+     */
+    public function openBatchStats(): array
+    {
+        $stmt = $this->db->prepare(
+            'SELECT COUNT(DISTINCT batch_id) AS open_batches,
+                    COALESCE(EXTRACT(EPOCH FROM (NOW() - MIN(updated_at))), 0) AS oldest_age
+               FROM sourcedata_change_requests
+              WHERE publication_status = :open'
+        );
+        $stmt->execute(['open' => ChangePublicationStatus::OPEN->value]);
+
+        /** @var array<string, mixed>|false $row */
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (false === $row) {
+            return ['open_batches' => 0, 'oldest_open_age_seconds' => 0];
+        }
+
+        return [
+            'open_batches'            => self::requireInt($row['open_batches'] ?? null, 'open_batches'),
+            'oldest_open_age_seconds' => self::requireInt($row['oldest_age'] ?? null, 'oldest_age'),
+        ];
+    }
+
+    /**
      * Release a failed publish attempt: put a `queued` batch back to `none` so it is
      * claimable again on the next run, and count the attempt against
      * {@see MAX_PUBLISH_ATTEMPTS}.

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -958,6 +958,12 @@ class SourceDataChangeRequestRepository
      * are counted separately by {@see countOpenBatchesWithoutPullRequest()} so they cannot be
      * silently skipped.
      *
+     * Each value is narrowed with {@see requireInt()} rather than blind-cast: a non-numeric
+     * `pr_number` would blind-cast to `0`, and `0` is not inert here — it would be handed straight
+     * to `getPullRequest(0)`, and the batch behind it would never be polled correctly again.
+     * `requireInt()` throws instead, consistent with every other column this class reads back
+     * through PDO.
+     *
      * @return list<int>
      */
     public function listOpenPullRequestNumbers(): array
@@ -975,7 +981,7 @@ class SourceDataChangeRequestRepository
         /** @var list<int|string> $numbers */
         $numbers = $stmt->fetchAll(PDO::FETCH_COLUMN);
 
-        return array_map(static fn (int|string $n): int => (int) $n, $numbers);
+        return array_map(static fn (int|string $n): int => self::requireInt($n, 'pr_number'), $numbers);
     }
 
     /**

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -643,13 +643,18 @@ class SourceDataChangeRequestRepository
     }
 
     /**
-     * Set `publication_status` on every row of a batch, unconditionally on `review_status`.
+     * Set `publication_status` on every row of a batch, unconditionally on `review_status` AND
+     * on the row's current `publication_status` — no guard at all.
      *
-     * This is the write the publisher (phase 2, {@see NOT_SUPERSEDED_BY_PUBLISHED}) uses to record
-     * that a batch reached the repository. It does not touch `review_status` — publication and
-     * review are independent axes, and a batch is always approved before it is publishable, so
-     * gating this on review status would be redundant with the publisher's own selection query
-     * rather than a safety net.
+     * NOT the write any production path uses. The publisher records a real publication through
+     * {@see recordPublication()} instead (which also clears `publish_attempts` and stamps the
+     * git-side identifiers), and the merge poller uses its own guarded
+     * {@see markBatchMerged()} / {@see markBatchClosedUnmerged()} (each conditioned on
+     * `publication_status = 'open'`, so two racing pollers produce one transition and one
+     * no-op) — see {@see releaseClaim()}'s own docblock for why it, too, cannot delegate here.
+     * This method is test/ops tooling only: exactly what a repair script wants when an operator
+     * needs to force a row into a specific state regardless of what it currently holds. It does
+     * not touch `review_status` — publication and review are independent axes.
      *
      * @return int Rows transitioned.
      */
@@ -1186,9 +1191,12 @@ class SourceDataChangeRequestRepository
      * counted exactly when a claim is actually given back — never when this call is a no-op
      * because someone else already settled the batch.
      *
-     * Deliberately NOT built on {@see markBatchPublicationStatus()} — that method is
-     * unconditional by design (it is also how `merged`/`closed` get set later, which must
-     * stay unconditional) and this call must NOT be. This method carries its own guard,
+     * Deliberately NOT built on {@see markBatchPublicationStatus()} — that method has NO guard
+     * at all (see its own docblock), and this call needs one specific to releasing: it must
+     * touch only a `queued` row still carrying THIS claim's token. `merged`/`closed` are not a
+     * counterexample requiring an unconditional write either — {@see markBatchMerged()} and
+     * {@see markBatchClosedUnmerged()} carry their own guard, `publication_status = 'open'`, and
+     * would themselves regress if rewritten to delegate here. This method carries its own guard,
      * `AND publication_status = 'queued' AND publish_claim_token = :token`, so it releases
      * only a batch that is under OUR claim. Do not "simplify" this back into a delegating call
      * to `markBatchPublicationStatus()` — that is the exact regression this guard exists to

--- a/src/Repositories/UserNotificationRepository.php
+++ b/src/Repositories/UserNotificationRepository.php
@@ -10,12 +10,35 @@ use LiturgicalCalendar\Api\Database\Connection;
  * Repository for user-facing notification state and inbox queries.
  *
  * Backs the GET /auth/notifications and POST /auth/notifications/seen
- * endpoints. Reads from access_requests (filtered to reviewed rows for
- * the authenticated user) and reads/writes the user_notification_state
- * bookmark table.
+ * endpoints. Reads from two sources — access_requests (filtered to reviewed
+ * rows for the authenticated user) and sourcedata_change_requests (filtered
+ * to settled batches submitted by the authenticated user) — merges them in
+ * PHP, and reads/writes the user_notification_state bookmark table.
  *
  * The "no row yet = unseen since epoch" semantics are handled in the
  * read path via a NULL → '1970-01-01' fallback. Reads never insert.
+ *
+ * @phpstan-type AccessRequestItem array{
+ *     type: 'access_request_reviewed',
+ *     request_id: string,
+ *     requested_role: string,
+ *     status: string,
+ *     review_notes: ?string,
+ *     reviewed_at: string,
+ *     permissions: list<array{object_type: string, object_id: string, relation: string}>,
+ *     unread: bool
+ * }
+ * @phpstan-type ChangeRequestItem array{
+ *     type: 'change_request_published',
+ *     batch_id: string,
+ *     resource_type: string,
+ *     resource_id: string,
+ *     publication_status: string,
+ *     pr_number: ?int,
+ *     settled_at: string,
+ *     unread: bool
+ * }
+ * @phpstan-type InboxItem AccessRequestItem|ChangeRequestItem
  */
 final class UserNotificationRepository
 {
@@ -32,17 +55,49 @@ final class UserNotificationRepository
     /**
      * Fetch the user's inbox + unread badge metadata.
      *
+     * `items` is a DISCRIMINATED list: reviewed access requests
+     * (`type: 'access_request_reviewed'`) and settled source-data change
+     * requests (`type: 'change_request_published'`) are interleaved
+     * newest-first. The two shapes share only `type` and `unread` — clients
+     * MUST switch on `type` before reading any other key.
+     *
+     * # Why two queries and a PHP merge, rather than one UNION
+     *
+     * The two sources have genuinely different shapes, and `total` / `unread_count` are window
+     * counts over the FULL filtered set rather than over the returned page — so a UNION would need
+     * `COUNT(*) OVER ()` spanning both halves, over rows whose columns do not line up. That is one
+     * query that is hard to read and harder to prove right. Two straightforward queries plus a
+     * `usort` are verifiable by inspection, and each source is already capped at 50 rows, so the
+     * merge is bounded.
+     *
+     * # Why `publication_settled_at` and not `updated_at`
+     *
+     * `updated_at` moves on every claim, release, reclaim and record, so it answers "when was this
+     * row last touched", not "when did this become news". `publication_settled_at` is written once,
+     * by the transition to `merged` or `closed`.
+     *
+     * # One item per batch
+     *
+     * An editor who changed a calendar and its fourteen i18n files proposed ONE thing. `DISTINCT ON
+     * (batch_id)` collapses the rows the way the reviewer already sees them.
+     *
+     * # Sorting across two differently-typed timestamp columns
+     *
+     * `access_requests.reviewed_at` is TIMESTAMP (no time zone); `sourcedata_change_requests
+     * .publication_settled_at` is TIMESTAMPTZ. String-comparing raw DB values would be wrong unless
+     * both always render with the same UTC offset. They are never compared raw: both go through
+     * `iso8601()` first, which parses each value (respecting an explicit offset when the string
+     * carries one, and otherwise interpreting it as Europe/Vatican wall-clock — the session
+     * time zone) and re-renders it via `->setTimezone(UTC)->format('Y-m-d\TH:i:sP')`. That format
+     * call always yields a `+00:00` suffix, so by the time `settled_at` / `reviewed_at` reach the
+     * merge sort, both are UTC-normalized RFC 3339 strings sharing one offset — `strcmp` on them is
+     * chronologically correct. Verified empirically against this DB: a TIMESTAMPTZ value comes back
+     * from pdo_pgsql as e.g. `2026-08-30 12:00:00+02` under the Europe/Vatican session zone, and
+     * `iso8601()` turns that into `2026-08-30T10:00:00+00:00` — the same shape `iso8601()` produces
+     * for a naive TIMESTAMP string interpreted in that same zone.
+     *
      * @return array{
-     *     items: list<array{
-     *         type: string,
-     *         request_id: string,
-     *         requested_role: string,
-     *         status: string,
-     *         review_notes: ?string,
-     *         reviewed_at: string,
-     *         permissions: list<array{object_type: string, object_id: string, relation: string}>,
-     *         unread: bool
-     *     }>,
+     *     items: list<InboxItem>,
      *     total: int,
      *     unread_count: int,
      *     last_seen_at: string
@@ -54,7 +109,7 @@ final class UserNotificationRepository
         // callers that ask for an unbounded or non-positive page size.
         $limit = max(1, min($limit, 50));
 
-        // Statement A: bookmark (or epoch).
+        // Bookmark (or epoch).
         $stmt = $this->db->prepare(
             'SELECT last_notification_seen_at FROM user_notification_state WHERE user_id = :uid'
         );
@@ -64,7 +119,43 @@ final class UserNotificationRepository
         $lastSeen    = $hasBookmark ? $lastSeenRaw : self::EPOCH;
         $lastSeenIso = $hasBookmark ? $this->iso8601($lastSeen) : self::EPOCH_ISO8601;
 
-        // Statement B: items + window-function counts over the full filtered set.
+        $access = $this->accessRequestItems($userId, $lastSeen, $limit);
+        $change = $this->changeRequestItems($userId, $lastSeen, $limit);
+
+        /** @var list<InboxItem> $items */
+        $items = array_merge($access['items'], $change);
+        usort(
+            $items,
+            static fn (array $a, array $b): int => strcmp(
+                self::sortTimestamp($b),
+                self::sortTimestamp($a)
+            )
+        );
+
+        // total and unread_count span the FULL filtered set of both sources, not the merged page —
+        // consistent with what the access-request half already promised on its own.
+        $total       = $access['total'] + count($change);
+        $unreadCount = $access['unread_count'] + count(array_filter(
+            $change,
+            static fn (array $item): bool => true === $item['unread']
+        ));
+
+        return [
+            'items'        => array_slice($items, 0, $limit),
+            'total'        => $total,
+            'unread_count' => $unreadCount,
+            'last_seen_at' => $lastSeenIso,
+        ];
+    }
+
+    /**
+     * Reviewed access requests for `$userId`, plus window-function counts over the full filtered
+     * set (not just the returned page).
+     *
+     * @return array{items: list<AccessRequestItem>, total: int, unread_count: int}
+     */
+    private function accessRequestItems(string $userId, string $lastSeen, int $limit): array
+    {
         $sql  = <<<'SQL'
             SELECT
                 id,
@@ -97,7 +188,6 @@ final class UserNotificationRepository
                 'items'        => [],
                 'total'        => 0,
                 'unread_count' => 0,
-                'last_seen_at' => $lastSeenIso,
             ];
         }
 
@@ -129,8 +219,86 @@ final class UserNotificationRepository
             'items'        => array_values($items),
             'total'        => $total,
             'unread_count' => $unreadCount,
-            'last_seen_at' => $lastSeenIso,
         ];
+    }
+
+    /**
+     * Settled source-data change-request batches submitted by `$userId` — one item per batch, not
+     * per file. Unlike accessRequestItems(), there is no window-function total/unread_count here:
+     * with `DISTINCT ON (batch_id)` already collapsing rows, `COUNT(*) OVER ()` would count the
+     * post-collapse rows correctly, but capping the result at $limit inside the same query would cut
+     * DISTINCT ON's input before it has seen every row for a batch. Counting is done in PHP by the
+     * caller instead, over the uncapped-per-batch (capped at 50 batches) result below.
+     *
+     * @return list<ChangeRequestItem>
+     */
+    private function changeRequestItems(string $userId, string $lastSeen, int $limit): array
+    {
+        $sql  = <<<'SQL'
+            SELECT DISTINCT ON (batch_id)
+                batch_id,
+                resource_type,
+                resource_id,
+                publication_status,
+                pr_number,
+                publication_settled_at,
+                (publication_settled_at > :last_seen::timestamptz) AS unread
+            FROM sourcedata_change_requests
+            WHERE submitted_by_sub = :uid
+              AND publication_settled_at IS NOT NULL
+            ORDER BY batch_id, publication_settled_at DESC
+        SQL;
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindValue(':uid', $userId);
+        $stmt->bindValue(':last_seen', $lastSeen);
+        $stmt->execute();
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        $items = array_map(
+            function (array $row): array {
+                return [
+                    'type'               => 'change_request_published',
+                    'batch_id'           => $this->toString($row['batch_id']),
+                    'resource_type'      => $this->toString($row['resource_type']),
+                    'resource_id'        => $this->toString($row['resource_id']),
+                    'publication_status' => $this->toString($row['publication_status']),
+                    'pr_number'          => $this->toNullableInt($row['pr_number'] ?? null),
+                    'settled_at'         => $this->iso8601($this->toString($row['publication_settled_at'])),
+                    'unread'             => in_array($row['unread'], [true, 't', 'true', '1', 1], true),
+                ];
+            },
+            $rows
+        );
+
+        // DISTINCT ON forces ORDER BY batch_id first, so the newest-first ordering the inbox needs
+        // has to be re-applied here rather than left to SQL. Safe to strcmp: see the "Sorting
+        // across two differently-typed timestamp columns" note on fetchInbox().
+        usort($items, static fn (array $a, array $b): int => strcmp($b['settled_at'], $a['settled_at']));
+
+        return array_slice($items, 0, $limit);
+    }
+
+    /**
+     * The timestamp an InboxItem sorts by, regardless of which shape it is.
+     *
+     * `$item['settled_at'] ?? $item['reviewed_at']` would work at runtime, but PHPStan L10 flags it
+     * (`offsetAccess.notFound`) because neither key exists on both halves of the InboxItem union — a
+     * `??` access does not narrow which shape `$item` actually is. Matching on the `type`
+     * discriminant does narrow it, so each arm's offset access is provably safe.
+     *
+     * Both values passed through iso8601() before reaching here, so both are UTC-normalized RFC
+     * 3339 strings sharing one `+00:00` offset — see fetchInbox()'s docblock for why that makes
+     * strcmp() on the result chronologically correct.
+     *
+     * @param InboxItem $item
+     */
+    private static function sortTimestamp(array $item): string
+    {
+        return match ($item['type']) {
+            'change_request_published' => $item['settled_at'],
+            'access_request_reviewed'  => $item['reviewed_at'],
+        };
     }
 
     /**
@@ -145,6 +313,19 @@ final class UserNotificationRepository
             throw new \UnexpectedValueException('Expected int, got ' . gettype($value));
         }
         return $value;
+    }
+
+    /**
+     * Narrow a scalar DB column value that may be SQL NULL to ?int without violating PHPStan L10's
+     * cast-from-mixed rule. sourcedata_change_requests.pr_number is INTEGER NULL, and with
+     * PDO::ATTR_EMULATE_PREPARES=false pdo_pgsql returns it as a native PHP int (or null).
+     */
+    private function toNullableInt(mixed $value): ?int
+    {
+        if ($value === null) {
+            return null;
+        }
+        return $this->toInt($value);
     }
 
     /**

--- a/src/Repositories/UserNotificationRepository.php
+++ b/src/Repositories/UserNotificationRepository.php
@@ -123,7 +123,7 @@ final class UserNotificationRepository
         $change = $this->changeRequestItems($userId, $lastSeen, $limit);
 
         /** @var list<InboxItem> $items */
-        $items = array_merge($access['items'], $change);
+        $items = array_merge($access['items'], $change['items']);
         usort(
             $items,
             static fn (array $a, array $b): int => strcmp(
@@ -133,12 +133,11 @@ final class UserNotificationRepository
         );
 
         // total and unread_count span the FULL filtered set of both sources, not the merged page —
-        // consistent with what the access-request half already promised on its own.
-        $total       = $access['total'] + count($change);
-        $unreadCount = $access['unread_count'] + count(array_filter(
-            $change,
-            static fn (array $item): bool => true === $item['unread']
-        ));
+        // both accessRequestItems() and changeRequestItems() compute their own total/unread_count
+        // via a window function over their full filtered set, so this is a plain sum of two
+        // already-correct numbers, not a re-derivation from either returned page.
+        $total       = $access['total'] + $change['total'];
+        $unreadCount = $access['unread_count'] + $change['unread_count'];
 
         return [
             'items'        => array_slice($items, 0, $limit),
@@ -224,36 +223,69 @@ final class UserNotificationRepository
 
     /**
      * Settled source-data change-request batches submitted by `$userId` — one item per batch, not
-     * per file. Unlike accessRequestItems(), there is no window-function total/unread_count here:
-     * with `DISTINCT ON (batch_id)` already collapsing rows, `COUNT(*) OVER ()` would count the
-     * post-collapse rows correctly, but capping the result at $limit inside the same query would cut
-     * DISTINCT ON's input before it has seen every row for a batch. Counting is done in PHP by the
-     * caller instead, over the uncapped-per-batch (capped at 50 batches) result below.
+     * per file — plus window-function counts over the FULL filtered set (every settled batch the
+     * user has, not just the returned page). Mirrors accessRequestItems()'s COUNT(*) OVER()
+     * pattern, but `DISTINCT ON (batch_id)` cannot sit in the same SELECT as that window function
+     * and still count the collapsed (one-row-per-batch) rows the count is supposed to be over —
+     * `COUNT(*) OVER ()` next to `DISTINCT ON` would count the PRE-collapse rows (one per file),
+     * not batches. A CTE runs the `DISTINCT ON` to completion first; the outer SELECT then applies
+     * `COUNT(*) OVER ()` and `LIMIT` against that already-collapsed, still-uncapped result, exactly
+     * the way accessRequestItems() applies its window functions before its own LIMIT. Without the
+     * outer LIMIT, this fetched every settled batch a user has ever had, unbounded — a latent
+     * performance problem for prolific contributors independent of the counting bug it caused (see
+     * fetchInbox()'s total/unread_count, which used to silently plateau at $limit).
      *
-     * @return list<ChangeRequestItem>
+     * @return array{items: list<ChangeRequestItem>, total: int, unread_count: int}
      */
     private function changeRequestItems(string $userId, string $lastSeen, int $limit): array
     {
         $sql  = <<<'SQL'
-            SELECT DISTINCT ON (batch_id)
+            WITH batches AS (
+                SELECT DISTINCT ON (batch_id)
+                    batch_id,
+                    resource_type,
+                    resource_id,
+                    publication_status,
+                    pr_number,
+                    publication_settled_at,
+                    (publication_settled_at > :last_seen::timestamptz) AS unread
+                FROM sourcedata_change_requests
+                WHERE submitted_by_sub = :uid
+                  AND publication_settled_at IS NOT NULL
+                ORDER BY batch_id, publication_settled_at DESC
+            )
+            SELECT
                 batch_id,
                 resource_type,
                 resource_id,
                 publication_status,
                 pr_number,
                 publication_settled_at,
-                (publication_settled_at > :last_seen::timestamptz) AS unread
-            FROM sourcedata_change_requests
-            WHERE submitted_by_sub = :uid
-              AND publication_settled_at IS NOT NULL
-            ORDER BY batch_id, publication_settled_at DESC
+                unread,
+                COUNT(*) OVER () AS total,
+                COUNT(*) FILTER (WHERE unread) OVER () AS unread_count
+            FROM batches
+            ORDER BY publication_settled_at DESC
+            LIMIT :limit
         SQL;
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':uid', $userId);
         $stmt->bindValue(':last_seen', $lastSeen);
+        $stmt->bindValue(':limit', $limit, \PDO::PARAM_INT);
         $stmt->execute();
         /** @var list<array<string, mixed>> $rows */
         $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        if ($rows === []) {
+            return [
+                'items'        => [],
+                'total'        => 0,
+                'unread_count' => 0,
+            ];
+        }
+
+        $total       = $this->toInt($rows[0]['total']);
+        $unreadCount = $this->toInt($rows[0]['unread_count']);
 
         $items = array_map(
             function (array $row): array {
@@ -271,12 +303,11 @@ final class UserNotificationRepository
             $rows
         );
 
-        // DISTINCT ON forces ORDER BY batch_id first, so the newest-first ordering the inbox needs
-        // has to be re-applied here rather than left to SQL. Safe to strcmp: see the "Sorting
-        // across two differently-typed timestamp columns" note on fetchInbox().
-        usort($items, static fn (array $a, array $b): int => strcmp($b['settled_at'], $a['settled_at']));
-
-        return array_slice($items, 0, $limit);
+        return [
+            'items'        => array_values($items),
+            'total'        => $total,
+            'unread_count' => $unreadCount,
+        ];
     }
 
     /**

--- a/src/Services/GitHub/GitHubGitDataClient.php
+++ b/src/Services/GitHub/GitHubGitDataClient.php
@@ -239,6 +239,75 @@ final class GitHubGitDataClient
     }
 
     /**
+     * Read one pull request's merge state.
+     *
+     * A 404 is a real failure here, not a value. `getRef()` is the only method in this class that
+     * treats one as a value, and it does so because a missing branch is the expected state before
+     * a resource's first publication. A pull request number came out of our own database, written
+     * by our own publisher — if GitHub cannot find it, something is wrong with the repository or
+     * the credential, and reporting "not merged" would hide that forever.
+     *
+     * @throws GitHubApiException If GitHub responds with a non-2xx status, or the payload carries
+     *                            no usable `state` / `head.sha`
+     */
+    public function getPullRequest(int $number): PullRequestState
+    {
+        $response = $this->send('GET', '/pulls/' . $number, null);
+        $decoded  = $this->decodeOrThrow($response);
+
+        $state = $decoded['state'] ?? null;
+        if (!is_string($state) || '' === $state) {
+            throw new GitHubApiException($response->getStatusCode(), 'GitHub returned a pull request with no usable state');
+        }
+
+        $head    = $decoded['head'] ?? null;
+        $headSha = is_array($head) ? ( $head['sha'] ?? null ) : null;
+        if (!is_string($headSha) || '' === $headSha) {
+            throw new GitHubApiException($response->getStatusCode(), 'GitHub returned a pull request with no usable head.sha');
+        }
+
+        $mergeCommitSha = $decoded['merge_commit_sha'] ?? null;
+
+        return new PullRequestState(
+            $state,
+            true === ( $decoded['merged'] ?? false ),
+            is_string($mergeCommitSha) && '' !== $mergeCommitSha ? $mergeCommitSha : null,
+            $headSha
+        );
+    }
+
+    /**
+     * Compare two commits, returning GitHub's `status`: `identical`, `ahead`, `behind` or
+     * `diverged`, read as "$head is <status> $base".
+     *
+     * Merge detection calls this as `compareCommits($batchCommitSha, $mergeCommitSha)` and treats
+     * `ahead` or `identical` as "the merge commit's history contains the batch's commit". Anything
+     * else means it does not, and the batch must NOT be marked merged.
+     *
+     * A missing `status` is an error rather than a default, because every default is wrong here:
+     * assuming contained loses content silently, assuming not-contained republishes work that is
+     * already in the repository. Neither guess is safe, so this refuses to guess.
+     *
+     * @throws GitHubApiException If GitHub responds with a non-2xx status, or returns no `status`
+     */
+    public function compareCommits(string $base, string $head): string
+    {
+        $response = $this->send(
+            'GET',
+            '/compare/' . rawurlencode($base) . '...' . rawurlencode($head),
+            null
+        );
+        $decoded  = $this->decodeOrThrow($response);
+
+        $status = $decoded['status'] ?? null;
+        if (!is_string($status) || '' === $status) {
+            throw new GitHubApiException($response->getStatusCode(), 'GitHub returned a comparison with no usable status');
+        }
+
+        return $status;
+    }
+
+    /**
      * URL-encode a `/`-separated branch name segment-by-segment, preserving the slashes as path
      * hierarchy instead of collapsing them into `%2F` — a plain {@see rawurlencode()} of the
      * whole branch name would turn every `/` into `%2F` and 404 against a ref path built from

--- a/src/Services/GitHub/GitHubGitDataClient.php
+++ b/src/Services/GitHub/GitHubGitDataClient.php
@@ -247,8 +247,15 @@ final class GitHubGitDataClient
      * by our own publisher — if GitHub cannot find it, something is wrong with the repository or
      * the credential, and reporting "not merged" would hide that forever.
      *
+     * A missing `merged` is an error rather than a default, for the same reason
+     * {@see compareCommits()} refuses to default a missing `status`: on a CLOSED pull request, a
+     * silent `false` default writes `closed` + `rejected`, drops the batch from the accumulation
+     * base, skips the OpenFGA purge, and tells the submitter their MERGED work was rejected —
+     * every one of those outcomes is worse than failing loudly. `state` and `head.sha` already
+     * throw rather than guess; `merged` gets the same treatment.
+     *
      * @throws GitHubApiException If GitHub responds with a non-2xx status, or the payload carries
-     *                            no usable `state` / `head.sha`
+     *                            no usable `state` / `merged` / `head.sha`
      */
     public function getPullRequest(int $number): PullRequestState
     {
@@ -258,6 +265,11 @@ final class GitHubGitDataClient
         $state = $decoded['state'] ?? null;
         if (!is_string($state) || '' === $state) {
             throw new GitHubApiException($response->getStatusCode(), 'GitHub returned a pull request with no usable state');
+        }
+
+        $merged = $decoded['merged'] ?? null;
+        if (!is_bool($merged)) {
+            throw new GitHubApiException($response->getStatusCode(), 'GitHub returned a pull request with no usable merged flag');
         }
 
         $head    = $decoded['head'] ?? null;
@@ -270,7 +282,7 @@ final class GitHubGitDataClient
 
         return new PullRequestState(
             $state,
-            true === ( $decoded['merged'] ?? false ),
+            $merged,
             is_string($mergeCommitSha) && '' !== $mergeCommitSha ? $mergeCommitSha : null,
             $headSha
         );

--- a/src/Services/GitHub/PullRequestState.php
+++ b/src/Services/GitHub/PullRequestState.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\GitHub;
+
+/**
+ * The three facts merge detection needs about a rolling pull request, plus the one it needs to
+ * decide WHICH batches the merge actually carried.
+ *
+ * `$headSha` is here because "this batch's pull request merged" is not the same as "this batch
+ * was in the merge": a reviewer clicking Merge concurrently with a publish leaves a commit on the
+ * branch and outside the merge. See
+ * {@see \LiturgicalCalendar\Api\Services\SourceData\MergePollRunner} for what is done with it.
+ */
+final readonly class PullRequestState
+{
+    public function __construct(
+        /** GitHub's `state`: `open` or `closed`. A merged PR is always `closed`. */
+        public string $state,
+        public bool $merged,
+        /** Null while the pull request is open — never the empty string. */
+        public ?string $mergeCommitSha,
+        /** The head commit at the time of this read; at merge time, what was merged. */
+        public string $headSha
+    ) {
+    }
+
+    public function isClosedUnmerged(): bool
+    {
+        return 'closed' === $this->state && false === $this->merged;
+    }
+}

--- a/src/Services/Outbox/ConsumerLoop.php
+++ b/src/Services/Outbox/ConsumerLoop.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Api\Services\Outbox;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
 /**
  * Long-lived consumer loop body.
  *
@@ -21,12 +24,16 @@ final class ConsumerLoop
 {
     private bool $groupEnsured = false;
 
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly StreamConsumerInterface $consumer,
         private readonly OutboxProcessorInterface $processor,
         private readonly int $blockMs = 5000,
         private readonly ?CascadeReconcilerInterface $cascade = null,
+        ?LoggerInterface $logger = null,
     ) {
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function tick(): void
@@ -41,8 +48,14 @@ final class ConsumerLoop
                 // The stream layer hands over a raw string, because the publish stream on the other
                 // side of the same interface carries UUIDs. The outbox's unit of work is an integer
                 // row id, so narrowing it — and rejecting anything that is not a positive integer —
-                // is this layer's job now.
+                // is this layer's job now. This validation used to live in RedisStreamConsumer
+                // itself, which logged 'outbox.consumer.bad_message' before discarding; moving the
+                // check up here must not silently drop that observability along with it — a
+                // non-numeric or non-positive id is exactly as malformed as the "no id at all" case
+                // RedisStreamConsumer::readOnce() still logs and ACKs on its own.
                 if (!ctype_digit($id) || (int) $id <= 0) {
+                    $this->logger->warning('outbox.consumer.bad_message', ['id' => $id]);
+
                     return;
                 }
 

--- a/src/Services/Outbox/ConsumerLoop.php
+++ b/src/Services/Outbox/ConsumerLoop.php
@@ -37,7 +37,16 @@ final class ConsumerLoop
         }
         $this->consumer->readOnce(
             $this->blockMs,
-            function (int $rowId): void {
+            function (string $id): void {
+                // The stream layer hands over a raw string, because the publish stream on the other
+                // side of the same interface carries UUIDs. The outbox's unit of work is an integer
+                // row id, so narrowing it — and rejecting anything that is not a positive integer —
+                // is this layer's job now.
+                if (!ctype_digit($id) || (int) $id <= 0) {
+                    return;
+                }
+
+                $rowId       = (int) $id;
                 $disposition = $this->processor->processOne($rowId);
                 if ($disposition === OutboxDisposition::BENIGN_SUCCESS && $this->cascade !== null) {
                     try {

--- a/src/Services/Outbox/RedisStreamConsumer.php
+++ b/src/Services/Outbox/RedisStreamConsumer.php
@@ -26,6 +26,11 @@ final class RedisStreamConsumer implements StreamConsumerInterface
         private readonly string $groupName,
         private readonly string $consumerName,
         ?LoggerInterface $logger = null,
+        /**
+         * Which message field carries the id. `row_id` for the OpenFGA outbox, `batch_id` for the
+         * source-data publish stream.
+         */
+        private readonly string $payloadField = 'row_id',
     ) {
         $this->logger = $logger ?? new NullLogger();
     }
@@ -52,14 +57,14 @@ final class RedisStreamConsumer implements StreamConsumerInterface
     }
 
     /**
-     * Read one message (or batch) from the stream and invoke $process
-     * with the row_id field. XACK on success.
+     * Read one message (or batch) from the stream and invoke $process with the configured payload
+     * field's raw string value. XACK on success.
      *
      * Stale pending entries (idle > CLAIM_IDLE_MS) are reclaimed first
      * via XCLAIM so a new consumer can finish work a previous consumer
      * crashed mid-flight.
      *
-     * @param callable(int): void $process
+     * @param callable(string): void $process
      */
     public function readOnce(int $blockMs, callable $process): void
     {
@@ -82,20 +87,23 @@ final class RedisStreamConsumer implements StreamConsumerInterface
 
         $ackIds = [];
         foreach ($messages as $msgId => $payload) {
-            $rowId = isset($payload['row_id']) ? (int) $payload['row_id'] : 0;
-            if ($rowId <= 0) {
+            $id = $payload[$this->payloadField] ?? null;
+            if (!is_string($id) || '' === $id) {
+                // Unprocessable by ANY caller — there is no id at all — so ACK it rather than let
+                // it redeliver forever. Deciding whether a PRESENT id is valid belongs to the
+                // caller, which is the only layer that knows what shape it should be.
                 $this->logger->warning('outbox.consumer.bad_message', ['msg_id' => $msgId, 'payload' => $payload]);
                 $ackIds[] = $msgId;
                 continue;
             }
             try {
-                $process($rowId);
+                $process($id);
                 $ackIds[] = $msgId;
             } catch (\Throwable $e) {
                 // Leave the message in the PEL; XCLAIM on the next pass picks it up.
                 $this->logger->error('outbox.consumer.process_failed', [
                     'msg_id' => $msgId,
-                    'row_id' => $rowId,
+                    'id'     => $id,
                     'error'  => $e->getMessage(),
                 ]);
             }
@@ -107,7 +115,7 @@ final class RedisStreamConsumer implements StreamConsumerInterface
     }
 
     /**
-     * @param callable(int): void $process
+     * @param callable(string): void $process
      */
     private function claimStale(callable $process): void
     {
@@ -169,18 +177,18 @@ final class RedisStreamConsumer implements StreamConsumerInterface
 
         $ackIds = [];
         foreach ($claimed as $msgId => $payload) {
-            $rowId = isset($payload['row_id']) ? (int) $payload['row_id'] : 0;
+            $id = $payload[$this->payloadField] ?? null;
             $this->logger->warning('outbox.consumer.xclaim', [
                 'msg_id'  => $msgId,
-                'row_id'  => $rowId,
+                'id'      => $id,
                 'idle_ms' => self::CLAIM_IDLE_MS,
             ]);
-            if ($rowId <= 0) {
+            if (!is_string($id) || '' === $id) {
                 $ackIds[] = $msgId;
                 continue;
             }
             try {
-                $process($rowId);
+                $process($id);
                 $ackIds[] = $msgId;
             } catch (\Throwable) {
                 // leave it pending; next pass retries.

--- a/src/Services/Outbox/StreamConsumerInterface.php
+++ b/src/Services/Outbox/StreamConsumerInterface.php
@@ -9,7 +9,14 @@ interface StreamConsumerInterface
     public function ensureGroup(): void;
 
     /**
-     * @param callable(int): void $process
+     * Read one message (or batch) and invoke `$process` with the payload field's RAW STRING value.
+     *
+     * String, not int, because the two streams that use this carry different id types: the OpenFGA
+     * outbox's unit of work is an integer row id, while the source-data publisher's is a batch id,
+     * which is a UUID. Validating and narrowing the value is the caller's job — this layer no
+     * longer knows what a valid id looks like.
+     *
+     * @param callable(string): void $process
      */
     public function readOnce(int $blockMs, callable $process): void;
 }

--- a/src/Services/SourceData/ChangeRequestSourceDataWriter.php
+++ b/src/Services/SourceData/ChangeRequestSourceDataWriter.php
@@ -45,7 +45,7 @@ final class ChangeRequestSourceDataWriter implements SourceDataWriter
         ];
     }
 
-    public function commit(ChangeResource $resource): array
+    public function commit(ChangeResource $resource, bool $deletesResource = false): array
     {
         if ($this->staged === []) {
             throw new \LogicException('commit() called with no staged files');
@@ -71,6 +71,14 @@ final class ChangeRequestSourceDataWriter implements SourceDataWriter
         // DELETE and this INSERT. idx_scr_unique_pending_path_submitter is
         // defence-in-depth for exactly that race, not the primary guard, so surface it
         // as a 409 the client can retry rather than an opaque 500.
+        $metadata = ['authorizing_relation' => 'admin'];
+        if ($deletesResource) {
+            // Read at merge time by MergePollRunner, which is the only moment that knows the
+            // deletion actually happened. Written here because this is the only moment that
+            // knows it was a resource deletion at all.
+            $metadata['deletes_resource'] = true;
+        }
+
         try {
             $submission = $this->repository->submitBatch(
                 $resource,
@@ -79,7 +87,7 @@ final class ChangeRequestSourceDataWriter implements SourceDataWriter
                 $name,
                 $email,
                 $emailVerified,
-                ['authorizing_relation' => 'admin']
+                $metadata
             );
         } catch (PDOException $e) {
             if ('23505' === $e->getCode()) {

--- a/src/Services/SourceData/ChangeRequestSourceDataWriter.php
+++ b/src/Services/SourceData/ChangeRequestSourceDataWriter.php
@@ -25,14 +25,17 @@ final class ChangeRequestSourceDataWriter implements SourceDataWriter
     private array $staged = [];
 
     /**
-     * @param array<string, mixed> $oidcUser The authenticated identity, from the
-     *                                       request's `oidc_user` attribute.
+     * @param array<string, mixed>       $oidcUser        The authenticated identity, from the
+     *                                                     request's `oidc_user` attribute.
+     * @param ?SourceDataPublishNotifier $publishNotifier Null is a quiet no-op, not a missing
+     *                                                     dependency — see {@see commit()}.
      */
     public function __construct(
         private readonly SourceDataChangeRequestRepository $repository,
         private readonly ChangeRequestReview $review,
         private readonly array $oidcUser,
-        private readonly ?string $projectRoot = null
+        private readonly ?string $projectRoot = null,
+        private readonly ?SourceDataPublishNotifier $publishNotifier = null
     ) {
     }
 
@@ -106,6 +109,10 @@ final class ChangeRequestSourceDataWriter implements SourceDataWriter
         $autoApproved = $this->review->administers($resource, $sub);
         if ($autoApproved) {
             $this->repository->approveBatch($batchId, $sub);
+            // The auto-approval path is the COMMON one — an admin editing a resource they
+            // administer — and it never reaches ChangeRequestAdminHandler. Announcing only there
+            // would leave the most frequent approval waiting for the cron backstop.
+            $this->publishNotifier?->notify($batchId);
         }
 
         return [

--- a/src/Services/SourceData/DiskSourceDataWriter.php
+++ b/src/Services/SourceData/DiskSourceDataWriter.php
@@ -54,8 +54,10 @@ final class DiskSourceDataWriter implements SourceDataWriter
         ];
     }
 
-    public function commit(ChangeResource $resource): array
+    public function commit(ChangeResource $resource, bool $deletesResource = false): array
     {
+        // Ignored deliberately. Disk mode purges inline, in the handler, gated on the write having
+        // landed — there is no later moment at which to act on this, because there is no later.
         $staged       = $this->staged;
         $this->staged = [];
 

--- a/src/Services/SourceData/MergePollRunResult.php
+++ b/src/Services/SourceData/MergePollRunResult.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+/**
+ * What one {@see MergePollRunner::runOnce()} pass did.
+ *
+ * Every count is reported on EVERY run, including runs that stopped early, for the same reason
+ * {@see PublishRunResult} reports `parkedBatches` unconditionally: the runs most likely to leave
+ * work in an odd state are exactly the runs that end before they meant to.
+ */
+final readonly class MergePollRunResult
+{
+    public function __construct(
+        /** Batches transitioned to `merged`. */
+        public int $merged = 0,
+        /** Batches transitioned to `closed` (and `rejected`) because their PR closed unmerged. */
+        public int $closed = 0,
+        /**
+         * Batches returned to `none` because their pull request merged WITHOUT them. Not a
+         * failure — the design's answer to a concurrent merge — but never silent either, since a
+         * non-zero value here means work was overtaken and will be republished.
+         */
+        public int $reset = 0,
+        /**
+         * Batches `open` with a NULL `pr_number`: unpollable, and stuck forever unless an operator
+         * intervenes. Should always be zero; a non-zero value is an unexplained state, reported
+         * rather than filtered out of the query.
+         */
+        public int $unpollable = 0,
+        /** True if the run stopped because a poll or a containment check threw. */
+        public bool $stoppedOnFailure = false
+    ) {
+    }
+}

--- a/src/Services/SourceData/MergePollRunner.php
+++ b/src/Services/SourceData/MergePollRunner.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Api\Services\SourceData;
 
+use LiturgicalCalendar\Api\Repositories\AuditLogRepository;
 use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
 use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
 use LiturgicalCalendar\Api\Services\GitHub\PullRequestState;
+use LiturgicalCalendar\Api\Services\ResourceTuplePurgeServiceInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -64,6 +66,13 @@ final class MergePollRunner
     public function __construct(
         private readonly SourceDataChangeRequestRepository $repository,
         private readonly GitHubGitDataClient $client,
+        /**
+         * Null on a deployment without OpenFGA. Merge detection must still work there — the whole
+         * point of the write-mode seam is that the stack is optional — so a null purge service is
+         * a quiet no-op, not a failure.
+         */
+        private readonly ?ResourceTuplePurgeServiceInterface $purge = null,
+        private readonly ?AuditLogRepository $auditLog = null,
         ?LoggerInterface $logger = null
     ) {
         $this->logger = $logger ?? new NullLogger();
@@ -136,6 +145,7 @@ final class MergePollRunner
                         'Source-data change request batch closed unmerged.',
                         ['batch_id' => $batch['batch_id'], 'pr_number' => $prNumber]
                     );
+                    $this->audit('change_request.closed_unmerged', $batch['batch_id'], ['pr_number' => $prNumber]);
                 }
             }
 
@@ -157,6 +167,8 @@ final class MergePollRunner
                         'Source-data change request batch merged.',
                         ['batch_id' => $batch['batch_id'], 'pr_number' => $prNumber, 'merge_commit_sha' => $mergeCommitSha]
                     );
+                    $this->audit('change_request.merged', $batch['batch_id'], ['pr_number' => $prNumber, 'merge_commit_sha' => $mergeCommitSha]);
+                    $this->purgeIfResourceDeletion($batch['batch_id']);
                 }
                 continue;
             }
@@ -236,5 +248,99 @@ final class MergePollRunner
         }
 
         return $unpollable;
+    }
+
+    /**
+     * Purge a deleted resource's operational OpenFGA tuples, now that the deletion is real.
+     *
+     * The trigger is `metadata.deletes_resource`, NOT `operation = 'delete'`. The operation cannot
+     * answer this: `RegionalDataHandler::writeI18nFiles()` stages a DELETE for every locale file
+     * dropped from `metadata.locales`, on a calendar that still exists, so keying on it would
+     * revoke every editor on a live calendar because a translator removed a language.
+     *
+     * The object string is rebuilt from the row's own `resource_type` and `resource_id`, which are
+     * already rite-qualified. Do NOT reconstruct a `ChangeResource` here: its factories RE-qualify
+     * a bare id, so `roman/US` would become `roman/roman/US` and fail closed for the wrong reason.
+     *
+     * `admin` tuples survive — that is `ResourceTuplePurgeService`'s own contract — so ownership
+     * outlives a deletion and a recreated resource id belongs to the same person.
+     *
+     * Best-effort, and deliberately so: the batch is already `merged`, which is a fact about the
+     * repository, and a reachable OpenFGA is not a precondition for recording it. A failure logs
+     * and leaves the tuples for `ResourceTuplePurgeReconciler`'s sweep, exactly as the disk-mode
+     * path does.
+     */
+    private function purgeIfResourceDeletion(string $batchId): void
+    {
+        if (null === $this->purge) {
+            return;
+        }
+
+        try {
+            $rows = $this->repository->getBatch($batchId);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Could not read a merged batch to decide whether it deleted a resource; any '
+                    . 'operational tuples it orphaned stay live until the reconciler sweep.',
+                ['batch_id' => $batchId, 'exception' => $e::class, 'message' => $e->getMessage()]
+            );
+
+            return;
+        }
+
+        $first = $rows[0] ?? null;
+        if (null === $first) {
+            return;
+        }
+
+        $metadata = is_array($first['metadata'] ?? null) ? $first['metadata'] : [];
+        if (true !== ( $metadata['deletes_resource'] ?? false )) {
+            return;
+        }
+
+        $resourceType = $first['resource_type'] ?? null;
+        $resourceId   = $first['resource_id'] ?? null;
+        if (!is_string($resourceType) || !is_string($resourceId)) {
+            return;
+        }
+
+        $fgaObject = $resourceType . ':' . $resourceId;
+
+        try {
+            $purged = $this->purge->purgeForObject($fgaObject);
+            $this->logger->info(
+                'Purged operational tuples for a resource whose deletion has merged.',
+                ['batch_id' => $batchId, 'object' => $fgaObject, 'tuples' => $purged]
+            );
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Purging operational tuples for a merged resource deletion failed; the merge stands '
+                    . 'and the reconciler sweep will retry. Until it does, the deleted resource\'s '
+                    . 'former editors retain access to an object whose files are gone.',
+                ['batch_id' => $batchId, 'object' => $fgaObject, 'exception' => $e::class, 'message' => $e->getMessage()]
+            );
+        }
+    }
+
+    /**
+     * Best-effort audit entry. A logging failure must never turn a recorded transition into a
+     * failed run — same rule, and same reasoning, as `ChangeRequestAdminHandler::audit()`.
+     *
+     * The actor is null: nobody at this deployment performed the merge. The reviewer who clicked
+     * Merge did so on GitHub, and attributing it to the approving admin would be a fabrication.
+     *
+     * @param array<string, mixed> $details
+     */
+    private function audit(string $action, string $batchId, array $details): void
+    {
+        if (null === $this->auditLog) {
+            return;
+        }
+
+        try {
+            $this->auditLog->log(null, $action, 'sourcedata_change_request', $batchId, $details);
+        } catch (\Throwable) {
+            // Deliberately swallowed — see method docblock.
+        }
     }
 }

--- a/src/Services/SourceData/MergePollRunner.php
+++ b/src/Services/SourceData/MergePollRunner.php
@@ -258,8 +258,30 @@ final class MergePollRunner
      * dropped from `metadata.locales`, on a calendar that still exists, so keying on it would
      * revoke every editor on a live calendar because a translator removed a language.
      *
-     * The object string is rebuilt from the row's own `resource_type` and `resource_id`, which are
-     * already rite-qualified. Do NOT reconstruct a `ChangeResource` here: its factories RE-qualify
+     * EVERY row of the batch must carry the flag, not merely one. `getBatch()` orders `BY path
+     * ASC` under the database's collation — see its own docblock — so which row lands at index 0
+     * is an accident of string comparison, not a signal that it belongs to the submission that
+     * actually deleted the resource. Worse, `submitBatch()`'s carry-forward UPDATE re-parents an
+     * untouched row onto a new batch id but leaves its `metadata` exactly as it was, so a batch
+     * can genuinely mix a flagged row from one submission with an unflagged row carried forward
+     * from an earlier, non-deleting one. `array_find()` (accept any flagged row) does not close
+     * this: a batch that mixes an unflagged UPDATE of the calendar file with flagged, carried-
+     * forward i18n DELETE rows is a locale removal, not a resource deletion, and `array_find()`
+     * would purge it. So this requires unanimity via `array_all()` — a pure resource deletion has
+     * every row flagged, and any mixture, in either direction, does not purge.
+     *
+     * This fails CLOSED, deliberately, and that asymmetry is the whole point for an authorization
+     * decision: wrongly purging revokes real access on a live calendar, while wrongly not purging
+     * merely leaves tuples live — exactly the status quo before this task, visible and
+     * recoverable. The residual: an exotic carry-forward can leave a genuine deletion batch
+     * holding one unflagged row, in which case the purge does not fire and the tuples stay live
+     * until an operator or `ResourceTuplePurgeReconciler`'s sweep removes them. That is accepted,
+     * not an oversight — do not "tighten" this back to `array_find()` without re-reading this.
+     *
+     * The object string is rebuilt from a flagged row's own `resource_type` and `resource_id`,
+     * which are already rite-qualified (all rows of a batch share one resource, so any flagged row
+     * gives the same answer — but it is read only once unanimity is established, never from
+     * `$rows[0]` by position). Do NOT reconstruct a `ChangeResource` here: its factories RE-qualify
      * a bare id, so `roman/US` would become `roman/roman/US` and fail closed for the wrong reason.
      *
      * `admin` tuples survive — that is `ResourceTuplePurgeService`'s own contract — so ownership
@@ -288,18 +310,29 @@ final class MergePollRunner
             return;
         }
 
-        $first = $rows[0] ?? null;
-        if (null === $first) {
+        if ([] === $rows) {
             return;
         }
 
-        $metadata = is_array($first['metadata'] ?? null) ? $first['metadata'] : [];
-        if (true !== ( $metadata['deletes_resource'] ?? false )) {
+        $isFlagged = static function (array $row): bool {
+            $metadata = is_array($row['metadata'] ?? null) ? $row['metadata'] : [];
+
+            return true === ( $metadata['deletes_resource'] ?? false );
+        };
+
+        if (!array_all($rows, $isFlagged)) {
+            // Not unanimous: either no row is flagged (an ordinary batch), or the flag is mixed
+            // with an unflagged row — a locale removal or a carry-forward mismatch. Neither
+            // deletes the resource, so nothing is purged.
             return;
         }
 
-        $resourceType = $first['resource_type'] ?? null;
-        $resourceId   = $first['resource_id'] ?? null;
+        // Unanimity established: every row is flagged, so the first one is a row this method has
+        // actually tested, not a `$rows[0]` read by bare position.
+        $flagged = $rows[0];
+
+        $resourceType = $flagged['resource_type'] ?? null;
+        $resourceId   = $flagged['resource_id'] ?? null;
         if (!is_string($resourceType) || !is_string($resourceId)) {
             return;
         }

--- a/src/Services/SourceData/MergePollRunner.php
+++ b/src/Services/SourceData/MergePollRunner.php
@@ -7,7 +7,6 @@ namespace LiturgicalCalendar\Api\Services\SourceData;
 use LiturgicalCalendar\Api\Repositories\AuditLogRepository;
 use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
 use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
-use LiturgicalCalendar\Api\Services\GitHub\PullRequestState;
 use LiturgicalCalendar\Api\Services\ResourceTuplePurgeServiceInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -37,14 +36,31 @@ use Psr\Log\NullLogger;
  * Marking C `merged` would ASSERT it reached the repository. The publisher selects approved rows
  * that are not yet `merged`, so C would never be attempted again and its content would be lost
  * silently — the same failure mode the age-based ancestor exclusion was chosen to avoid, reached
- * from the other direction. So containment is verified rather than assumed: a batch whose commit
- * is the merged head is contained (no extra call, the ordinary case), and any other batch on that
- * pull request is checked with one `compareCommits()`. A batch that is NOT contained is returned
- * to `none` and republished under a fresh pull request.
+ * from the other direction. So containment is verified with one `compareCommits()` PER BATCH on a
+ * merged pull request, never assumed. A batch that is NOT contained is returned to `none` and
+ * republished under a fresh pull request.
  *
  * A containment check that FAILS is read neither way. Assuming contained loses content; assuming
  * not-contained republishes work already in the repository. Both guesses are wrong, so the run
  * stops and the batch stays `open` for the next tick.
+ *
+ * # No zero-call fast path — a deliberate departure from the design spec
+ *
+ * An earlier revision (and the original design spec) short-circuited {@see isContained()} when
+ * a batch's own commit sha equaled the pull request's reported `head.sha`, reasoning that a
+ * merged pull request's head IS what was merged, so equality alone proves containment with no
+ * GitHub call. That reasoning silently assumes GitHub's reported `head.sha` stays frozen once a
+ * pull request merges. It does not, here: the branch this feature publishes to is a ROLLING
+ * branch, reused across successive pull requests for the SAME resource, so a closed pull
+ * request's `head.sha` can move after its own merge, as a later publish reuses the branch name
+ * and GitHub reports the branch's new tip against the now-closed pull request too. The one case
+ * where `headSha === batchCommitSha` would have failed is exactly the concurrent-merge race the
+ * whole containment mechanism exists to catch — see "Sharing a pull request is not being in the
+ * merge" above — so a fast path that skips verification precisely when verification matters most
+ * defeats the mechanism it was meant to optimize. The savings were one API call per MERGED pull
+ * request, ever — a pull request transitions out of `open` exactly once — which is not worth
+ * trading away the one property this class exists to guarantee. Do not reinstate this as an
+ * "obvious" optimization.
  *
  * # No claim protocol
  *
@@ -94,13 +110,12 @@ final class MergePollRunner
             return new MergePollRunResult(unpollable: $unpollable, stoppedOnFailure: true);
         }
 
-        $merged = 0;
-        $closed = 0;
-        $reset  = 0;
+        /** @var array{merged: int, closed: int, reset: int} $tally */
+        $tally = ['merged' => 0, 'closed' => 0, 'reset' => 0];
 
         foreach (array_slice($prNumbers, 0, $limit) as $prNumber) {
             try {
-                $tally = $this->pollOne($prNumber);
+                $this->pollOne($prNumber, $tally);
             } catch (\Throwable $e) {
                 $this->logger->error(
                     'Polling a source-data pull request failed; stopping this run rather than '
@@ -108,30 +123,34 @@ final class MergePollRunner
                     ['pr_number' => $prNumber, 'exception' => $e::class, 'message' => $e->getMessage()]
                 );
 
-                return new MergePollRunResult($merged, $closed, $reset, $unpollable, true);
+                return new MergePollRunResult($tally['merged'], $tally['closed'], $tally['reset'], $unpollable, true);
             }
-
-            $merged += $tally['merged'];
-            $closed += $tally['closed'];
-            $reset  += $tally['reset'];
         }
 
-        return new MergePollRunResult($merged, $closed, $reset, $unpollable);
+        return new MergePollRunResult($tally['merged'], $tally['closed'], $tally['reset'], $unpollable);
     }
 
     /**
-     * @return array{merged: int, closed: int, reset: int}
+     * `$tally` is mutated IN PLACE, rather than accumulated from a return value, so that a throw
+     * partway through this pull request's own batches does not discard the transitions already
+     * COMMITTED (to the database) for earlier batches on the SAME pull request — a merged pull
+     * request can carry several batches (see the class docblock's "One poll per pull request, not
+     * per batch"), and a `compareCommits()` failure on the second batch must not make this run
+     * report `merged=0` for a first batch it genuinely already marked merged.
+     * {@see MergePollRunResult}'s own docblock requires exactly this: every count reported on
+     * every run, "including runs that stopped early".
+     *
+     * @param array{merged: int, closed: int, reset: int} $tally
      */
-    private function pollOne(int $prNumber): array
+    private function pollOne(int $prNumber, array &$tally): void
     {
-        $pr    = $this->client->getPullRequest($prNumber);
-        $tally = ['merged' => 0, 'closed' => 0, 'reset' => 0];
+        $pr = $this->client->getPullRequest($prNumber);
 
         if ('open' === $pr->state) {
             // The steady-state majority: most polled pull requests are still awaiting review.
             // Checked before listOpenBatchesForPullRequest() so an open PR costs one GitHub call
             // and no wasted database query.
-            return $tally;
+            return;
         }
 
         $states = $this->repository->listOpenBatchesForPullRequest($prNumber);
@@ -149,7 +168,7 @@ final class MergePollRunner
                 }
             }
 
-            return $tally;
+            return;
         }
 
         // Merged. `mergeCommitSha` is non-null for a merged pull request; a merged PR without one
@@ -160,7 +179,7 @@ final class MergePollRunner
         }
 
         foreach ($states as $batch) {
-            if ($this->isContained($batch['commit_sha'], $pr, $mergeCommitSha)) {
+            if ($this->isContained($batch['commit_sha'], $mergeCommitSha)) {
                 if ($this->repository->markBatchMerged($batch['batch_id'], $mergeCommitSha) > 0) {
                     $tally['merged']++;
                     $this->logger->info(
@@ -190,29 +209,24 @@ final class MergePollRunner
                 );
             }
         }
-
-        return $tally;
     }
 
     /**
      * Is this batch's commit inside the merged pull request's history?
      *
-     * Equality with the merged head is decided locally and costs nothing — the ordinary case, since
-     * most pull requests carry one batch. Anything else costs one `compareCommits()`, read as
-     * "$head is <status> $base": `ahead` or `identical` means the merge commit's history contains
-     * the batch's commit.
+     * ALWAYS costs one `compareCommits()` — see the class docblock's "No zero-call fast path"
+     * section for why an equality shortcut against the pull request's reported `head.sha` was
+     * removed rather than kept as an optimization. Read as "$head is <status> $base": `ahead` or
+     * `identical` means the merge commit's history contains the batch's commit.
      *
      * A null `commit_sha` on an `open` row is unexplained (the publisher writes one for every row
-     * it records), so it is read conservatively as NOT contained rather than optimistically.
+     * it records), so it is read conservatively as NOT contained rather than optimistically —
+     * and spends no GitHub call, since there is nothing to compare.
      */
-    private function isContained(?string $batchCommitSha, PullRequestState $pr, string $mergeCommitSha): bool
+    private function isContained(?string $batchCommitSha, string $mergeCommitSha): bool
     {
         if (null === $batchCommitSha || '' === $batchCommitSha) {
             return false;
-        }
-
-        if ($batchCommitSha === $pr->headSha) {
-            return true;
         }
 
         $status = $this->client->compareCommits($batchCommitSha, $mergeCommitSha);

--- a/src/Services/SourceData/MergePollRunner.php
+++ b/src/Services/SourceData/MergePollRunner.php
@@ -115,13 +115,17 @@ final class MergePollRunner
      */
     private function pollOne(int $prNumber): array
     {
-        $pr     = $this->client->getPullRequest($prNumber);
-        $tally  = ['merged' => 0, 'closed' => 0, 'reset' => 0];
-        $states = $this->repository->listOpenBatchesForPullRequest($prNumber);
+        $pr    = $this->client->getPullRequest($prNumber);
+        $tally = ['merged' => 0, 'closed' => 0, 'reset' => 0];
 
         if ('open' === $pr->state) {
+            // The steady-state majority: most polled pull requests are still awaiting review.
+            // Checked before listOpenBatchesForPullRequest() so an open PR costs one GitHub call
+            // and no wasted database query.
             return $tally;
         }
+
+        $states = $this->repository->listOpenBatchesForPullRequest($prNumber);
 
         if ($pr->isClosedUnmerged()) {
             foreach ($states as $batch) {

--- a/src/Services/SourceData/MergePollRunner.php
+++ b/src/Services/SourceData/MergePollRunner.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
+use LiturgicalCalendar\Api\Services\GitHub\PullRequestState;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Polls the rolling pull requests that carry published change-request batches and records what
+ * became of them.
+ *
+ * # Polling, not webhooks
+ *
+ * A webhook would need a new public route, HMAC verification, and a second authentication mode on
+ * `/_ops` — real attack surface for a transition nobody is waiting on. A missed webhook is a
+ * silently stuck row; a missed poll is picked up on the next tick.
+ *
+ * # One poll per pull request, not per batch
+ *
+ * The rolling branch is per RESOURCE, and {@see SourceDataPublisher} reuses an already-open pull
+ * request. Two batches for one resource therefore share one `pr_number`, and polling per batch
+ * would ask GitHub the same question twice and answer it twice.
+ *
+ * # Sharing a pull request is not being in the merge
+ *
+ * A reviewer clicking Merge concurrently with a publish separates the two: the publish
+ * fast-forwards the branch to batch C's commit, the merge takes the head it had a moment earlier,
+ * and C is left recorded against a pull request that closed without carrying it.
+ *
+ * Marking C `merged` would ASSERT it reached the repository. The publisher selects approved rows
+ * that are not yet `merged`, so C would never be attempted again and its content would be lost
+ * silently — the same failure mode the age-based ancestor exclusion was chosen to avoid, reached
+ * from the other direction. So containment is verified rather than assumed: a batch whose commit
+ * is the merged head is contained (no extra call, the ordinary case), and any other batch on that
+ * pull request is checked with one `compareCommits()`. A batch that is NOT contained is returned
+ * to `none` and republished under a fresh pull request.
+ *
+ * A containment check that FAILS is read neither way. Assuming contained loses content; assuming
+ * not-contained republishes work already in the repository. Both guesses are wrong, so the run
+ * stops and the batch stays `open` for the next tick.
+ *
+ * # No claim protocol
+ *
+ * Unlike {@see PublishRunner}, this holds nothing and claims nothing. Its writes are `UPDATE`s
+ * guarded on `publication_status = 'open'`, so two racing pollers produce one transition and one
+ * no-op. There is no stranded state to reclaim, which is why there is no grace period, no attempt
+ * bound and no reclaim step here. Do not add one for symmetry.
+ *
+ * # Stop, don't hammer
+ *
+ * A failed poll stops the run rather than moving to the next pull request. If GitHub is down or
+ * the installation credential is stale, every remaining poll fails identically, and retrying
+ * in-process would only exhaust the rate limit faster. The cron interval is what re-attempts.
+ */
+final class MergePollRunner
+{
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly SourceDataChangeRequestRepository $repository,
+        private readonly GitHubGitDataClient $client,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function runOnce(int $limit = 50): MergePollRunResult
+    {
+        $unpollable = $this->unpollableCountSafely();
+
+        try {
+            $prNumbers = $this->repository->listOpenPullRequestNumbers();
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Listing open source-data pull requests failed; stopping this run rather than '
+                    . 'polling against an unhealthy database.',
+                ['exception' => $e::class, 'message' => $e->getMessage()]
+            );
+
+            return new MergePollRunResult(unpollable: $unpollable, stoppedOnFailure: true);
+        }
+
+        $merged = 0;
+        $closed = 0;
+        $reset  = 0;
+
+        foreach (array_slice($prNumbers, 0, $limit) as $prNumber) {
+            try {
+                $tally = $this->pollOne($prNumber);
+            } catch (\Throwable $e) {
+                $this->logger->error(
+                    'Polling a source-data pull request failed; stopping this run rather than '
+                        . 'hammering a failing API with the rest of the queue.',
+                    ['pr_number' => $prNumber, 'exception' => $e::class, 'message' => $e->getMessage()]
+                );
+
+                return new MergePollRunResult($merged, $closed, $reset, $unpollable, true);
+            }
+
+            $merged += $tally['merged'];
+            $closed += $tally['closed'];
+            $reset  += $tally['reset'];
+        }
+
+        return new MergePollRunResult($merged, $closed, $reset, $unpollable);
+    }
+
+    /**
+     * @return array{merged: int, closed: int, reset: int}
+     */
+    private function pollOne(int $prNumber): array
+    {
+        $pr     = $this->client->getPullRequest($prNumber);
+        $tally  = ['merged' => 0, 'closed' => 0, 'reset' => 0];
+        $states = $this->repository->listOpenBatchesForPullRequest($prNumber);
+
+        if ('open' === $pr->state) {
+            return $tally;
+        }
+
+        if ($pr->isClosedUnmerged()) {
+            foreach ($states as $batch) {
+                $reason = sprintf('Pull request #%d was closed without merging.', $prNumber);
+                if ($this->repository->markBatchClosedUnmerged($batch['batch_id'], $reason) > 0) {
+                    $tally['closed']++;
+                    $this->logger->info(
+                        'Source-data change request batch closed unmerged.',
+                        ['batch_id' => $batch['batch_id'], 'pr_number' => $prNumber]
+                    );
+                }
+            }
+
+            return $tally;
+        }
+
+        // Merged. `mergeCommitSha` is non-null for a merged pull request; a merged PR without one
+        // is GitHub contradicting itself, and guessing a sha is worse than stopping.
+        $mergeCommitSha = $pr->mergeCommitSha;
+        if (null === $mergeCommitSha) {
+            throw new \RuntimeException(sprintf('Pull request #%d reports merged but carries no merge_commit_sha', $prNumber));
+        }
+
+        foreach ($states as $batch) {
+            if ($this->isContained($batch['commit_sha'], $pr, $mergeCommitSha)) {
+                if ($this->repository->markBatchMerged($batch['batch_id'], $mergeCommitSha) > 0) {
+                    $tally['merged']++;
+                    $this->logger->info(
+                        'Source-data change request batch merged.',
+                        ['batch_id' => $batch['batch_id'], 'pr_number' => $prNumber, 'merge_commit_sha' => $mergeCommitSha]
+                    );
+                }
+                continue;
+            }
+
+            if ($this->repository->returnBatchToUnpublished($batch['batch_id']) > 0) {
+                $tally['reset']++;
+                $this->logger->warning(
+                    'A pull request merged WITHOUT one of the batches recorded against it — most '
+                        . 'likely a review that landed concurrently with a publish. The batch is '
+                        . 'claimable again and the next publish opens a fresh pull request carrying '
+                        . 'it; it is deliberately NOT marked merged, which would assert it reached '
+                        . 'the repository and lose its content silently.',
+                    [
+                        'batch_id'         => $batch['batch_id'],
+                        'pr_number'        => $prNumber,
+                        'batch_commit_sha' => $batch['commit_sha'],
+                        'merge_commit_sha' => $mergeCommitSha,
+                    ]
+                );
+            }
+        }
+
+        return $tally;
+    }
+
+    /**
+     * Is this batch's commit inside the merged pull request's history?
+     *
+     * Equality with the merged head is decided locally and costs nothing — the ordinary case, since
+     * most pull requests carry one batch. Anything else costs one `compareCommits()`, read as
+     * "$head is <status> $base": `ahead` or `identical` means the merge commit's history contains
+     * the batch's commit.
+     *
+     * A null `commit_sha` on an `open` row is unexplained (the publisher writes one for every row
+     * it records), so it is read conservatively as NOT contained rather than optimistically.
+     */
+    private function isContained(?string $batchCommitSha, PullRequestState $pr, string $mergeCommitSha): bool
+    {
+        if (null === $batchCommitSha || '' === $batchCommitSha) {
+            return false;
+        }
+
+        if ($batchCommitSha === $pr->headSha) {
+            return true;
+        }
+
+        $status = $this->client->compareCommits($batchCommitSha, $mergeCommitSha);
+
+        return in_array($status, ['ahead', 'identical'], true);
+    }
+
+    /**
+     * Wrapped for the same reason every DB call in {@see PublishRunner} is: reporting how much work
+     * is in an odd state must never be the thing that turns a completed run into a raw fatal.
+     */
+    private function unpollableCountSafely(): int
+    {
+        try {
+            $unpollable = $this->repository->countOpenBatchesWithoutPullRequest();
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Counting unpollable open source-data batches failed; this run reports 0, which may '
+                    . 'understate what is actually stuck.',
+                ['exception' => $e::class, 'message' => $e->getMessage()]
+            );
+
+            return 0;
+        }
+
+        if ($unpollable > 0) {
+            $this->logger->warning(
+                'Source-data change request batches are `open` with no pull request number, so '
+                    . 'nothing will ever poll them. The publisher always records one, so this is an '
+                    . 'unexplained state and needs an operator.',
+                ['unpollable_batches' => $unpollable]
+            );
+        }
+
+        return $unpollable;
+    }
+}

--- a/src/Services/SourceData/PublishClaim.php
+++ b/src/Services/SourceData/PublishClaim.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+/**
+ * A held claim on one publishable batch: which batch, and — the part phase 2 lacked — WHICH
+ * runner holds it.
+ *
+ * Phase 2 returned a bare batch id, so `releaseClaim()`'s `publication_status = 'queued'` guard
+ * could only ask "is this batch under SOME claim", never "under MINE". The token closes that:
+ * see {@see \LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository::releaseClaim()}.
+ */
+final readonly class PublishClaim
+{
+    public function __construct(
+        public string $batchId,
+        /** Generated inside the claiming transaction; cleared by record and by reclaim. */
+        public string $token
+    ) {
+    }
+}

--- a/src/Services/SourceData/PublishConsumerLoop.php
+++ b/src/Services/SourceData/PublishConsumerLoop.php
@@ -124,60 +124,90 @@ final class PublishConsumerLoop
 
     public function tick(): void
     {
-        if (!$this->groupEnsured) {
-            $this->consumer->ensureGroup();
-            $this->groupEnsured = true;
-        }
-
         $woken = false;
 
-        $this->consumer->readOnce(
-            $this->blockMs,
-            function (string $batchId) use (&$woken): void {
-                $woken = true;
+        try {
+            if (!$this->groupEnsured) {
+                $this->consumer->ensureGroup();
+                $this->groupEnsured = true;
+            }
 
-                if ($this->publishBackoffActive()) {
+            $this->consumer->readOnce(
+                $this->blockMs,
+                function (string $batchId) use (&$woken): void {
+                    $woken = true;
+
+                    if ($this->publishBackoffActive()) {
+                        $this->logger->info(
+                            'Stream-driven publish run suppressed by the post-failure backoff; '
+                                . 'the message is acknowledged and cron remains the backstop.',
+                            ['batch_id' => $batchId, 'backoff_seconds' => $this->mergePollIntervalSeconds]
+                        );
+
+                        return;
+                    }
+
                     $this->logger->info(
-                        'Stream-driven publish run suppressed by the post-failure backoff; '
-                            . 'the message is acknowledged and cron remains the backstop.',
-                        ['batch_id' => $batchId, 'backoff_seconds' => $this->mergePollIntervalSeconds]
+                        'Woken by an approved source-data batch; claiming from the database.',
+                        ['batch_id' => $batchId]
                     );
 
-                    return;
-                }
+                    try {
+                        $result = $this->publisher->runOnce();
+                        $this->logger->info('Stream-driven publish run finished.', [
+                            'published'          => $result->published,
+                            'stopped_on_failure' => $result->stoppedOnFailure,
+                            'parked'             => $result->parkedBatches,
+                        ]);
 
-                $this->logger->info(
-                    'Woken by an approved source-data batch; claiming from the database.',
-                    ['batch_id' => $batchId]
-                );
+                        // See class docblock's "Publish-failure backoff" section: a failed run
+                        // starts the backoff window; a successful one clears it.
+                        $this->lastPublishFailureAt = $result->stoppedOnFailure ? time() : null;
+                    } catch (\Throwable $e) {
+                        // Reachable: PublishRunner's own catch blocks call its logger, and a logger
+                        // whose write throws escapes from inside them. See the class docblock's
+                        // "Nothing here may kill the consumer" section — this is load-bearing, not
+                        // defensive-in-depth for an impossible case.
+                        $this->logger->error('Stream-driven publish run threw; the consumer stays up.', [
+                            'batch_id'  => $batchId,
+                            'exception' => $e::class,
+                            'message'   => $e->getMessage(),
+                        ]);
 
-                try {
-                    $result = $this->publisher->runOnce();
-                    $this->logger->info('Stream-driven publish run finished.', [
-                        'published'          => $result->published,
-                        'stopped_on_failure' => $result->stoppedOnFailure,
-                        'parked'             => $result->parkedBatches,
-                    ]);
+                        $this->lastPublishFailureAt = time();
+                    }
+                },
+            );
+        } catch (\Throwable $e) {
+            // ensureGroup() and readOnce() sit OUTSIDE the try/catch above them on purpose — that
+            // one only ever guards the publisher's own runOnce() call. A \RedisException from
+            // xPending/xClaim/xReadGroup/xAck (a dropped connection, a Redis restart) would
+            // otherwise propagate out of tick(), out of run(), and kill this long-lived process —
+            // exactly the crash loop this class's own docblock ("Nothing here may kill the
+            // consumer") argues against, reached one collaborator further down than the cases
+            // that docblock already covers.
+            //
+            // groupEnsured resets to false so the NEXT tick re-runs ensureGroup() — the
+            // connection may have dropped and a fresh one starts with no consumer group.
+            $this->groupEnsured = false;
 
-                    // See class docblock's "Publish-failure backoff" section: a failed run
-                    // starts the backoff window; a successful one clears it.
-                    $this->lastPublishFailureAt = $result->stoppedOnFailure ? time() : null;
-                } catch (\Throwable $e) {
-                    // Reachable: PublishRunner's own catch blocks call its logger, and a logger
-                    // whose write throws escapes from inside them. See the class docblock's
-                    // "Nothing here may kill the consumer" section — this is load-bearing, not
-                    // defensive-in-depth for an impossible case.
-                    $this->logger->error('Stream-driven publish run threw; the consumer stays up.', [
-                        'batch_id'  => $batchId,
-                        'exception' => $e::class,
-                        'message'   => $e->getMessage(),
-                    ]);
+            $this->logger->error('Stream read failed; the consumer stays up.', [
+                'exception' => $e::class,
+                'message'   => $e->getMessage(),
+            ]);
 
-                    $this->lastPublishFailureAt = time();
-                }
-            },
-        );
+            // readOnce()'s BLOCK is what normally paces this loop; when it throws instead of
+            // blocking, tick() would otherwise return immediately and run() would spin hot
+            // against a still-failing Redis. usleep() here replaces exactly the wait the block
+            // would have provided — and stays instant in tests that pass blockMs: 0.
+            usleep($this->blockMs * 1000);
+        }
 
+        // Runs on every path where the stream did not hand over a message, deliberately
+        // including the failure path above: the merge poll depends on Postgres and GitHub, not
+        // Redis, so a stream outage is not a reason to stop finding merged pull requests — it is
+        // still rate-limited to $mergePollIntervalSeconds by pollMergesIfDue() itself, so a
+        // hot-spinning stream failure cannot turn this into hammering GitHub either.
         if (!$woken) {
             $this->pollMergesIfDue();
         }

--- a/src/Services/SourceData/PublishConsumerLoop.php
+++ b/src/Services/SourceData/PublishConsumerLoop.php
@@ -23,13 +23,36 @@ use Psr\Log\NullLogger;
  * - This class inherits every guarantee phase 2 built (the claim protocol, bounded attempts,
  *   parking, stop-don't-hammer) without reimplementing any of it.
  *
- * # Nothing here may kill the consumer
+ * # Nothing here may kill the consumer — and this catch is load-bearing, not decorative
  *
- * `PublishRunner` and `MergePollRunner` already catch everything they can and report it in
- * their result objects, so an exception reaching this loop is unexpected by construction —
- * which is exactly why it must be caught rather than allowed to end a process that is meant to
- * stay up. systemd would restart it, but a crash loop against a failing database is the
- * hammering both runners exist to avoid.
+ * `PublishRunner` and `MergePollRunner` catch everything they can from their OWN collaborators
+ * (repository, publisher, GitHub client, purge service, audit log) and report it in their result
+ * objects. That is NOT the same as "an exception can never reach this loop": both classes take an
+ * ordinary, non-`final` `?LoggerInterface $logger` through their constructors, and their own
+ * `catch (\Throwable)` blocks call that logger from INSIDE themselves — a write that itself
+ * throws is not caught by the block it is inside of. `MergePollRunner::unpollableCountSafely()`
+ * is the clearest case: its `warning()` call on a non-zero unpollable count sits entirely outside
+ * any `try`/`catch`, at the very top of `runOnce()`, before that method's own first `try` block
+ * even opens — so a throwing logger escapes immediately and completely.
+ *
+ * This is not hypothetical for this codebase: phase 2 shipped a cron entry point wired to
+ * `LoggerFactory::create()`'s default processors, which threw on any record whose context lacked
+ * `type => request|response` — meaning every log line either runner wrote, including the ones
+ * inside their own defensive catch blocks, would have thrown in production. The `try`/`catch`
+ * around each `runOnce()` call below is what stands between that failure mode and a crashed
+ * long-lived process; systemd would restart it, but a crash loop against a failing logger is the
+ * hammering both runners exist to avoid, reached one layer up instead of down. See
+ * {@see \LiturgicalCalendar\Tests\Services\SourceData\PublishConsumerLoopTest::testAPublishRunFailureDoesNotKillTheConsumer()}
+ * and
+ * {@see \LiturgicalCalendar\Tests\Services\SourceData\PublishConsumerLoopTest::testAMergePollFailureDoesNotKillTheConsumer()},
+ * which drive a real `PublishRunner` / `MergePollRunner` with a throwing `LoggerInterface` double
+ * to pin exactly this path, and were confirmed to fail (with the escaped exception) when this
+ * class's own catch is removed.
+ *
+ * A deliberate departure from {@see \LiturgicalCalendar\Api\Services\Outbox\ConsumerLoop},
+ * which does NOT wrap its own `processor->processOne()` call and relies on systemd alone — not a
+ * habit copied without thought, but a stronger guarantee this class chooses to provide because the
+ * failure mode above is real here.
  *
  * # The idle tick, and why it is rate-limited
  *
@@ -89,8 +112,10 @@ final class PublishConsumerLoop
                         'parked'             => $result->parkedBatches,
                     ]);
                 } catch (\Throwable $e) {
-                    // PublishRunner catches everything it can, so reaching here is unexpected —
-                    // which is why it must not end the process. See the class docblock.
+                    // Reachable: PublishRunner's own catch blocks call its logger, and a logger
+                    // whose write throws escapes from inside them. See the class docblock's
+                    // "Nothing here may kill the consumer" section — this is load-bearing, not
+                    // defensive-in-depth for an impossible case.
                     $this->logger->error('Stream-driven publish run threw; the consumer stays up.', [
                         'batch_id'  => $batchId,
                         'exception' => $e::class,
@@ -127,8 +152,9 @@ final class PublishConsumerLoop
                 ]);
             }
         } catch (\Throwable $e) {
-            // MergePollRunner catches everything it can, so reaching here is unexpected —
-            // which is why it must not end the process. See the class docblock.
+            // Reachable: MergePollRunner::unpollableCountSafely()'s warning() call sits outside
+            // any try/catch at the very top of runOnce(), so a throwing logger escapes cleanly.
+            // See the class docblock's "Nothing here may kill the consumer" section.
             $this->logger->error('Idle-tick merge poll threw; the consumer stays up.', [
                 'exception' => $e::class,
                 'message'   => $e->getMessage(),

--- a/src/Services/SourceData/PublishConsumerLoop.php
+++ b/src/Services/SourceData/PublishConsumerLoop.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+use LiturgicalCalendar\Api\Services\Outbox\StreamConsumerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Long-lived consumer for the source-data publish stream.
+ *
+ * # The message is a hint, not a work item
+ *
+ * A message says WHEN to look; Postgres says WHAT is claimable and by whom. So the batch id
+ * carried by a message is used only for logging, and {@see PublishRunner::runOnce()} does the
+ * ordinary claim, exactly as cron does — the message is never handed to the publisher, because
+ * `runOnce()` takes no batch id at all. Three consequences, all of them the point:
+ *
+ * - A lost `XADD` costs latency, never correctness — the cron backstop finds the batch.
+ * - A duplicate or out-of-order message costs one wasted claim against an empty queue.
+ * - This class inherits every guarantee phase 2 built (the claim protocol, bounded attempts,
+ *   parking, stop-don't-hammer) without reimplementing any of it.
+ *
+ * # Nothing here may kill the consumer
+ *
+ * `PublishRunner` and `MergePollRunner` already catch everything they can and report it in
+ * their result objects, so an exception reaching this loop is unexpected by construction —
+ * which is exactly why it must be caught rather than allowed to end a process that is meant to
+ * stay up. systemd would restart it, but a crash loop against a failing database is the
+ * hammering both runners exist to avoid.
+ *
+ * # The idle tick, and why it is rate-limited
+ *
+ * Merge detection has no event to wake on: nothing at this deployment knows a reviewer clicked
+ * Merge. It runs on the idle tick instead — a `readOnce()` that blocked and returned nothing.
+ * With `blockMs` at 5000 that is every five seconds, or 720 GitHub polls an hour for a
+ * transition nobody is waiting on, so it is rate-limited to `$mergePollIntervalSeconds`. Cron
+ * polls it too; this only shortens the wait.
+ *
+ * Not a reuse of {@see \LiturgicalCalendar\Api\Services\Outbox\ConsumerLoop}, which is
+ * constructor-typed to `OutboxProcessorInterface`. Its sibling, sharing the `tick()` / `run()`
+ * split that keeps the loop body unit-testable.
+ */
+final class PublishConsumerLoop
+{
+    private bool $groupEnsured = false;
+
+    private ?int $lastMergePollAt = null;
+
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly StreamConsumerInterface $consumer,
+        private readonly PublishRunner $publisher,
+        /** Null disables the idle poll; the cron entry point still runs it. */
+        private readonly ?MergePollRunner $mergePoller = null,
+        private readonly int $blockMs = 5000,
+        private readonly int $mergePollIntervalSeconds = 60,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function tick(): void
+    {
+        if (!$this->groupEnsured) {
+            $this->consumer->ensureGroup();
+            $this->groupEnsured = true;
+        }
+
+        $woken = false;
+
+        $this->consumer->readOnce(
+            $this->blockMs,
+            function (string $batchId) use (&$woken): void {
+                $woken = true;
+                $this->logger->info(
+                    'Woken by an approved source-data batch; claiming from the database.',
+                    ['batch_id' => $batchId]
+                );
+
+                try {
+                    $result = $this->publisher->runOnce();
+                    $this->logger->info('Stream-driven publish run finished.', [
+                        'published'          => $result->published,
+                        'stopped_on_failure' => $result->stoppedOnFailure,
+                        'parked'             => $result->parkedBatches,
+                    ]);
+                } catch (\Throwable $e) {
+                    // PublishRunner catches everything it can, so reaching here is unexpected —
+                    // which is why it must not end the process. See the class docblock.
+                    $this->logger->error('Stream-driven publish run threw; the consumer stays up.', [
+                        'batch_id'  => $batchId,
+                        'exception' => $e::class,
+                        'message'   => $e->getMessage(),
+                    ]);
+                }
+            },
+        );
+
+        if (!$woken) {
+            $this->pollMergesIfDue();
+        }
+    }
+
+    private function pollMergesIfDue(): void
+    {
+        if (null === $this->mergePoller) {
+            return;
+        }
+
+        $now = time();
+        if (null !== $this->lastMergePollAt && ( $now - $this->lastMergePollAt ) < $this->mergePollIntervalSeconds) {
+            return;
+        }
+        $this->lastMergePollAt = $now;
+
+        try {
+            $result = $this->mergePoller->runOnce();
+            if ($result->merged > 0 || $result->closed > 0 || $result->reset > 0) {
+                $this->logger->info('Idle-tick merge poll settled some batches.', [
+                    'merged' => $result->merged,
+                    'closed' => $result->closed,
+                    'reset'  => $result->reset,
+                ]);
+            }
+        } catch (\Throwable $e) {
+            // MergePollRunner catches everything it can, so reaching here is unexpected —
+            // which is why it must not end the process. See the class docblock.
+            $this->logger->error('Idle-tick merge poll threw; the consumer stays up.', [
+                'exception' => $e::class,
+                'message'   => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Forever. systemd restarts on crash.
+     *
+     * @codeCoverageIgnore
+     */
+    public function run(): never
+    {
+        while (true) {
+            $this->tick();
+        }
+    }
+}

--- a/src/Services/SourceData/PublishConsumerLoop.php
+++ b/src/Services/SourceData/PublishConsumerLoop.php
@@ -38,10 +38,21 @@ use Psr\Log\NullLogger;
  * This is not hypothetical for this codebase: phase 2 shipped a cron entry point wired to
  * `LoggerFactory::create()`'s default processors, which threw on any record whose context lacked
  * `type => request|response` — meaning every log line either runner wrote, including the ones
- * inside their own defensive catch blocks, would have thrown in production. The `try`/`catch`
- * around each `runOnce()` call below is what stands between that failure mode and a crashed
- * long-lived process; systemd would restart it, but a crash loop against a failing logger is the
- * hammering both runners exist to avoid, reached one layer up instead of down. See
+ * inside their own defensive catch blocks, would have thrown in production. Note what this
+ * class's OWN catch below does NOT protect against, though: both of its own `catch` blocks
+ * report through that SAME `$this->logger`, so a logger that throws unconditionally for every
+ * record would make this class's own `error()` call throw too, right back out of the catch that
+ * was supposed to contain it. The actual fix for that specific, unconditional-throw scenario is
+ * upstream, not here: {@see SourceDataPublisherFactory::logger()}'s `includeProcessors: false`
+ * is what keeps the throwing processor out of every logger this feature constructs in the first
+ * place. What THIS class's `try`/`catch` protects against is narrower but still real: a logger
+ * that throws only for SOME records (the runners' own successful-path log calls carry different
+ * context than their catch-block ones, so a processor keyed on record shape could throw for one
+ * and not the other) and any other unexpected escape from a collaborator's logging call that
+ * this class did not anticipate. Either way, the `try`/`catch` around each `runOnce()` call below
+ * is what stands between that narrower failure mode and a crashed long-lived process; systemd
+ * would restart it, but a crash loop against a failing logger is the hammering both runners
+ * exist to avoid, reached one layer up instead of down. See
  * {@see \LiturgicalCalendar\Tests\Services\SourceData\PublishConsumerLoopTest::testAPublishRunFailureDoesNotKillTheConsumer()}
  * and
  * {@see \LiturgicalCalendar\Tests\Services\SourceData\PublishConsumerLoopTest::testAMergePollFailureDoesNotKillTheConsumer()},
@@ -65,12 +76,37 @@ use Psr\Log\NullLogger;
  * Not a reuse of {@see \LiturgicalCalendar\Api\Services\Outbox\ConsumerLoop}, which is
  * constructor-typed to `OutboxProcessorInterface`. Its sibling, sharing the `tick()` / `run()`
  * split that keeps the loop body unit-testable.
+ *
+ * # Publish-failure backoff — the stream removes the interval the attempt bound assumed
+ *
+ * {@see \LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS}
+ * was sized against cron's fixed interval: a handful of consecutive failures spread over a
+ * handful of cron ticks before a batch parks. The stream deletes that spacing. `readOnce()`'s
+ * `COUNT` is 1, so a backlog of queued `XADD`s drains one message per wake with no block in
+ * between — during a GitHub outage, every queued approval wakes `tick()` straight into
+ * `runOnce()` again, and each failing call increments `publish_attempts` (via
+ * `releaseClaim()`) with none of the spacing the bound assumed. A handful of approvals that
+ * arrive while GitHub is down can therefore park the SAME oldest batch in the time a handful
+ * of failed HTTP calls take, rather than the time a handful of cron intervals take.
+ *
+ * The fix mirrors this class's own idle-tick rate limit immediately above: a `runOnce()` that
+ * comes back with {@see PublishRunResult::$stoppedOnFailure} suppresses further stream-driven
+ * publish attempts for `$mergePollIntervalSeconds` — the SAME interval as the idle merge poll,
+ * not a dedicated one, because both exist for the same reason: to keep a bounded, rate-limited
+ * resource (a GitHub API budget) from being spent faster than cron itself would spend it, and
+ * one configuration knob for "how patient is this consumer with a wounded GitHub" is easier to
+ * reason about than two. A suppressed wake still ACKs its message normally — nothing is lost,
+ * because cron remains the backstop throughout — and logs at info so an operator can see the
+ * backoff engage rather than mistake a quiet consumer for a stuck one.
  */
 final class PublishConsumerLoop
 {
     private bool $groupEnsured = false;
 
     private ?int $lastMergePollAt = null;
+
+    /** Set to `time()` when a stream-driven publish run stops on failure; see class docblock. */
+    private ?int $lastPublishFailureAt = null;
 
     private readonly LoggerInterface $logger;
 
@@ -99,6 +135,17 @@ final class PublishConsumerLoop
             $this->blockMs,
             function (string $batchId) use (&$woken): void {
                 $woken = true;
+
+                if ($this->publishBackoffActive()) {
+                    $this->logger->info(
+                        'Stream-driven publish run suppressed by the post-failure backoff; '
+                            . 'the message is acknowledged and cron remains the backstop.',
+                        ['batch_id' => $batchId, 'backoff_seconds' => $this->mergePollIntervalSeconds]
+                    );
+
+                    return;
+                }
+
                 $this->logger->info(
                     'Woken by an approved source-data batch; claiming from the database.',
                     ['batch_id' => $batchId]
@@ -111,6 +158,10 @@ final class PublishConsumerLoop
                         'stopped_on_failure' => $result->stoppedOnFailure,
                         'parked'             => $result->parkedBatches,
                     ]);
+
+                    // See class docblock's "Publish-failure backoff" section: a failed run
+                    // starts the backoff window; a successful one clears it.
+                    $this->lastPublishFailureAt = $result->stoppedOnFailure ? time() : null;
                 } catch (\Throwable $e) {
                     // Reachable: PublishRunner's own catch blocks call its logger, and a logger
                     // whose write throws escapes from inside them. See the class docblock's
@@ -121,6 +172,8 @@ final class PublishConsumerLoop
                         'exception' => $e::class,
                         'message'   => $e->getMessage(),
                     ]);
+
+                    $this->lastPublishFailureAt = time();
                 }
             },
         );
@@ -128,6 +181,16 @@ final class PublishConsumerLoop
         if (!$woken) {
             $this->pollMergesIfDue();
         }
+    }
+
+    /** True while a stream-driven publish run stays suppressed after a prior failure. */
+    private function publishBackoffActive(): bool
+    {
+        if (null === $this->lastPublishFailureAt) {
+            return false;
+        }
+
+        return ( time() - $this->lastPublishFailureAt ) < $this->mergePollIntervalSeconds;
     }
 
     private function pollMergesIfDue(): void

--- a/src/Services/SourceData/PublishRunner.php
+++ b/src/Services/SourceData/PublishRunner.php
@@ -235,6 +235,7 @@ final class PublishRunner
                     $this->isBranchContention($e)
                     && null !== $outcome
                     && ClaimReleaseOutcome::BATCH_MISSING !== $outcome
+                    && ClaimReleaseOutcome::CLAIM_LOST !== $outcome
                 ) {
                     // Two batches of the SAME resource target one branch, so the loser of that
                     // race gets a 422. See the class docblock's "Contention is not an outage".
@@ -244,11 +245,19 @@ final class PublishRunner
                     // that "the next tick republishes it" — true when the release reported
                     // RELEASED or NOT_CLAIMED, and false when the release itself threw (null:
                     // the same outage broke both, and the batch is left `queued` until the
-                    // grace-period reclaim) or when the batch has vanished. Continuing there
-                    // would exit 0 on a database failure purely because the GitHub error that
+                    // grace-period reclaim), when the batch has vanished (BATCH_MISSING), or
+                    // when another runner already holds the live claim (CLAIM_LOST) — that
+                    // reading is excluded here for the same reason the class docblock's "A
+                    // merely SLOW process is not a dead one" section gives: this runner's own
+                    // grace period already elapsed and a second runner has since taken over,
+                    // so THIS runner's attempt genuinely failed regardless of how benign the
+                    // 422 looks, and the run must stop rather than claim the batch "stays
+                    // claimable" when it is actively held by someone else. Continuing on
+                    // BATCH_MISSING or CLAIM_LOST would exit 0 on an unexplained or
+                    // already-spoken-for state purely because the GitHub error that
                     // accompanied it happened to be a 422 — the same DB failure beside a 500
-                    // stops the run — and would read an unexplained state optimistically,
-                    // against ClaimReleaseOutcome's own rule.
+                    // stops the run — and would read that state optimistically, against
+                    // ClaimReleaseOutcome's own rule.
                     // "stays claimable" holds for every attempt but the last: the release that
                     // reports RELEASED is also the one that spends an attempt, so the attempt that
                     // reaches the bound parks the batch in the same breath as this message. Said

--- a/src/Services/SourceData/PublishRunner.php
+++ b/src/Services/SourceData/PublishRunner.php
@@ -68,8 +68,8 @@ use Psr\Log\NullLogger;
  * below. `releaseClaim()` therefore reports the OBSERVED STATUS as a
  * {@see \LiturgicalCalendar\Api\Enum\ClaimReleaseOutcome}, and `runOnce()` branches on it:
  * only `SETTLED_ELSEWHERE` continues without failing; `RELEASED`, `NOT_CLAIMED`,
- * `BATCH_MISSING` and a release that throws are all genuine failures that stop the loop with
- * `stoppedOnFailure: true`, per "Stop, don't hammer" below. See
+ * `BATCH_MISSING`, `CLAIM_LOST` and a release that throws are all genuine failures that stop
+ * the loop with `stoppedOnFailure: true`, per "Stop, don't hammer" below. See
  * {@see \LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient} /
  * `scripts/publish-sourcedata.php`'s HTTP client wiring for the timeout that keeps "still
  * running" and "abandoned" distinguishable in the first place — an unbounded request could
@@ -183,7 +183,7 @@ final class PublishRunner
 
         for ($i = 0; $i < $limit; $i++) {
             try {
-                $batchId = $this->repository->claimNextPublishableBatch($attempted);
+                $claim = $this->repository->claimNextPublishableBatch($attempted);
             } catch (\Throwable $e) {
                 $this->logger->error(
                     'Claiming the next publishable source-data change request batch failed; '
@@ -197,25 +197,25 @@ final class PublishRunner
                 return $this->result($published, stoppedOnFailure: true);
             }
 
-            if (null === $batchId) {
+            if (null === $claim) {
                 break;
             }
 
-            $attempted[] = $batchId;
+            $attempted[] = $claim->batchId;
 
             try {
-                $this->publisher->publish($batchId);
+                $this->publisher->publish($claim->batchId);
             } catch (\Throwable $e) {
                 $this->logger->error(
                     'Publishing source-data change request batch failed.',
                     [
-                        'batch_id'  => $batchId,
+                        'batch_id'  => $claim->batchId,
                         'exception' => $e::class,
                         'message'   => $e->getMessage(),
                     ]
                 );
 
-                $outcome = $this->releaseClaimSafely($batchId);
+                $outcome = $this->releaseClaimSafely($claim->batchId, $claim->token);
 
                 if (null !== $outcome && $outcome->isSettled()) {
                     // The ONLY non-failure reading of a zero-row release, and it is a positive
@@ -226,7 +226,7 @@ final class PublishRunner
                     $this->logger->info(
                         'Batch was already settled (published) by another runner before this '
                             . "run's own release could take effect; not counted as a failure.",
-                        ['batch_id' => $batchId, 'release_outcome' => $outcome->value]
+                        ['batch_id' => $claim->batchId, 'release_outcome' => $outcome->value]
                     );
                     continue;
                 }
@@ -261,7 +261,7 @@ final class PublishRunner
                             . 'which case it is parked and this run reports it as such. '
                             . 'Continuing with the rest of the queue.',
                         [
-                            'batch_id'        => $batchId,
+                            'batch_id'        => $claim->batchId,
                             'message'         => $e->getMessage(),
                             'release_outcome' => $outcome->value ?? 'release_failed',
                         ]
@@ -273,12 +273,15 @@ final class PublishRunner
                 // RELEASED (this runner held the live claim and its publish failed),
                 // NOT_CLAIMED (`none` — nobody published it and nobody holds it, so the work
                 // is still undone), BATCH_MISSING (an unexplained state, never read
-                // optimistically), or null (the release itself threw, already logged by
-                // releaseClaimSafely()). Stop rather than hammer a failing API with the rest
-                // of the queue.
+                // optimistically), CLAIM_LOST (this runner was merely slow, the grace-period
+                // reclaim already freed the batch, and another runner has since claimed it —
+                // this runner's own publish still genuinely failed, and the run stops even
+                // though the runner that actually holds the claim carries on regardless), or
+                // null (the release itself threw, already logged by releaseClaimSafely()).
+                // Stop rather than hammer a failing API with the rest of the queue.
                 $this->logger->warning(
                     'Stopping this run after a failed publish attempt.',
-                    ['batch_id' => $batchId, 'release_outcome' => $outcome->value ?? 'release_failed']
+                    ['batch_id' => $claim->batchId, 'release_outcome' => $outcome->value ?? 'release_failed']
                 );
 
                 return $this->result($published, stoppedOnFailure: true);
@@ -374,10 +377,10 @@ final class PublishRunner
      *                   observation the way a clean status read does, and an unknown state is
      *                   read conservatively.
      */
-    private function releaseClaimSafely(string $batchId): ?ClaimReleaseOutcome
+    private function releaseClaimSafely(string $batchId, string $token): ?ClaimReleaseOutcome
     {
         try {
-            return $this->repository->releaseClaim($batchId);
+            return $this->repository->releaseClaim($batchId, $token);
         } catch (\Throwable $e) {
             $this->logger->error(
                 'Releasing the claim on a failed source-data publish batch also failed; '

--- a/src/Services/SourceData/PublishRunner.php
+++ b/src/Services/SourceData/PublishRunner.php
@@ -67,9 +67,13 @@ use Psr\Log\NullLogger;
  * iteration of the loop that exists to stop hammering — the exact opposite of both rules
  * below. `releaseClaim()` therefore reports the OBSERVED STATUS as a
  * {@see \LiturgicalCalendar\Api\Enum\ClaimReleaseOutcome}, and `runOnce()` branches on it:
- * only `SETTLED_ELSEWHERE` continues without failing; `RELEASED`, `NOT_CLAIMED`,
- * `BATCH_MISSING`, `CLAIM_LOST` and a release that throws are all genuine failures that stop
- * the loop with `stoppedOnFailure: true`, per "Stop, don't hammer" below. See
+ * only `SETTLED_ELSEWHERE` continues without failing outright; `RELEASED`, `NOT_CLAIMED`,
+ * `BATCH_MISSING`, `CLAIM_LOST` and a release that throws are genuine failures that stop the
+ * loop with `stoppedOnFailure: true`, per "Stop, don't hammer" below — UNLESS the failure was
+ * also a lost branch race (a GitHub `422`), which "Contention is not an outage" below carves
+ * out as its own exception for `RELEASED`, `NOT_CLAIMED` and `CLAIM_LOST` (never for
+ * `BATCH_MISSING` or a thrown release, which stay unexplained states regardless of the GitHub
+ * status beside them). See
  * {@see \LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient} /
  * `scripts/publish-sourcedata.php`'s HTTP client wiring for the timeout that keeps "still
  * running" and "abandoned" distinguishable in the first place — an unbounded request could
@@ -85,8 +89,17 @@ use Psr\Log\NullLogger;
  * paging an operator — would report an outage for a race the design deliberately allows. A
  * `422` therefore logs a WARNING (it must stay visible; a silenced race is how a genuinely
  * stuck branch hides) and continues with the rest of the queue, while every other failure
- * still stops. The batch is not let off: the attempt is counted, so a batch that `422`s
- * forever is parked by the bounded-attempts rule below rather than retried forever.
+ * still stops. The batch is not let off when the release was RELEASED: the attempt is
+ * counted, so a batch that `422`s forever is parked by the bounded-attempts rule below rather
+ * than retried forever.
+ *
+ * `CLAIM_LOST` alongside a `422` gets the same continue treatment, for a reason stronger than
+ * "GitHub answered": it is a POSITIVE observation that a different runner holds a live,
+ * freshly-issued claim on this exact batch and is actively working it — the batch is not
+ * merely un-stranded, it is spoken for. That is the opposite of `BATCH_MISSING`, which stays
+ * excluded here even under a `422` because nothing is known about a vanished row. `CLAIM_LOST`
+ * spends no attempt (the guard fails before `releaseClaim()`'s increment runs), so there is no
+ * "parked" caveat for it the way there is for `RELEASED`.
  *
  * # One bad batch must not strand the queue
  *
@@ -235,40 +248,57 @@ final class PublishRunner
                     $this->isBranchContention($e)
                     && null !== $outcome
                     && ClaimReleaseOutcome::BATCH_MISSING !== $outcome
-                    && ClaimReleaseOutcome::CLAIM_LOST !== $outcome
                 ) {
                     // Two batches of the SAME resource target one branch, so the loser of that
                     // race gets a 422. See the class docblock's "Contention is not an outage".
                     //
                     // Gated on the release having actually been OBSERVED, not on the GitHub
-                    // status alone. The message below promises the batch "stays claimable" and
-                    // that "the next tick republishes it" — true when the release reported
-                    // RELEASED or NOT_CLAIMED, and false when the release itself threw (null:
-                    // the same outage broke both, and the batch is left `queued` until the
-                    // grace-period reclaim), when the batch has vanished (BATCH_MISSING), or
-                    // when another runner already holds the live claim (CLAIM_LOST) — that
-                    // reading is excluded here for the same reason the class docblock's "A
-                    // merely SLOW process is not a dead one" section gives: this runner's own
-                    // grace period already elapsed and a second runner has since taken over,
-                    // so THIS runner's attempt genuinely failed regardless of how benign the
-                    // 422 looks, and the run must stop rather than claim the batch "stays
-                    // claimable" when it is actively held by someone else. Continuing on
-                    // BATCH_MISSING or CLAIM_LOST would exit 0 on an unexplained or
-                    // already-spoken-for state purely because the GitHub error that
-                    // accompanied it happened to be a 422 — the same DB failure beside a 500
-                    // stops the run — and would read that state optimistically, against
-                    // ClaimReleaseOutcome's own rule.
-                    // "stays claimable" holds for every attempt but the last: the release that
-                    // reports RELEASED is also the one that spends an attempt, so the attempt that
-                    // reaches the bound parks the batch in the same breath as this message. Said
-                    // plainly here rather than left to contradict the parked warning and the
-                    // `parked` count that the very same run emits.
-                    $this->logger->warning(
-                        'Publishing this batch lost a race for its resource branch (GitHub 422); '
+                    // status alone. RELEASED, NOT_CLAIMED and CLAIM_LOST all continue here;
+                    // only BATCH_MISSING (an unexplained state, never read optimistically) and
+                    // null (the release itself threw — the same outage broke both, and the
+                    // batch is left `queued` until the grace-period reclaim) are excluded.
+                    // Continuing on those would exit 0 on an unexplained state purely because
+                    // the GitHub error that accompanied it happened to be a 422 — the same DB
+                    // failure beside a 500 stops the run — and would read it optimistically,
+                    // against ClaimReleaseOutcome's own rule.
+                    //
+                    // CLAIM_LOST belongs in the continue set, not the stop set, DESPITE the
+                    // class docblock listing it among the outcomes that "stop the loop": that
+                    // sentence describes the fall-through default outside of branch contention.
+                    // Inside a 422, CLAIM_LOST is doubly benign — the "Contention is not an
+                    // outage" section's own reasoning (a 422 is GitHub answering, in detail,
+                    // about THIS request; proof the API is healthy) PLUS a positive observation
+                    // that another runner holds a live, freshly-claimed token on this exact
+                    // batch and is actively working it. That is the opposite of BATCH_MISSING,
+                    // which is excluded precisely because nothing is known about the row.
+                    // Stopping the whole tick here would page an operator for a race the design
+                    // deliberately allows, for a batch that is provably not stranded.
+                    //
+                    // The message varies by outcome because "stays claimable" is only true for
+                    // RELEASED and NOT_CLAIMED — under CLAIM_LOST the batch is not sitting idle
+                    // and claimable, it is held right now by another runner's live claim, which
+                    // will publish it. Saying "stays claimable" there would be false: nobody
+                    // needs to re-claim it, someone already has.
+                    // "stays claimable" also only holds for every RELEASED attempt but the
+                    // last: the release that reports RELEASED is also the one that spends an
+                    // attempt, so the attempt that reaches the bound parks the batch in the
+                    // same breath as this message. Said plainly here rather than left to
+                    // contradict the parked warning and the `parked` count the very same run
+                    // emits. CLAIM_LOST spends no attempt at all — the guard fails before the
+                    // increment runs — so that caveat does not apply to it either.
+                    $message = ClaimReleaseOutcome::CLAIM_LOST === $outcome
+                        ? 'Publishing this batch lost a race for its resource branch (GitHub 422); '
+                            . 'the batch is not stranded — another runner holds a live claim on it '
+                            . 'right now and will publish it, so this attempt was simply redundant. '
+                            . 'Continuing with the rest of the queue.'
+                        : 'Publishing this batch lost a race for its resource branch (GitHub 422); '
                             . 'the batch stays claimable and the next tick republishes it onto the '
                             . 'branch head the winner pushed — unless this attempt was its last, in '
                             . 'which case it is parked and this run reports it as such. '
-                            . 'Continuing with the rest of the queue.',
+                            . 'Continuing with the rest of the queue.';
+
+                    $this->logger->warning(
+                        $message,
                         [
                             'batch_id'        => $claim->batchId,
                             'message'         => $e->getMessage(),
@@ -278,16 +308,20 @@ final class PublishRunner
                     continue;
                 }
 
-                // Everything else is a real failure, whichever way the release read:
-                // RELEASED (this runner held the live claim and its publish failed),
-                // NOT_CLAIMED (`none` — nobody published it and nobody holds it, so the work
-                // is still undone), BATCH_MISSING (an unexplained state, never read
-                // optimistically), CLAIM_LOST (this runner was merely slow, the grace-period
-                // reclaim already freed the batch, and another runner has since claimed it —
-                // this runner's own publish still genuinely failed, and the run stops even
-                // though the runner that actually holds the claim carries on regardless), or
-                // null (the release itself threw, already logged by releaseClaimSafely()).
-                // Stop rather than hammer a failing API with the rest of the queue.
+                // Reached only when the 422-contention branch above did not already
+                // `continue` — i.e. either this was not a lost branch race, or it was but the
+                // release came back BATCH_MISSING or null. Everything that reaches here is a
+                // real failure, whichever way the release read: RELEASED (this runner held the
+                // live claim and its publish failed), NOT_CLAIMED (`none` — nobody published
+                // it and nobody holds it, so the work is still undone), BATCH_MISSING (an
+                // unexplained state, never read optimistically), CLAIM_LOST (this runner was
+                // merely slow, the grace-period reclaim already freed the batch, and another
+                // runner has since claimed it — this runner's own publish still genuinely
+                // failed for a reason OTHER than the benign branch race the 422 branch above
+                // forgives, so the run stops even though the runner that actually holds the
+                // claim carries on regardless), or null (the release itself threw, already
+                // logged by releaseClaimSafely()). Stop rather than hammer a failing API with
+                // the rest of the queue.
                 $this->logger->warning(
                     'Stopping this run after a failed publish attempt.',
                     ['batch_id' => $claim->batchId, 'release_outcome' => $outcome->value ?? 'release_failed']

--- a/src/Services/SourceData/SourceDataPublishNotifier.php
+++ b/src/Services/SourceData/SourceDataPublishNotifier.php
@@ -28,6 +28,17 @@ use Psr\Log\NullLogger;
  */
 class SourceDataPublishNotifier
 {
+    /**
+     * The stream message field carrying the batch id — NOT `RedisStreamConsumer`'s default
+     * ('row_id', the OpenFGA outbox's own field name). `bin/publish-sourcedata-consumer` must
+     * construct its `RedisStreamConsumer` with this same value; nothing else ties the two
+     * together, and a drift between them makes every message look malformed —
+     * `RedisStreamConsumer::readOnce()` logs `bad_message` and ACKs it away silently, so the
+     * consumer would run forever, waking on every notification and doing nothing with any of
+     * them, while cron quietly did all the real work.
+     */
+    public const BATCH_ID_FIELD = 'batch_id';
+
     private readonly LoggerInterface $logger;
 
     public function __construct(
@@ -45,7 +56,7 @@ class SourceDataPublishNotifier
         }
 
         try {
-            $this->redis->xAdd($this->streamName, '*', ['batch_id' => $batchId]);
+            $this->redis->xAdd($this->streamName, '*', [self::BATCH_ID_FIELD => $batchId]);
         } catch (\RedisException $e) {
             $this->logger->warning('sourcedata.redis.notify_failed', [
                 'batch_id' => $batchId,

--- a/src/Services/SourceData/SourceDataPublishNotifier.php
+++ b/src/Services/SourceData/SourceDataPublishNotifier.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Best-effort `XADD` announcing that a batch has become publishable.
+ *
+ * Mirrors {@see \LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier}, and for the same reason:
+ * the row is already durable in Postgres and cron is the backstop, so this is an accelerator over
+ * a durable queue, never the queue itself. It therefore NEVER throws to the caller — a Redis
+ * outage must not fail an approval that has already committed. Losing the message costs latency
+ * and nothing else.
+ *
+ * The message is a HINT, not a work item: the consumer ignores the batch id except for logging and
+ * claims from Postgres exactly as cron does. That is what makes a lost, duplicated or out-of-order
+ * message harmless.
+ *
+ * Pass a null `\Redis` to disable — the ordinary state for a self-hoster, since `REDIS_SOCKET` /
+ * `REDIS_HOST` are commented out in `.env.example`.
+ *
+ * Not `final`, unlike most of this namespace: it has one method and no invariant worth protecting,
+ * and tests substitute a recording subclass rather than justify an interface for it.
+ */
+class SourceDataPublishNotifier
+{
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly ?\Redis $redis,
+        private readonly string $streamName,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function notify(string $batchId): void
+    {
+        if (null === $this->redis) {
+            return;
+        }
+
+        try {
+            $this->redis->xAdd($this->streamName, '*', ['batch_id' => $batchId]);
+        } catch (\RedisException $e) {
+            $this->logger->warning('sourcedata.redis.notify_failed', [
+                'batch_id' => $batchId,
+                'error'    => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/src/Services/SourceData/SourceDataPublisher.php
+++ b/src/Services/SourceData/SourceDataPublisher.php
@@ -11,6 +11,8 @@ use LiturgicalCalendar\Api\Services\GitHub\GitHubAppAuth;
 use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Client\ClientInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use RuntimeException;
 
 /**
@@ -75,6 +77,8 @@ final class SourceDataPublisher implements SourceDataPublisherInterface
 
     private const FALLBACK_AUTHOR_NAME = 'Unknown Editor';
 
+    private readonly LoggerInterface $logger;
+
     public function __construct(
         private readonly SourceDataChangeRequestRepository $repository,
         private readonly GitHubGitDataClient $client,
@@ -83,8 +87,10 @@ final class SourceDataPublisher implements SourceDataPublisherInterface
         /** The App's display name, used as the commit `committer.name`. */
         private readonly string $committerName,
         /** The App's email, used as the commit `committer.email`. */
-        private readonly string $committerEmail
+        private readonly string $committerEmail,
+        ?LoggerInterface $logger = null
     ) {
+        $this->logger = $logger ?? new NullLogger();
     }
 
     /**
@@ -139,7 +145,23 @@ final class SourceDataPublisher implements SourceDataPublisherInterface
             );
         }
 
-        $this->repository->recordPublication($batchId, $branch, $commitSha, $prNumber, $headSha);
+        $recorded = $this->repository->recordPublication($batchId, $branch, $commitSha, $prNumber, $headSha);
+        if (0 === $recorded) {
+            // See recordPublication()'s own docblock: zero rows means the batch was no longer
+            // `queued` when this ran — most likely another runner already recorded a publish
+            // for it first (a stale claim reclaimed while this run was in flight, then both
+            // runs' pushes succeeded). The GitHub side effects above (commit, ref update, pull
+            // request) already happened and cannot be undone here; this is visibility only, so
+            // the guard's effect is not silent.
+            $this->logger->warning(
+                'source_data.publish.record_blocked',
+                [
+                    'batch_id' => $batchId,
+                    'reason'   => 'publication_status was not "queued" when recordPublication() ran '
+                        . '(likely: another runner already recorded a publish for this batch)',
+                ]
+            );
+        }
 
         return new PublishResult($branch, $commitSha, $prNumber, $headSha);
     }
@@ -288,6 +310,8 @@ final class SourceDataPublisher implements SourceDataPublisherInterface
      * `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY_PATH` (via
      * {@see GitHubAppAuth::fromEnv()}), `GITHUB_REPOSITORY` (required), and the optional
      * `GITHUB_BASE_BRANCH` / `GITHUB_APP_COMMITTER_NAME` / `GITHUB_APP_COMMITTER_EMAIL`.
+     * `$logger` defaults to a `NullLogger` and is used only for `publish()`'s
+     * `recordPublication()`-blocked warning — see that method's own docblock.
      *
      * Mirrors {@see \LiturgicalCalendar\Api\Services\OpenFgaClient::fromEnv()}: centralizes
      * every `mixed` `$_ENV`/`getenv()` read in `src/`, behind the already-narrowed
@@ -303,7 +327,8 @@ final class SourceDataPublisher implements SourceDataPublisherInterface
     public static function fromEnv(
         SourceDataChangeRequestRepository $repository,
         ClientInterface $http,
-        CacheItemPoolInterface $installationTokenCache
+        CacheItemPoolInterface $installationTokenCache,
+        ?LoggerInterface $logger = null
     ): self {
         $auth = GitHubAppAuth::fromEnv($http, $installationTokenCache);
 
@@ -320,7 +345,7 @@ final class SourceDataPublisher implements SourceDataPublisherInterface
         $committerEmail = self::getEnvString('GITHUB_APP_COMMITTER_EMAIL')
             ?: 'litcal-publisher[bot]@users.noreply.github.com';
 
-        return new self($repository, $client, $baseBranch, $committerName, $committerEmail);
+        return new self($repository, $client, $baseBranch, $committerName, $committerEmail, $logger);
     }
 
     /**

--- a/src/Services/SourceData/SourceDataPublisherFactory.php
+++ b/src/Services/SourceData/SourceDataPublisherFactory.php
@@ -164,11 +164,11 @@ final class SourceDataPublisherFactory
             try {
                 $redis = new \Redis();
                 if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
-                    $redis->connect((string) $_ENV['REDIS_SOCKET']);
+                    $redis->connect((string) $_ENV['REDIS_SOCKET'], 0, 2.0); // 2 second timeout
                 } else {
                     $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
                     $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
-                    $redis->connect($redisHost, $redisPort);
+                    $redis->connect($redisHost, $redisPort, 2.0); // 2 second timeout
                 }
                 if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
                     $redis->auth((string) $_ENV['REDIS_PASSWORD']);

--- a/src/Services/SourceData/SourceDataPublisherFactory.php
+++ b/src/Services/SourceData/SourceDataPublisherFactory.php
@@ -107,7 +107,7 @@ final class SourceDataPublisherFactory
     public function publishRunner(LoggerInterface $logger): PublishRunner
     {
         $repository = $this->repository();
-        $publisher  = SourceDataPublisher::fromEnv($repository, $this->httpClient(), $this->tokenCache($logger));
+        $publisher  = SourceDataPublisher::fromEnv($repository, $this->httpClient(), $this->tokenCache($logger), $logger);
 
         return new PublishRunner($repository, $publisher, logger: $logger);
     }

--- a/src/Services/SourceData/SourceDataPublisherFactory.php
+++ b/src/Services/SourceData/SourceDataPublisherFactory.php
@@ -157,30 +157,66 @@ final class SourceDataPublisherFactory
      * `.env.example`). A connection failure is caught and also falls back to a null `\Redis`
      * rather than failing this call — Redis here is an accelerator, never a dependency.
      */
+    /**
+     * Read an environment variable from BOTH layers: `$_ENV` first, then `getenv()`.
+     *
+     * Public and static because `bin/publish-sourcedata-consumer` needs exactly this and must not
+     * grow a second copy — see the class docblock on why the wiring lives here.
+     *
+     * The two layers are not interchangeable. Dotenv populates `$_ENV` from the `.env*` FILES, but
+     * PHP CLI commonly runs with `variables_order` excluding `E`, so a variable exported by the
+     * shell or set by a systemd `Environment=`/`EnvironmentFile=` directive reaches `getenv()` and
+     * NEVER `$_ENV`. Reading only `$_ENV` therefore silently ignores the configuration mechanism
+     * the change-request runbook's own systemd unit tells operators to use, and the consumer would
+     * quietly fall back to its defaults — connecting to 127.0.0.1 instead of the configured Redis.
+     *
+     * Mirrors {@see SourceDataPublisher}'s private helper of the same shape, duplicated there
+     * rather than shared for the same precedent {@see \LiturgicalCalendar\Api\Services\OpenFgaClient}
+     * set; this copy exists so the two entry points that are NOT `SourceDataPublisher` share one.
+     *
+     * @return string The trimmed value, or '' when set in neither layer (or empty in both).
+     */
+    public static function envString(string $name): string
+    {
+        $value = $_ENV[$name] ?? null;
+        if (is_string($value) && '' !== trim($value)) {
+            return trim($value);
+        }
+
+        $fromProcess = getenv($name);
+        if (is_string($fromProcess) && '' !== trim($fromProcess)) {
+            return trim($fromProcess);
+        }
+
+        return '';
+    }
+
     public function publishNotifier(): SourceDataPublishNotifier
     {
+        $socket   = self::envString('REDIS_SOCKET');
+        $host     = self::envString('REDIS_HOST');
+        $password = self::envString('REDIS_PASSWORD');
+
         $redis = null;
-        if (extension_loaded('redis') && ( isset($_ENV['REDIS_HOST']) || isset($_ENV['REDIS_SOCKET']) )) {
+        if (extension_loaded('redis') && ( '' !== $socket || '' !== $host )) {
             try {
                 $redis = new \Redis();
-                if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
-                    $redis->connect((string) $_ENV['REDIS_SOCKET'], 0, 2.0); // 2 second timeout
+                if ('' !== $socket) {
+                    $redis->connect($socket, 0, 2.0); // 2 second timeout
                 } else {
-                    $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
-                    $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
-                    $redis->connect($redisHost, $redisPort, 2.0); // 2 second timeout
+                    $port = self::envString('REDIS_PORT');
+                    $redis->connect($host, is_numeric($port) ? (int) $port : 6379, 2.0); // 2 second timeout
                 }
-                if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
-                    $redis->auth((string) $_ENV['REDIS_PASSWORD']);
+                if ('' !== $password) {
+                    $redis->auth($password);
                 }
             } catch (\Throwable) {
                 $redis = null; // Best-effort; the publisher falls back to PG-plus-cron durability.
             }
         }
 
-        $streamName = is_string($_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM'] ?? null)
-            ? $_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM']
-            : 'litcal:sourcedata-publish-stream';
+        $streamName = self::envString('REDIS_SOURCEDATA_PUBLISH_STREAM')
+            ?: 'litcal:sourcedata-publish-stream';
 
         return new SourceDataPublishNotifier($redis, $streamName);
     }

--- a/src/Services/SourceData/SourceDataPublisherFactory.php
+++ b/src/Services/SourceData/SourceDataPublisherFactory.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+use GuzzleHttp\Client as GuzzleClient;
+use LiturgicalCalendar\Api\Database\Connection;
+use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
+use LiturgicalCalendar\Api\Repositories\AuditLogRepository;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubAppAuth;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
+use LiturgicalCalendar\Api\Services\ResourceTuplePurgeService;
+use LiturgicalCalendar\Api\Services\ResourceTuplePurgeServiceInterface;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+
+/**
+ * One wiring, behind three entry points: the cron publisher (`scripts/publish-sourcedata.php`),
+ * the cron merge poller (`scripts/poll-sourcedata-merges.php`) and the Redis stream consumer
+ * (`bin/publish-sourcedata-consumer`).
+ *
+ * # Why this exists
+ *
+ * Phase 2's most expensive defect was a script CONSTRUCTING what every test INJECTED. The cron
+ * entry point took `LoggerFactory::create()`'s default processors, which attach a processor
+ * ({@see \LiturgicalCalendar\Api\Http\Logs\RequestResponseProcessor}) that THROWS on any record
+ * whose context lacks `type => request|response`. `PublishRunner` and `MergePollRunner` log batch
+ * ids and exception classes — so with that default, every log call either runner made, INCLUDING
+ * the ones inside their own catch blocks, would have thrown in production, before
+ * `releaseClaim()` ever ran, stranding the batch. Every unit test passed; none of them crossed
+ * the seam between a hand-built test logger and what the script actually asked `LoggerFactory`
+ * for.
+ *
+ * Phase 3 adds two more entry points to that same wiring, tripling the surface for the same
+ * mistake to recur on. Moving it here, into `src/`, is what brings it under `composer analyse`
+ * (PHPStan level 10): `phpstan.neon.dist` scans `paths: [src]` only, so a script-level
+ * `(string) $_ENV[...]` blind cast is invisible to CI, while the same read inside this class is
+ * not.
+ *
+ * # The umask window is NOT this class's job
+ *
+ * {@see tokenCache()} builds the filesystem-backed cache the installation token is written into
+ * and chmods its directory — but it does not touch the process umask. The token itself is
+ * fetched LAZILY, the first time a built {@see GitHubGitDataClient} sends a request (inside
+ * `runOnce()`, not inside anything in this class), so the restrictive umask that protects it has
+ * to stay in effect for the whole run, not merely for construction. A factory method that set it
+ * and returned would either leave it set long after the object graph it built has nothing left to
+ * do (harmless for a one-shot script, but wrong for a factory called from a unit test that keeps
+ * running afterward), or restore it before the run it is meant to protect ever starts (wrong
+ * everywhere). Both entry points that touch the token cache therefore own the umask themselves,
+ * bracketing their own call into this factory and the run that follows it — see the matching
+ * comment in each of `scripts/publish-sourcedata.php`, `scripts/poll-sourcedata-merges.php` and
+ * `bin/publish-sourcedata-consumer`.
+ */
+final class SourceDataPublisherFactory
+{
+    private ?SourceDataChangeRequestRepository $repository = null;
+
+    private ?GuzzleClient $httpClient = null;
+
+    private ?FilesystemAdapter $tokenCache = null;
+
+    private bool $purgeServiceResolved = false;
+
+    private ?ResourceTuplePurgeServiceInterface $purgeService = null;
+
+    /**
+     * `includeProcessors: false` — the sixth argument, and load-bearing rather than cosmetic.
+     * LoggerFactory's default attaches RequestResponseProcessor, which THROWS a RuntimeException
+     * for any record whose context does not carry type => request|response. The runners log
+     * batch ids, so with the default every log call they make — including the ones inside their
+     * catch blocks — would throw from inside the failure handling, before releaseClaim() ever
+     * ran, stranding the batch and killing the process. Every other non-HTTP caller of this
+     * factory passes false for the same reason; only the HTTP error middleware, which really
+     * does log requests and responses, passes true.
+     */
+    public function logger(string $channel): LoggerInterface
+    {
+        return LoggerFactory::create($channel, null, 30, false, true, false);
+    }
+
+    /**
+     * Memoised so every caller within one process — including {@see publishRunner()} and
+     * {@see mergePollRunner()}, both of which need it — shares one repository wired to the one
+     * PDO singleton, rather than each silently constructing its own.
+     */
+    public function repository(): SourceDataChangeRequestRepository
+    {
+        return $this->repository ??= new SourceDataChangeRequestRepository();
+    }
+
+    /**
+     * Build a {@see PublishRunner} wired to a real {@see SourceDataPublisher}.
+     *
+     * @throws RuntimeException         If the GitHub App credential is not configured or
+     *                                  `GITHUB_REPOSITORY` is unset — see
+     *                                  {@see SourceDataPublisher::fromEnv()}.
+     * @throws \InvalidArgumentException If `GITHUB_REPOSITORY` is set but not a valid
+     *                                  "owner/repo" pair.
+     */
+    public function publishRunner(LoggerInterface $logger): PublishRunner
+    {
+        $repository = $this->repository();
+        $publisher  = SourceDataPublisher::fromEnv($repository, $this->httpClient(), $this->tokenCache($logger));
+
+        return new PublishRunner($repository, $publisher, logger: $logger);
+    }
+
+    /**
+     * Build a {@see MergePollRunner} wired to a real {@see GitHubGitDataClient}.
+     *
+     * Unlike {@see publishRunner()}, this does not go through {@see SourceDataPublisher::fromEnv()}
+     * — `MergePollRunner` needs the lower-level `GitHubGitDataClient` directly, not a publisher —
+     * so the GitHub App credential and `GITHUB_REPOSITORY` are resolved here, independently, with
+     * the same validation `SourceDataPublisher::fromEnv()` applies (via
+     * {@see SourceDataPublisher::splitGithubRepository()}, the single shared definition of what a
+     * well-formed `GITHUB_REPOSITORY` is) so the two entry points fail identically on the same
+     * misconfiguration.
+     *
+     * @throws RuntimeException         If the GitHub App credential is not configured (see
+     *                                  {@see GitHubAppAuth::fromEnv()}) or `GITHUB_REPOSITORY` is
+     *                                  unset or empty.
+     * @throws \InvalidArgumentException If `GITHUB_REPOSITORY` is set but not a valid
+     *                                  "owner/repo" pair. This is one pasted repository URL away
+     *                                  for any operator, and extends `LogicException`, not
+     *                                  `RuntimeException` — callers must catch `\Throwable`, not
+     *                                  `\RuntimeException`, or this exception reaches them as an
+     *                                  uncaught fatal.
+     */
+    public function mergePollRunner(LoggerInterface $logger): MergePollRunner
+    {
+        $auth = GitHubAppAuth::fromEnv($this->httpClient(), $this->tokenCache($logger));
+
+        $githubRepository = self::getEnvString('GITHUB_REPOSITORY');
+        if ('' === $githubRepository) {
+            throw new RuntimeException('GITHUB_REPOSITORY is not configured (expected "owner/repo").');
+        }
+        ['owner' => $owner, 'repo' => $repo] = SourceDataPublisher::splitGithubRepository($githubRepository);
+
+        $client = new GitHubGitDataClient($owner, $repo, $auth, $this->httpClient());
+
+        return new MergePollRunner($this->repository(), $client, $this->purgeService(), new AuditLogRepository(), $logger);
+    }
+
+    /**
+     * Best-effort `XADD` notifier — see {@see SourceDataPublishNotifier}'s own class docblock for
+     * why it never throws. Mirrors
+     * {@see \LiturgicalCalendar\Api\Handlers\Concerns\WritesSourceData::sourceDataPublishNotifier()}:
+     * null `\Redis` when `ext-redis` is missing or neither `REDIS_SOCKET` nor `REDIS_HOST` is
+     * configured, which is the ordinary state for a self-hoster (both are commented out in
+     * `.env.example`). A connection failure is caught and also falls back to a null `\Redis`
+     * rather than failing this call — Redis here is an accelerator, never a dependency.
+     */
+    public function publishNotifier(): SourceDataPublishNotifier
+    {
+        $redis = null;
+        if (extension_loaded('redis') && ( isset($_ENV['REDIS_HOST']) || isset($_ENV['REDIS_SOCKET']) )) {
+            try {
+                $redis = new \Redis();
+                if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
+                    $redis->connect((string) $_ENV['REDIS_SOCKET']);
+                } else {
+                    $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
+                    $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
+                    $redis->connect($redisHost, $redisPort);
+                }
+                if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
+                    $redis->auth((string) $_ENV['REDIS_PASSWORD']);
+                }
+            } catch (\Throwable) {
+                $redis = null; // Best-effort; the publisher falls back to PG-plus-cron durability.
+            }
+        }
+
+        $streamName = is_string($_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM'] ?? null)
+            ? $_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM']
+            : 'litcal:sourcedata-publish-stream';
+
+        return new SourceDataPublishNotifier($redis, $streamName);
+    }
+
+    /**
+     * Explicit timeouts, not Guzzle's default (no timeout at all — a hung TCP handshake or a
+     * GitHub response that never completes would otherwise run indefinitely). This is what keeps
+     * `PublishRunner`'s "still running" and "abandoned" distinguishable at all: without a bound
+     * here, a whole publish can silently outlive `PublishRunner::DEFAULT_GRACE_SECONDS`, making
+     * it the common case — not the rare one — that a second cron tick reclaims a batch whose
+     * first publish attempt is still genuinely in flight (see `PublishRunner`'s class docblock,
+     * "A merely SLOW process is not a dead one"). `connect_timeout: 10s` is generous for TLS+DNS
+     * to api.github.com. `timeout: 30s` per request is generous for any single Git Data call.
+     *
+     * The quantity that must stay under the grace period is the WHOLE publish, not one request.
+     * A batch issues one `createBlob` per changed file, serially, then six fixed calls. The
+     * widest batch this repository can produce is the decrees corpus — decrees.json plus 14 i18n
+     * locales plus 7 lectionary locales — so 22 blob writes plus 6 is 28 requests, or 840s if
+     * every one hit its full ceiling. That is dozens of requests, not a handful, and it is why
+     * the grace period is 1800 rather than the 600 an earlier draft of this comment assumed. If
+     * either the timeout here or the widest batch grows, the grace period must grow with them.
+     *
+     * Shared between {@see publishRunner()} and {@see mergePollRunner()} — both talk to the same
+     * GitHub API under the same latency assumptions, and a consumer that builds both (see
+     * `bin/publish-sourcedata-consumer`) gets one client, not two.
+     */
+    private function httpClient(): GuzzleClient
+    {
+        return $this->httpClient ??= new GuzzleClient(['connect_timeout' => 10, 'timeout' => 30]);
+    }
+
+    /**
+     * Installation-token cache.
+     *
+     * Installation tokens are cached (PSR-6) for 50 minutes against GitHub's one-hour token
+     * life — see `GitHubAppAuth`'s own class docblock. A cron-invoked, short-lived CLI process
+     * needs that cache to be filesystem-backed, not in-memory, or every single invocation would
+     * re-authenticate; a long-lived consumer benefits from the same cache surviving restarts.
+     *
+     * What lands on disk is a BEARER CREDENTIAL carrying `contents: write` and
+     * `pull_requests: write` on the repository, valid for up to 50 minutes. The private key it
+     * is derived from is handled carefully (a path in the environment, never the key bytes;
+     * never logged); the token derived from it must be too, and Symfony's `FilesystemAdapter`
+     * creates its directory and its entries with 0777/0666 masked by the process umask —
+     * 0755/0644 under the usual 0022, i.e. readable by every local user, UNLESS the caller has
+     * already narrowed the umask before this method runs — see the class docblock's "The umask
+     * window is NOT this class's job".
+     *
+     * The explicit `chmod` below is the second, independent layer: entries of any mode inside a
+     * 0700 directory are unreachable regardless of what created them or under what umask, so it
+     * repairs a directory an earlier, laxer run (or a caller that forgot to narrow its umask)
+     * left wide open. It is a no-op — silently, via the `is_dir()` guard — on the very first run,
+     * before the directory exists; that gap is exactly what a caller's own restrictive umask is
+     * for, which is why both layers are load-bearing and neither is redundant with the other.
+     *
+     * Memoised per factory instance so {@see publishRunner()} and {@see mergePollRunner()} share
+     * one cache and the directory is chmod'd (and any failure logged) at most once per run.
+     */
+    private function tokenCache(LoggerInterface $logger): FilesystemAdapter
+    {
+        if (null !== $this->tokenCache) {
+            return $this->tokenCache;
+        }
+
+        $projectRoot   = dirname(__DIR__, 3);
+        $tokenCache    = new FilesystemAdapter('github_app_tokens', 0, $projectRoot . '/cache');
+        $tokenCacheDir = $projectRoot . '/cache/github_app_tokens';
+        if (is_dir($tokenCacheDir) && !@chmod($tokenCacheDir, 0o700)) {
+            $logger->warning(
+                'Could not restrict permissions on the GitHub App token cache directory; the '
+                    . 'installation token it holds may be readable by other local users.',
+                ['directory' => $tokenCacheDir]
+            );
+        }
+
+        return $this->tokenCache = $tokenCache;
+    }
+
+    /**
+     * Returns null when OpenFGA is not configured — merge detection must still work on a
+     * deployment without it, since the whole point of the write-mode seam
+     * {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode} exists behind is
+     * that the stack is optional. Mirrors
+     * {@see \LiturgicalCalendar\Api\Handlers\Concerns\ResolvesOutboxTooling::getPurgeService()},
+     * duplicated rather than shared because that trait's version is memoised per HTTP request
+     * (and carries a test seam via `setPurgeService()`) — a different lifecycle from this
+     * factory's, which is memoised per CLI process instead.
+     */
+    private function purgeService(): ?ResourceTuplePurgeServiceInterface
+    {
+        if ($this->purgeServiceResolved) {
+            return $this->purgeService;
+        }
+        $this->purgeServiceResolved = true;
+
+        if (!OpenFgaClient::isConfigured()) {
+            return $this->purgeService = null;
+        }
+
+        $pdo       = Connection::getInstance();
+        $client    = OpenFgaClient::fromEnv();
+        $repo      = new OutboxRepository($pdo);
+        $processor = new OutboxProcessor($repo, $client);
+
+        return $this->purgeService = new ResourceTuplePurgeService($client, $repo, $processor, $pdo);
+    }
+
+    /**
+     * Get an environment variable as a string, or '' if unset/empty. Mirrors
+     * {@see SourceDataPublisher}'s own private helper of the same name (duplicated rather than
+     * shared — same precedent as {@see \LiturgicalCalendar\Api\Services\OpenFgaClient}'s own
+     * copy, and {@see \LiturgicalCalendar\Api\Services\GitHub\GitHubAppAuth}'s).
+     */
+    private static function getEnvString(string $name): string
+    {
+        $value = $_ENV[$name] ?? null;
+        if (is_string($value) && '' !== trim($value)) {
+            return trim($value);
+        }
+
+        $envValue = getenv($name);
+        if (is_string($envValue) && '' !== trim($envValue)) {
+            return trim($envValue);
+        }
+
+        return '';
+    }
+}

--- a/src/Services/SourceData/SourceDataWriter.php
+++ b/src/Services/SourceData/SourceDataWriter.php
@@ -31,11 +31,20 @@ interface SourceDataWriter
     /**
      * Apply everything staged so far, and describe what happened.
      *
+     * @param bool $deletesResource True only when this request removes the RESOURCE, not merely
+     *        some of its files. Set by the handler that knows, at the moment it knows.
+     *
+     *        `operation = ChangeOperation::DELETE` cannot answer this and must never be used to:
+     *        `RegionalDataHandler::writeI18nFiles()` stages a DELETE for every locale file dropped
+     *        from `metadata.locales`, on a calendar that still exists. Keying the OpenFGA purge on
+     *        the operation would revoke every editor on a live calendar because a translator
+     *        removed one language.
+     *
      * @return array<string, mixed> Always carries a `disposition` key: `applied`
      *                              when the files are now on disk, `submitted` or
      *                              `approved` when a proposal was recorded.
      */
-    public function commit(ChangeResource $resource): array;
+    public function commit(ChangeResource $resource, bool $deletesResource = false): array;
 
     /**
      * What this submitter has in flight for `$absolutePath` that is not yet in the


### PR DESCRIPTION
Closes #902. Implements #915.

Phase 3 of the source-data change requests arc. Phase 1 (#912) made server-side edits become change
requests in Postgres instead of files an `rsync --archive --delete` deploy would revert; phase 2 (#914)
published approved ones to GitHub as rolling per-resource pull requests. **Nothing yet noticed when
those pull requests merged**, so every side effect that depends on a change actually landing had never
fired. This is that — plus the side effects only merge detection can safely perform.

32 commits, 66 files, +11,051/−351.

## What it does

```text
approved batch → published (phase 2) → publication_status: open
                                     → poll GET /pulls/{n}
                                     → verify containment
                                     → merged | closed
                                     → OpenFGA purge (deletions only)
                                     → notify the submitter
```

- **`MergePollRunner`** polls the DISTINCT pull request numbers among `open` rows — several batches
  legitimately share one rolling pull request, so one call decides the fate of all of them.
- **The OpenFGA operational-tuple purge** for a resource deletion that has actually merged. This closes
  the known limitation phase 2 shipped with, where a deleted diocese's former editors kept edit access
  to an object whose files were gone.
- **Claim ownership** (`publish_claim_token`), closing a hole where a merely-slow runner's late release
  could revoke a different runner's live claim and spend a second attempt against a bounded budget.
- **Change-request notifications** on `GET /auth/notifications`.
- **An optional Redis publish stream**, with cron demoted to the backstop it already resembled.

## Things a reviewer cannot infer from the diff

**Containment is verified, not assumed.** Sharing a `pr_number` is not the same as being in that pull
request's merge: a reviewer clicking Merge concurrently with a publish leaves a batch's commit on the
branch and outside the merge. Marking it `merged` would assert it reached the repository — and the
publisher skips merged rows, so its content would be lost silently. That is the same failure mode
phase 2's age-based ancestor exclusion was chosen to avoid, reached from the other direction. So every
batch on a merged pull request is checked with `compareCommits()`, and one that is not contained is
returned to `none` for republishing under a fresh pull request.

**`operation = 'delete'` is NOT the purge trigger, and must never become one.**
`RegionalDataHandler::writeI18nFiles()` stages a `DELETE` for every locale file dropped from
`metadata.locales`, on a calendar that still exists. Keying an authorization purge on the operation
would revoke every editor and viewer on a live calendar because a translator removed a language. The
trigger is `metadata.deletes_resource`, set by the two handlers that actually delete a resource — and
**every** row of the batch must carry it, because `submitBatch()`'s carry-forward can re-parent a
flagged row from an earlier submission onto a batch that is only a locale removal. It fails closed.

**`GET /auth/notifications`'s `items` is now a discriminated list.** Clients must switch on `type`
before reading any other key. This is the one change that can break a client. The OpenAPI schema is
updated, which included renaming `UserNotification` to `AccessRequestNotification` — codegen-breaking,
and called out in the CHANGELOG.

**Redis is optional and cron alone is a complete, correct deployment.** The queue of record stays in
Postgres: `publication_status` can be withdrawn or rejected there, so a second queue would be a second
truth. The stream message is a *hint* carrying no work — the consumer ignores the batch id except for
logging and claims from Postgres exactly as cron does, which is what makes a lost, duplicated or
out-of-order message a latency cost rather than a correctness one.

## One deliberate deviation from the approved design

The design spec mandates a zero-call containment fast path when a batch's commit equals the pull
request's head sha. **It is removed here, deliberately.** This feature publishes to a *rolling* branch
reused across successive pull requests for one resource, so a closed pull request's head can move after
its merge. That makes "head.sha is what was merged" an assumption about GitHub's reporting rather than
an observation, and it breaks in precisely the concurrent-merge case the containment check exists for.
An optimization that defeats the safety mechanism in exactly the case it was built for is not worth its
savings, and the saving is one API call per *merged* pull request, ever. The reasoning is in
`MergePollRunner`'s class docblock so nobody reinstates it as an obvious win.

## Verification

4,229 tests / 492,545 assertions / **0 failures**, run against a live API server and WebSocket server.
PHPStan level 10 clean on `src`, and standalone over all three entry points — `phpstan.neon.dist` scans
`paths: [src]` only, so the cron scripts and the consumer binary need their own pass. phpcs, `lint:md`
and `lint:jsondata` clean.

20 errors remain in `phpunit_tests/WebSocket/`; these are pre-existing and environmental, verified by
checking out the merge base, restarting the WebSocket server there to remove a known stale-process
confound, and re-running — 20 errors, 0 assertions, identical. They need Zitadel and OpenFGA.

Every task was reviewed independently, then the whole branch was reviewed as one change. Notable
defects caught and fixed along the way: a docblock still telling maintainers the claim token did not
exist; a `$rows[0]` read that could have purged a live calendar's editors; two assertions that could not
fail in the direction they existed to catch; and — found only by the whole-branch pass —
`MAX_PUBLISH_ATTEMPTS` being sized against a cron interval that the stream removes, so a GitHub outage
plus an approval burst would park batches at the rate of pending messages.

## Deferred

Each was scoped out deliberately, not missed. The two that block nothing else but change what the
publisher persists or when it validates are now filed:

- **#917 — Keep per-file `base_sha` so rebase detection is possible.** `recordPublication()` overwrites
  every row's `base_sha` with the batch-level branch head, destroying the bookkeeping a rebase check
  would need.
- **#918 — Re-validate a change request against the current schema before publishing.** A batch approved
  against one schema and published after that schema changed fails `lint:jsondata` on the resulting pull
  request — a backstop on the wrong side of the gate.

Not yet filed:

- **The frontend inbox UI** for `change_request_published` items — belongs in
  `LiturgicalCalendarFrontend`, not here. `GET /auth/notifications` carries the items after this lands.
- **A shared `\Redis`-from-env helper.** That block now exists at ten sites; this branch added the
  missing 2.0s connect timeout to the four it introduced rather than refactoring five pre-existing call
  sites unrelated to phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ueFDAmZFPEP3fhbe26JHj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added phase-three merge detection for source-data change requests, including merged, closed and reset outcomes.
  * Added inbox notifications for published change-request batches.
  * Added optional Redis-based publishing acceleration, with scheduled publishing retained as a fallback.
  * Added resource-deletion handling and associated access cleanup.
  * Expanded health reporting with open-batch counts and age information.

* **Documentation**
  * Updated operational runbooks, changelog entries, design documentation and configuration guidance for the new workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
