### PR TITLE
fix(data): PATCH on /data/* answers 200 OK, not 201 Created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@
   reviewer or a stopped poller, since an undetected merge is indistinguishable from an unreviewed one from
   this side. See `docs/ops/change-request-runbook.md`'s "Merge detection (phase 3)" section for the full
   operator playbook.
+* **`PATCH` on the seven `/data/*` calendar routes now answers `200 OK` instead of `201 Created`**, see
+  issue [#913](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/913). The affected
+  routes are `/data/nation/{key}`, `/data/roman/nation/{key}`, `/data/diocese/{key}`,
+  `/data/roman/diocese/{key}`, `/data/ambrosian/diocese/{key}`, `/data/widerregion/{key}` and
+  `/data/roman/widerregion/{key}`. `PATCH` updates an existing calendar, and the `201` was returned
+  unconditionally and without a `Location` header, so it never carried the "a resource was created"
+  meaning that would justify it; every other `PATCH` in the API already answered `200`. `PUT` is
+  unchanged and still answers `201 Created` on creation. The response body is identical in both cases,
+  so a client that checks for any `2xx` (or reads `disposition`) needs no change — but a third-party
+  client that compares the status to the literal `201` must be updated. `openapi.json` is updated to
+  match.
 -->
 
 ## [v5.7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/releases/tag/v5.7) (December 15th 2025)

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -6610,8 +6610,8 @@
           }
         },
         "responses": {
-          "201": {
-            "description": "201 Created. Even when updating an existing resource, we will still get the same 201 Created because we are basically overwriting the previous resource",
+          "200": {
+            "description": "200 OK: the existing resource was updated. Creating a new resource is a separate operation (`PUT`), which answers `201 Created`.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6943,8 +6943,8 @@
           }
         },
         "responses": {
-          "201": {
-            "description": "201 Created. Even when updating an existing resource, we will still get the same 201 Created because we are basically overwriting the previous resource",
+          "200": {
+            "description": "200 OK: the existing resource was updated. Creating a new resource is a separate operation (`PUT`), which answers `201 Created`.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7289,8 +7289,8 @@
           }
         },
         "responses": {
-          "201": {
-            "description": "201 Created. Even when updating an existing resource, we will still get the same 201 Created because we are basically overwriting the previous resource",
+          "200": {
+            "description": "200 OK: the existing resource was updated. Creating a new resource is a separate operation (`PUT`), which answers `201 Created`.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7624,8 +7624,8 @@
           }
         },
         "responses": {
-          "201": {
-            "description": "201 Created. Even when updating an existing resource, we will still get the same 201 Created because we are basically overwriting the previous resource",
+          "200": {
+            "description": "200 OK: the existing resource was updated. Creating a new resource is a separate operation (`PUT`), which answers `201 Created`.",
             "content": {
               "application/json": {
                 "schema": {
@@ -7972,8 +7972,8 @@
           }
         },
         "responses": {
-          "201": {
-            "description": "201 Created. Even when updating an existing resource, we will still get the same 201 Created because we are basically overwriting the previous resource",
+          "200": {
+            "description": "200 OK: the existing resource was updated. Creating a new resource is a separate operation (`PUT`), which answers `201 Created`.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8303,8 +8303,8 @@
           }
         },
         "responses": {
-          "201": {
-            "description": "201 Created. Even when updating an existing resource, we will still get the same 201 Created because we are basically overwriting the previous resource",
+          "200": {
+            "description": "200 OK: the existing resource was updated. Creating a new resource is a separate operation (`PUT`), which answers `201 Created`.",
             "content": {
               "application/json": {
                 "schema": {
@@ -8628,8 +8628,8 @@
           }
         },
         "responses": {
-          "201": {
-            "description": "201 Created. Even when updating an existing resource, we will still get the same 201 Created because we are basically overwriting the previous resource",
+          "200": {
+            "description": "200 OK: the existing resource was updated. Creating a new resource is a separate operation (`PUT`), which answers `201 Created`.",
             "content": {
               "application/json": {
                 "schema": {

--- a/phpunit_tests/Handlers/RegionalDataHandlerTest.php
+++ b/phpunit_tests/Handlers/RegionalDataHandlerTest.php
@@ -555,7 +555,7 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
         $updateResponse = ( new RegionalDataHandler(['nation', 'MT']) )
             ->handle($this->requestFor('PATCH', '/data/nation/MT', ['Accept-Language' => 'en-MT'], $payload));
 
-        self::assertSame(201, $updateResponse->getStatusCode());
+        self::assertSame(200, $updateResponse->getStatusCode());
         $body = $this->decodeJsonBody($updateResponse);
         self::assertSame('Calendar data updated for Nation "Malta" ("MT")', $body['success']);
     }

--- a/phpunit_tests/Handlers/RegionalDataQueueModeTest.php
+++ b/phpunit_tests/Handlers/RegionalDataQueueModeTest.php
@@ -224,9 +224,8 @@ final class RegionalDataQueueModeTest extends AbstractHandlerTestCase
 
         $body = $this->decodeJsonBody($response);
 
-        // This handler answers 201 for PATCH as well as PUT; asserting the real contract
-        // rather than the expected one, since changing it is out of scope here.
-        self::assertSame(201, $response->getStatusCode());
+        // PATCH updates an existing calendar, so it answers 200 OK; only PUT answers 201.
+        self::assertSame(200, $response->getStatusCode());
         self::assertQueued($body, 'ambrosian/novara_it');
         self::assertNotSame([], $this->pendingRows());
     }
@@ -256,7 +255,7 @@ final class RegionalDataQueueModeTest extends AbstractHandlerTestCase
 
         $body = $this->decodeJsonBody($response);
 
-        self::assertSame(201, $response->getStatusCode());
+        self::assertSame(200, $response->getStatusCode());
         self::assertQueued($body, 'roman/Europe');
         self::assertNotSame([], $this->pendingRows());
     }

--- a/src/Handlers/RegionalDataHandler.php
+++ b/src/Handlers/RegionalDataHandler.php
@@ -627,7 +627,7 @@ final class RegionalDataHandler extends AbstractHandler
      * If the resource to update is not found in the national calendars index, the response will be a JSON error response with a status code of 404 Not Found.
      * If the resource to update is not writable or the write was not successful, the response will be a JSON error response with a status code of 503 Service Unavailable.
      *
-     * If the update is successful, the response will be a JSON success response with a status code of 201 Created.
+     * If the update is successful, the response will be a JSON success response with a status code of 200 OK (creation is a separate operation: `PUT` answers 201 Created).
      */
     private function updateNationalCalendar(ResponseInterface $response): ResponseInterface
     {
@@ -703,7 +703,7 @@ final class RegionalDataHandler extends AbstractHandler
         foreach ($changeRequest as $crKey => $crValue) {
             $responseObj->{$crKey} = $crValue;
         }
-        return $this->encodeResponseBody($response, $responseObj, StatusCode::CREATED);
+        return $this->encodeResponseBody($response, $responseObj, StatusCode::OK);
     }
 
     /**
@@ -716,7 +716,7 @@ final class RegionalDataHandler extends AbstractHandler
      * If the resource to update is not found in the wider region calendars index, the response will be a JSON error response with a status code of 404 Not Found.
      * If the resource to update is not writable or the write was not successful, the response will be a JSON error response with a status code of 503 Service Unavailable.
      *
-     * If the update is successful, the response will be a JSON success response with a status code of 201 Created.
+     * If the update is successful, the response will be a JSON success response with a status code of 200 OK (creation is a separate operation: `PUT` answers 201 Created).
      */
     private function updateWiderRegionCalendar(ResponseInterface $response): ResponseInterface
     {
@@ -788,7 +788,7 @@ final class RegionalDataHandler extends AbstractHandler
         foreach ($changeRequest as $crKey => $crValue) {
             $responseObj->{$crKey} = $crValue;
         }
-        return $this->encodeResponseBody($response, $responseObj, StatusCode::CREATED);
+        return $this->encodeResponseBody($response, $responseObj, StatusCode::OK);
     }
 
     /**
@@ -802,7 +802,7 @@ final class RegionalDataHandler extends AbstractHandler
      * If the resource to update is not found in the diocesan calendars index, the response will be a JSON error response with a status code of 404 Not Found.
      * If the resource to update is not writable or the write was not successful, the response will be a JSON error response with a status code of 503 Service Unavailable.
      *
-     * If the update is successful, the response will be a JSON success response with a status code of 201 Created.
+     * If the update is successful, the response will be a JSON success response with a status code of 200 OK (creation is a separate operation: `PUT` answers 201 Created).
      */
     private function updateDiocesanCalendar(ResponseInterface $response): ResponseInterface
     {
@@ -878,7 +878,7 @@ final class RegionalDataHandler extends AbstractHandler
         foreach ($changeRequest as $crKey => $crValue) {
             $responseObj->{$crKey} = $crValue;
         }
-        return $this->encodeResponseBody($response, $responseObj, StatusCode::CREATED);
+        return $this->encodeResponseBody($response, $responseObj, StatusCode::OK);
     }
 
     /**


### PR DESCRIPTION
Closes #913.

The seven `/data/*` `PATCH` routes answered `201 Created` when updating a calendar that already exists. The status was returned unconditionally and carried no `Location` header, so nothing about the response expressed the one meaning a `201` would have. Every other `PATCH` in the API answers `200 OK`.

Takes the issue's primary proposal, not the alternative: `StatusCode::OK` from the three `update*Calendar()` methods, and `200` for all seven `patch` responses in `openapi.json`. `PUT` is untouched — `201` is correct there, and the CREATE assertions were deliberately left alone.

## Notes for review

**"Reuse the existing response component the 200 paths already share" was not possible as written.** There is no shared *update-success* 200 component; `components/responses` holds `DeleteSuccess200`, `RegionalDataI18n200`, `LitCal200` and the error responses. The seven PATCH responses are inline schemas with per-path `success` examples, and `$ref`-ing `DeleteSuccess200` — same shape, delete-specific examples — would have silently swapped in wrong examples. Hence a 14-line literal status-and-description change rather than a refactor. A shared `UpdateSuccess200` component would be a reasonable follow-up.

**`openapi.json` was edited as text**, never through a `json_decode`/`json_encode` round-trip (see #907). The diff is `28 +++---`; `grep -c '\\u'` on the result is still `0`.

## Cross-repo

**This is a published contract change and it breaks the frontend's e2e suite.** Application code is unaffected — every write path judges these by `response.ok` — but three Playwright specs assert the literal `201` on PATCH. The companion PR must land at or before this deploys:

Liturgical-Calendar/LiturgicalCalendarFrontend — `fix/913-patch-200-ok`

## Verification

`parallel-lint`, `lint`, `analyse` (PHPStan L10), `lint:openapi`, `lint:md` all pass. `RegionalDataHandlerTest` + `RegionalDataQueueModeTest`: OK, 32 tests, 112 assertions. Full-suite failures are confined to `Routes/*` and `WebSocket/*` and were confirmed pre-existing by an empty set-difference against a clean `development` run — see #922 for why those suites currently give no signal on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ueFDAmZFPEP3fhbe26JHj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behaviour Changes**
  * Updating an existing calendar via `PATCH` now returns **200 OK** instead of **201 Created**.
  * Creating a calendar via `PUT` continues to return **201 Created**.
  * Response content remains unchanged.

* **Documentation**
  * API documentation now reflects the updated `PATCH` response status across all calendar routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->