### PR TITLE
feat(locales): guard official-locale readiness in CI, and report drift from /health

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,11 @@ name: Linting, static analysis, and POTs update
 on:
   push:
     branches: [ development ]
-    paths: [ '**/*.php', '**/*.md' ]
+    # jsondata/** and i18n/** are here for the data guards below (jsondata_lint,
+    # locale_readiness), which assert facts about committed data rather than about
+    # PHP — a data-only push would otherwise skip the very jobs that police it.
+    # Mirrors the push filter phpunit.yml already uses for the same reason.
+    paths: [ '**/*.php', '**/*.md', 'jsondata/**', 'i18n/**' ]
   pull_request:
     branches: [ development, stable ]
   workflow_dispatch:
@@ -100,6 +104,42 @@ jobs:
 
       - name: JSON source data canonical-encoding check
         run: composer lint:jsondata
+
+  # Declaring a locale officially supported changes behaviour, not just a label:
+  # ReadingsMap serves an official locale STRICTLY and throws on a missing readings
+  # entry, while degrading quietly for every other locale (#904). So a commit that
+  # deletes a lectionary corpus, or blanks a decreed event's name, converts a silent
+  # gap into a production 500 for a calendar the API advertises. That is how the
+  # Croatian calendar went down — found by a user, not by CI. This job is the gate.
+  #
+  # Least privilege, as jsondata_lint above: it only reads the tree.
+  locale_readiness:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Nothing here pushes; don't leave the token in .git/config for later steps.
+          persist-credentials: false
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+
+      - name: Download vendor folder from build job
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: vendor-folder
+          path: vendor
+
+      - name: Fix permissions on vendor binaries
+        run: test -d vendor/bin && chmod +x vendor/bin/* || true
+
+      - name: Officially supported locales are complete
+        run: composer lint:locales
 
   static_analysis:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,30 @@ name: Linting, static analysis, and POTs update
 on:
   push:
     branches: [ development ]
+    # This filter is workflow-wide: every job below is skipped when it misses, so it
+    # has to list everything ANY of them depends on, not only the sources they lint.
+    #
     # jsondata/** and i18n/** are here for the data guards below (jsondata_lint,
     # locale_readiness), which assert facts about committed data rather than about
     # PHP — a data-only push would otherwise skip the very jobs that police it.
     # Mirrors the push filter phpunit.yml already uses for the same reason.
-    paths: [ '**/*.php', '**/*.md', 'jsondata/**', 'i18n/**' ]
+    #
+    # composer.json/composer.lock are here because every job installs dependencies and
+    # runs tools pinned by them: a lockfile bump that moves phpstan or phpcs changes
+    # what static_analysis and codesniffer would say, and must not skip them. main.yml
+    # itself is here so a change to this workflow actually exercises it.
+    #
+    # Note the pull_request trigger below has no paths filter at all, so PRs always run
+    # everything; this filter only governs pushes to development, where it is the
+    # post-merge safety net rather than the gate.
+    paths:
+      - '**/*.php'
+      - '**/*.md'
+      - 'jsondata/**'
+      - 'i18n/**'
+      - 'composer.json'
+      - 'composer.lock'
+      - '.github/workflows/main.yml'
   pull_request:
     branches: [ development, stable ]
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,21 @@
   reviewer or a stopped poller, since an undetected merge is indistinguishable from an unreviewed one from
   this side. See `docs/ops/change-request-runbook.md`'s "Merge detection (phase 3)" section for the full
   operator playbook.
+* define the officially supported locales as a curated resource, `jsondata/supportedLocales.json`, and stop
+  answering `500` for the rest, see issue [#904](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/904).
+  The list (`en`, `fr`, `it`, `la`, `nl`) previously lived in a private constant referenced once; it is now the
+  single source of truth for both hosted and self-hosted deployments, and it changes behaviour rather than
+  labelling it: an **official** locale is served strictly, so a missing readings entry throws as the genuine data
+  defect it is, while any other locale degrades to an empty readings object — byte-identical to an explicitly
+  blank entry. That is what fixes `?locale=hr` answering `500`. Two new guards keep the promise honest: a
+  `LocaleReadinessChecker` probing whether a locale has everything an official locale needs (gettext catalogue,
+  all ten lectionary corpora, a readings entry for every newly created decreed event, a non-empty name for every
+  named one, and the four universal missals), wired into CI as `composer lint:locales` so an official locale that
+  loses a resource fails the build; and a new `locale_readiness` block on `GET /health` reporting the same drift
+  on a running deployment, where source data and the curated list can diverge without a commit. As with the other
+  nested blocks, a `warning` there does not change `/health`'s top-level `status` or its HTTP status code —
+  monitoring must parse `.locale_readiness.status`. Croatian remains deliberately unofficial: its lectionary is
+  complete, but `StJohnNewman` has no Croatian name, and the resource records why.
 -->
 
 ## [v5.7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/releases/tag/v5.7) (December 15th 2025)

--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,7 @@
         "lint:md:fix": "npx --yes markdownlint-cli2 --fix \"**/*.md\" \"#node_modules\" \"#vendor\" \"#.worktrees\" \"#.aider*\" \"#.superpowers\"",
         "lint:openapi": "npx --yes @redocly/cli lint",
         "lint:jsondata": "@php scripts/lint-jsondata.php",
+        "lint:locales": "@php scripts/lint-locales.php",
         "analyse": "phpstan analyse",
         "parallel-lint": "parallel-lint --exclude .git --exclude vendor .",
         "test": "phpunit --testdox --display-warnings --exclude-group golden-master-generate",

--- a/phpunit_tests/Handlers/Ops/HealthHandlerTest.php
+++ b/phpunit_tests/Handlers/Ops/HealthHandlerTest.php
@@ -82,6 +82,42 @@ final class HealthHandlerTest extends AbstractHandlerTestCase
         }
     }
 
+    /**
+     * The locale_readiness block must reach the HTTP response, and a `warning` in it must
+     * NOT change the top-level status or the HTTP code.
+     *
+     * Both halves matter. A block that is built and never surfaced is worse than a missing
+     * one — the promotion procedure ends with "confirm /health reports every official locale
+     * ready", which would have nothing to confirm. And the non-escalation is the documented
+     * contract for every nested block here (change-request runbook, "Read the nested block,
+     * not the top level"): a future change that escalated it would start pulling instances
+     * out of load-balancer pools over a content defect.
+     */
+    public function testGetSurfacesTheLocaleReadinessBlock(): void
+    {
+        $response = ( new HealthHandler() )->handle(
+            $this->requestFor('GET', '/health', [], [])
+        );
+
+        $body = $this->decodeJsonBody($response);
+
+        self::assertArrayHasKey('locale_readiness', $body, 'the block must be reachable over HTTP');
+        /** @var array<string, mixed> $readiness */
+        $readiness = $body['locale_readiness'];
+
+        self::assertContains($readiness['status'], ['ok', 'warning']);
+        self::assertIsString($readiness['message']);
+        self::assertNotSame('', $readiness['message'], 'the block must explain itself, not just flag a state');
+        self::assertIsArray($readiness['official']);
+        self::assertNotEmpty($readiness['official']);
+        self::assertIsArray($readiness['not_ready']);
+        self::assertIsArray($readiness['advisories']);
+
+        // Only the database probe may degrade the endpoint itself.
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('ok', $body['status']);
+    }
+
     public function testGetReturnsNotConfiguredWhenDbEnvAbsent(): void
     {
         // Clear DB_* env vars so Connection::isConfigured() returns false.

--- a/phpunit_tests/HealthLocaleReadinessTest.php
+++ b/phpunit_tests/HealthLocaleReadinessTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Services\Locale\LocaleReadinessChecker;
+use LiturgicalCalendar\Api\Services\SupportedLocales;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The `locale_readiness` block of `/health` is how an operator finds out that a locale the
+ * API already advertises as officially supported has lost a resource it needs.
+ *
+ * That matters more than it sounds. An official locale is served STRICTLY —
+ * `ReadingsMap::getReadings()` throws rather than degrading — so the drift this block
+ * reports is a calendar about to answer 500, not one that will merely render a gap (#904).
+ *
+ * `composer lint:locales` already proves the COMMITTED data is complete. What these tests
+ * pin is the block's own contract, which CI cannot: the shape monitoring parses, the
+ * advisory tier never gating, and the warning branch actually firing.
+ *
+ * The warning branch is driven by pointing a checker at a deliberately incomplete tree,
+ * never by rewriting `jsondata/supportedLocales.json`. Rewriting it would work, but the file
+ * is committed source data read by a process-wide memoized static: a fatal anywhere in the
+ * run would leave it replaced in the working tree, and every later test in the process would
+ * be reading a list this one invented.
+ */
+#[CoversClass(Health::class)]
+#[CoversClass(LocaleReadinessChecker::class)]
+final class HealthLocaleReadinessTest extends TestCase
+{
+    /** @var list<string> Temporary trees to remove, deepest paths first. */
+    private array $tempRoots = [];
+
+    protected function setUp(): void
+    {
+        SupportedLocales::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempRoots as $root) {
+            self::removeTree($root);
+        }
+        $this->tempRoots = [];
+
+        SupportedLocales::reset();
+    }
+
+    public function testTheBlockCarriesTheKeysMonitoringParses(): void
+    {
+        $block = Health::buildLocaleReadinessStatus();
+
+        self::assertContains($block['status'], ['ok', 'warning']);
+        self::assertNotSame('', $block['message'], 'the block must explain itself, not just flag a state');
+        self::assertSame(SupportedLocales::official(), $block['official']);
+    }
+
+    /**
+     * On the committed data every official locale is complete, so the block reports `ok` and
+     * names nothing. If this ever fails, `composer lint:locales` names the gap.
+     */
+    public function testTheCommittedDataReportsOk(): void
+    {
+        $block = Health::buildLocaleReadinessStatus();
+
+        self::assertSame('ok', $block['status'], (string) json_encode($block['not_ready']));
+        self::assertSame([], $block['not_ready']);
+    }
+
+    /**
+     * The blank-decree-readings probe is advisory, and four of the five official locales fail
+     * it on real data. It must be REPORTED — that is what the tier is for — while leaving the
+     * status `ok`. Making it a warning would leave /health permanently yellow and train
+     * operators to ignore the field.
+     */
+    public function testAdvisoryFailuresAreReportedWithoutRaisingTheStatus(): void
+    {
+        $block = Health::buildLocaleReadinessStatus();
+
+        self::assertSame('ok', $block['status']);
+        self::assertNotEmpty($block['advisories'], 'the advisory tier is expected to have something to say');
+
+        foreach ($block['advisories'] as $locale => $names) {
+            self::assertContains($locale, $block['official']);
+            self::assertNotEmpty($names);
+        }
+    }
+
+    /**
+     * The warning branch, and the one that must discriminate: exactly one official locale has
+     * lost exactly one lectionary corpus, and the block must implicate that locale and no
+     * other. A block that reported "something is wrong" without naming which calendar is
+     * about to answer 500 would not be worth polling.
+     */
+    public function testAnOfficialLocaleThatLostAResourceIsNamed(): void
+    {
+        $official = SupportedLocales::official();
+        $victim   = $official[count($official) - 1];
+
+        $root = $this->mirrorWithoutSanctorum($victim);
+
+        $block = Health::buildLocaleReadinessStatus(new LocaleReadinessChecker($root));
+
+        self::assertSame('warning', $block['status']);
+        self::assertSame([$victim], array_keys($block['not_ready']));
+        self::assertSame(['lectionary_corpora'], $block['not_ready'][$victim]);
+        self::assertSame($official, $block['official'], 'the block still reports the whole list it checked');
+        self::assertStringContainsString($victim . ' (lectionary_corpora)', $block['message']);
+        self::assertStringContainsString('supportedLocales.json', $block['message']);
+    }
+
+    /**
+     * Nothing to look at is not the same as nothing wrong.
+     *
+     * A deployment whose data tree is absent — a half-finished rsync, a bad document root —
+     * must report `warning`, never `ok`. The checker exists to refuse silent false passes,
+     * and a block that reported ready because it could not look would be one.
+     */
+    public function testAnEmptyDataTreeIsAWarningRatherThanOk(): void
+    {
+        $root  = $this->tempRoot();
+        $block = Health::buildLocaleReadinessStatus(new LocaleReadinessChecker($root));
+
+        self::assertSame('warning', $block['status']);
+        self::assertSame(SupportedLocales::official(), array_keys($block['not_ready']));
+        foreach ($block['not_ready'] as $failures) {
+            self::assertContains('decree_source', $failures, 'an unreadable corpus must fail loudly, not vacuously');
+        }
+    }
+
+    /**
+     * A tree that is the real one in every respect except that $locale has lost one of its
+     * ten lectionary corpora.
+     *
+     * Built out of symlinks rather than copies: the checker only ever stats, globs and reads,
+     * so a mirror is indistinguishable from the real tree to it, and this stays cheap enough
+     * to run per test.
+     */
+    private function mirrorWithoutSanctorum(string $locale): string
+    {
+        $repo = dirname(__DIR__) . '/';
+        $root = $this->tempRoot();
+
+        symlink($repo . 'i18n', $root . 'i18n');
+
+        $roman = $root . 'jsondata/sourcedata/rite/roman/';
+        mkdir($roman . 'lectionary', 0o755, true);
+
+        foreach (['decrees', 'missals', 'calendars'] as $sibling) {
+            symlink($repo . 'jsondata/sourcedata/rite/roman/' . $sibling, $roman . $sibling);
+        }
+
+        foreach (glob($repo . 'jsondata/sourcedata/rite/roman/lectionary/*', GLOB_ONLYDIR) ?: [] as $corpus) {
+            $name = basename($corpus);
+
+            if ($name !== 'sanctorum') {
+                symlink($corpus, $roman . 'lectionary/' . $name);
+                continue;
+            }
+
+            // The one corpus that is rebuilt file by file, minus the victim locale.
+            mkdir($roman . 'lectionary/sanctorum', 0o755, true);
+            foreach (glob($corpus . '/*.json') ?: [] as $file) {
+                if (basename($file) === $locale . '.json') {
+                    continue;
+                }
+                symlink($file, $roman . 'lectionary/sanctorum/' . basename($file));
+            }
+        }
+
+        return $root;
+    }
+
+    private function tempRoot(): string
+    {
+        $root = sys_get_temp_dir() . '/litcal-health-readiness-' . bin2hex(random_bytes(6)) . '/';
+        mkdir($root, 0o755, true);
+        $this->tempRoots[] = $root;
+
+        return $root;
+    }
+
+    private static function removeTree(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $it = new \RecursiveIteratorIterator(
+            // SKIP_DOTS plus no FOLLOW_SYMLINKS: the mirror is made of symlinks into the real
+            // source tree, and descending into them would delete the repository's own data.
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($it as $item) {
+            /** @var \SplFileInfo $item */
+            if ($item->isLink() || !$item->isDir()) {
+                unlink($item->getPathname());
+                continue;
+            }
+            rmdir($item->getPathname());
+        }
+
+        rmdir($dir);
+    }
+}

--- a/scripts/lint-locales.php
+++ b/scripts/lint-locales.php
@@ -1,0 +1,201 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Guard the promise made by jsondata/supportedLocales.json: every locale this
+ * repository declares officially supported must actually have the resources an
+ * official locale requires.
+ *
+ * Why this is a build gate and not merely a report: declaring a locale official
+ * is not a label change, it changes behaviour. `ReadingsMap::getReadings()`
+ * throws for an official locale and degrades quietly for every other one
+ * (#904), so a commit that removes a lectionary corpus, or empties a decreed
+ * event's name, turns a silent gap into a 500 on the next deploy — for a
+ * calendar the API advertises as supported. That is precisely the failure that
+ * took the Croatian calendar down, discovered in production rather than in CI.
+ *
+ * Three checks, in order of what they can hide:
+ *
+ *   1. The curated resource parses, and the list the API is actually using came
+ *      FROM it. {@see SupportedLocales} falls back to a built-in list when the
+ *      resource cannot be read — correct at runtime, but in CI it would mean
+ *      silently guarding a list nobody wrote. A guard that can pass without
+ *      reading the file it exists to guard is not a guard.
+ *   2. Every official locale is ready, via {@see LocaleReadinessChecker}.
+ *   3. Advisory only, never gating: any locale recorded in the resource's
+ *      `candidates` block that now passes every probe, i.e. is promotable.
+ *      Completing a candidate's data is an improvement, so it must never turn
+ *      the build red — it just should not go unnoticed either.
+ *
+ * The same assertion is also made from PHPUnit
+ * (phpunit_tests/Services/Locale/LocaleReadinessCheckerTest.php), which pins the
+ * checker's behaviour. This script is the data gate: it runs in seconds without
+ * a database or a PHPUnit bootstrap, it is what an editor runs locally before
+ * touching lectionary or decrees data, and it names the exact files and event
+ * keys that are missing rather than an assertion diff.
+ *
+ * Usage:
+ *   php scripts/lint-locales.php      (composer lint:locales)
+ *
+ * Exit codes:
+ *   0  every officially supported locale has every required resource.
+ *   1  the curated resource is unusable, or at least one official locale is incomplete.
+ */
+
+declare(strict_types=1);
+
+// Refuse any entry that is not the CLI. These scripts ship to the server — they are run there per
+// the RBAC runbook — and they sit under a path whose `.php` files are handed to php-fpm, so an HTTP
+// request can reach them. Inlined per script rather than factored into a shared require: a guard
+// that depends on resolving another path has a failure mode that a single constant comparison does
+// not. See the same block in lint-jsondata.php.
+if (PHP_SAPI !== 'cli') {
+    http_response_code(404);
+    exit(1);
+}
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\Locale\LocaleReadinessChecker;
+use LiturgicalCalendar\Api\Services\Locale\LocaleReadinessReport;
+use LiturgicalCalendar\Api\Services\SupportedLocales;
+
+// Initialize the file-path prefix that JsonData::path() requires.
+// Router sets this during HTTP boot; CLI scripts must set it manually.
+Router::$apiFilePath = dirname(__DIR__) . DIRECTORY_SEPARATOR;
+
+$fail = static function (string $message): never {
+    fwrite(STDERR, 'lint:locales FAILED — ' . $message . "\n");
+    exit(1);
+};
+
+// ---------------------------------------------------------------------------
+// 1. The curated resource itself.
+// ---------------------------------------------------------------------------
+
+$resourcePath = JsonData::SUPPORTED_LOCALES_FILE->path();
+
+if (!is_file($resourcePath)) {
+    $fail(JsonData::SUPPORTED_LOCALES_FILE->value . " is missing.\n"
+        . "It is the single source of truth for which locales the API promises to serve completely.\n"
+        . 'Without it every deployment silently falls back to the built-in list in SupportedLocales::FALLBACK.');
+}
+
+$raw = file_get_contents($resourcePath);
+if (false === $raw) {
+    $fail(JsonData::SUPPORTED_LOCALES_FILE->value . ' could not be read.');
+}
+
+try {
+    /** @var mixed $resource */
+    $resource = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+} catch (\JsonException $e) {
+    $fail(JsonData::SUPPORTED_LOCALES_FILE->value . ' is not valid JSON: ' . $e->getMessage());
+}
+
+if (!is_array($resource) || !isset($resource['general_roman_calendar']) || !is_array($resource['general_roman_calendar'])) {
+    $fail(JsonData::SUPPORTED_LOCALES_FILE->value . ' has no general_roman_calendar object.');
+}
+
+$grc      = $resource['general_roman_calendar'];
+$declared = isset($grc['official']) && is_array($grc['official'])
+    ? array_values(array_filter($grc['official'], static fn (mixed $v): bool => is_string($v) && $v !== ''))
+    : [];
+
+if ($declared === []) {
+    $fail(JsonData::SUPPORTED_LOCALES_FILE->value . " declares no official locales.\n"
+        . 'An empty list makes every locale unofficial, which disables strict serving everywhere rather than nowhere.');
+}
+
+// The list the code is actually using must be the list on disk. If it is not, the
+// service fell back, and every check below would be verifying a list nobody curated.
+$inUse = SupportedLocales::official();
+if ($inUse !== $declared) {
+    $fail("the declared official locales and the ones SupportedLocales is using differ.\n"
+        . '  declared in ' . JsonData::SUPPORTED_LOCALES_FILE->value . ': ' . implode(', ', $declared) . "\n"
+        . '  SupportedLocales::official():                    ' . implode(', ', $inUse) . "\n"
+        . 'This means the resource could not be read and the built-in fallback was used.');
+}
+
+// ---------------------------------------------------------------------------
+// 2. Every official locale is complete. This is the gate.
+// ---------------------------------------------------------------------------
+
+$checker = new LocaleReadinessChecker();
+$reports = $checker->checkOfficialLocales();
+
+/** @var list<LocaleReadinessReport> $incomplete */
+$incomplete = array_values(array_filter(
+    $reports,
+    static fn (LocaleReadinessReport $report): bool => !$report->ready()
+));
+
+foreach ($reports as $report) {
+    echo '  ' . $report->describe() . "\n";
+}
+
+if ($incomplete !== []) {
+    fwrite(STDERR, "\nlint:locales FAILED — the following officially supported locale(s) are incomplete:\n");
+    foreach ($incomplete as $report) {
+        fwrite(STDERR, '  ' . $report->locale . ":\n");
+        foreach ($report->failures() as $check) {
+            fwrite(STDERR, '    - ' . $check->name . ': ' . $check->summary . "\n");
+            foreach ($check->missing as $missing) {
+                fwrite(STDERR, '        ' . $missing . "\n");
+            }
+        }
+    }
+    fwrite(
+        STDERR,
+        "\nAn officially supported locale is served STRICTLY: a missing readings entry throws rather than\n"
+        . "degrading, so this will answer 500 in production for the affected events, not just render a gap.\n"
+        . "\nThere are exactly two correct fixes, and choosing between them is a governance decision:\n"
+        . "  - supply the missing data listed above, or\n"
+        . '  - remove the locale from the "official" list in ' . JsonData::SUPPORTED_LOCALES_FILE->value . ",\n"
+        . "    which restores graceful degradation for it and reduces the published contract.\n"
+        . "\nDo not relax the checker to make this pass: every probe here corresponds to something the\n"
+        . "calendar reads at request time.\n"
+    );
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Advisory: candidates that have become promotable, and advisory probes that
+//    an official locale does not meet. Neither is ever gating.
+// ---------------------------------------------------------------------------
+
+$candidates = isset($grc['candidates']) && is_array($grc['candidates']) ? $grc['candidates'] : [];
+$promotable = [];
+foreach (array_keys($candidates) as $candidate) {
+    $locale = (string) $candidate;
+    if ($checker->check($locale)->ready()) {
+        $promotable[] = $locale;
+    }
+}
+
+if ($promotable !== []) {
+    echo "\nNote — the following candidate locale(s) now pass every readiness probe and could be promoted:\n";
+    foreach ($promotable as $locale) {
+        echo '  - ' . $locale . "\n";
+    }
+    echo "Promotion is a governance decision, so this is a note, not a failure. Add the locale to the\n"
+        . '"official" list in ' . JsonData::SUPPORTED_LOCALES_FILE->value . " and drop its candidates entry.\n";
+}
+
+$advisories = [];
+foreach ($reports as $report) {
+    foreach ($report->advisories() as $check) {
+        $advisories[] = '  - ' . $report->locale . ': ' . $check->name . ' — ' . $check->summary;
+    }
+}
+
+if ($advisories !== []) {
+    echo "\nAdvisory (never gating) — content gaps in locales that are otherwise complete:\n"
+        . implode("\n", $advisories) . "\n";
+}
+
+echo "\nlint:locales OK — all " . count($reports) . ' officially supported locale(s) ('
+    . implode(', ', $inUse) . ") have every required resource.\n";
+exit(0);

--- a/src/Handlers/Ops/HealthHandler.php
+++ b/src/Handlers/Ops/HealthHandler.php
@@ -22,7 +22,15 @@ use Psr\Http\Message\ServerRequestInterface;
  * as change requests — see {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode}
  * — and a source_data_publisher block reporting whether the phase-2 GitHub App publisher
  * that turns approved change requests into commits can actually run — see
- * {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher::isConfigured()}.
+ * {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher::isConfigured()},
+ * and a locale_readiness block reporting whether every locale this deployment declares
+ * officially supported still has the resources that promise requires — see
+ * {@see \LiturgicalCalendar\Api\Services\Locale\LocaleReadinessChecker}.
+ *
+ * Each of those blocks carries its own nested `status`, and a nested `warning` deliberately
+ * does NOT degrade the top-level `status` or the HTTP status code: only an unreachable
+ * database does that. Monitoring wanting the content-level signals must parse the nested
+ * fields.
  *
  * This endpoint is unauthenticated and publicly accessible so that
  * monitoring infrastructure (load-balancers, uptime checks, etc.) can
@@ -67,6 +75,7 @@ final class HealthHandler extends AbstractHandler
             'openfga_outbox'        => Health::buildOutboxStats(),
             'source_data_writes'    => Health::buildSourceDataWriteModeStatus(),
             'source_data_publisher' => Health::buildSourceDataPublisherStatus(),
+            'locale_readiness'      => Health::buildLocaleReadinessStatus(),
         ];
 
         $body = json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);

--- a/src/Health.php
+++ b/src/Health.php
@@ -32,8 +32,11 @@ use LiturgicalCalendar\Api\Models\Auth\TestTarget;
 use LiturgicalCalendar\Api\Models\Auth\WsCaller;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
+use LiturgicalCalendar\Api\Services\Locale\LocaleReadinessCheck;
+use LiturgicalCalendar\Api\Services\Locale\LocaleReadinessChecker;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
+use LiturgicalCalendar\Api\Services\SupportedLocales;
 use LiturgicalCalendar\Api\Services\TestRunPolicy;
 use LiturgicalCalendar\Api\Services\WsCallerResolver;
 use LiturgicalCalendar\Api\Repositories\OutboxRepository;
@@ -5481,6 +5484,122 @@ class Health implements MessageComponentInterface
         } catch (\Throwable) {
             return ['open_batches' => 0, 'oldest_open_age_seconds' => 0];
         }
+    }
+
+    /**
+     * Build the locale_readiness block for the HTTP /health endpoint.
+     *
+     * Reports whether every locale this deployment declares officially supported still has
+     * the resources an official locale must have — see {@see LocaleReadinessChecker} for the
+     * probes and {@see SupportedLocales} for the list.
+     *
+     * This is drift detection, and the drift is real in a way CI cannot cover. `composer
+     * lint:locales` proves the list and the data agree at the commit that was built, but a
+     * deployment is not a commit: source data can be edited in place on a running host,
+     * `supportedLocales.json` is curated by an admin, and a partial rsync can land one
+     * without the other. On a locale the API has ALREADY promoted, a missing resource is not
+     * a quiet degradation — `ReadingsMap::getReadings()` throws for an official locale by
+     * design (#904) — so this block is how an operator learns that a calendar is about to
+     * start answering 500 before a user reports it.
+     *
+     * Nested status, like every other block here: a `warning` does NOT change /health's
+     * top-level `status` and does NOT change the HTTP status code. Monitoring that reads
+     * only the code, or only `.status`, will never see this — parse
+     * `.locale_readiness.status`. That is deliberate, and matches `source_data_writes` and
+     * `source_data_publisher`: incomplete locale data is a content defect to fix, not an
+     * outage that should pull the instance out of a load-balancer pool.
+     *
+     * Advisory probes are reported in `advisories` and never raise the status. The
+     * blank-decree-readings probe is advisory precisely because four of the five currently
+     * official locales fail it on real data; making it a `warning` here would leave /health
+     * permanently yellow and teach operators to ignore the field.
+     *
+     * @param ?LocaleReadinessChecker $checker A checker rooted elsewhere. Production passes
+     *                                        nothing; the seam exists so a test can exercise
+     *                                        the warning branch against a deliberately
+     *                                        incomplete tree instead of rewriting the
+     *                                        committed `supportedLocales.json` out from under
+     *                                        the rest of the suite. Mirrors the same optional
+     *                                        constructor argument on
+     *                                        {@see \LiturgicalCalendar\Api\Handlers\Admin\LocalesAdminHandler}.
+     * @return array{status: 'ok'|'warning', message: string, official: list<string>, not_ready: array<string, list<string>>, advisories: array<string, list<string>>}
+     */
+    public static function buildLocaleReadinessStatus(?LocaleReadinessChecker $checker = null): array
+    {
+        try {
+            $official = SupportedLocales::official();
+            $reports  = ( $checker ?? new LocaleReadinessChecker() )->checkOfficialLocales();
+        } catch (\Throwable $e) {
+            // Unlike buildOutboxStats(), which degrades to zeroes, an unanswerable
+            // readiness question must not read as "ready". The checker exists to refuse
+            // silent false passes; a block reporting `ok` because it could not look
+            // would be one.
+            return [
+                'status'     => 'warning',
+                'message'    => 'locale readiness could not be evaluated: ' . $e->getMessage(),
+                'official'   => [],
+                'not_ready'  => [],
+                'advisories' => [],
+            ];
+        }
+
+        /** @var array<string, list<string>> $notReady */
+        $notReady = [];
+        /** @var array<string, list<string>> $advisories */
+        $advisories = [];
+
+        foreach ($reports as $report) {
+            $failures = array_map(
+                static fn (LocaleReadinessCheck $check): string => $check->name,
+                $report->failures()
+            );
+            if ($failures !== []) {
+                $notReady[$report->locale] = $failures;
+            }
+
+            $advisory = array_map(
+                static fn (LocaleReadinessCheck $check): string => $check->name,
+                $report->advisories()
+            );
+            if ($advisory !== []) {
+                $advisories[$report->locale] = $advisory;
+            }
+        }
+
+        if ($notReady === []) {
+            return [
+                'status'     => 'ok',
+                'message'    => sprintf(
+                    'all %d officially supported locale(s) have every required resource',
+                    count($official)
+                ),
+                'official'   => $official,
+                'not_ready'  => [],
+                'advisories' => $advisories,
+            ];
+        }
+
+        $described = [];
+        foreach ($notReady as $locale => $failures) {
+            $described[] = $locale . ' (' . implode(', ', $failures) . ')';
+        }
+
+        return [
+            'status'     => 'warning',
+            'message'    => sprintf(
+                '%d of %d officially supported locale(s) no longer have every resource an official locale '
+                    . 'requires: %s. An official locale is served strictly — a missing readings entry throws '
+                    . 'rather than degrading — so these will answer 500 for the affected events. Either restore '
+                    . 'the data or demote the locale in jsondata/supportedLocales.json; `composer lint:locales` '
+                    . 'names the exact files and event keys',
+                count($notReady),
+                count($official),
+                implode('; ', $described)
+            ),
+            'official'   => $official,
+            'not_ready'  => $notReady,
+            'advisories' => $advisories,
+        ];
     }
 
     /**

--- a/src/Services/Locale/LocaleReadinessChecker.php
+++ b/src/Services/Locale/LocaleReadinessChecker.php
@@ -62,6 +62,37 @@ final class LocaleReadinessChecker
 
     private string $root;
 
+    /**
+     * Locale-independent corpus reads, memoized for the life of the instance.
+     *
+     * Every probe below is per-locale, but three of the facts they need are not:
+     * the decree corpus, the event keys it creates, and the union of keys the
+     * decrees i18n files name. Re-reading those once per locale made
+     * {@see checkOfficialLocales()} decode `decrees.json` ten times and every
+     * decrees i18n file five times over, which is more than a `/health` poll
+     * should pay to answer a question whose inputs cannot change mid-process.
+     *
+     * Instance-scoped rather than static: an instance is constructed per request
+     * and per CLI run, and {@see __construct()} takes a `$root`, so a static cache
+     * would leak one root's corpus into a checker built for another — which is
+     * exactly what the temp-tree tests do.
+     *
+     * @var list<array<string, mixed>>|null
+     */
+    private ?array $decrees = null;
+
+    /**
+     * Whether {@see decrees()} has run. Distinct from `$decrees === null`, which
+     * is a real answer meaning "the corpus could not be read" — see that method.
+     */
+    private bool $decreesLoaded = false;
+
+    /** @var list<string>|null */
+    private ?array $createdEventKeys = null;
+
+    /** @var list<string>|null */
+    private ?array $namedEventKeys = null;
+
     public function __construct(?string $root = null)
     {
         // Router::$apiFilePath is a typed static that is only initialised while a
@@ -387,6 +418,10 @@ final class LocaleReadinessChecker
      */
     private function createdEventKeys(): array
     {
+        if (null !== $this->createdEventKeys) {
+            return $this->createdEventKeys;
+        }
+
         $keys = [];
         foreach ($this->decrees() ?? [] as $decree) {
             $metadata = $decree['metadata'] ?? null;
@@ -400,7 +435,7 @@ final class LocaleReadinessChecker
             }
         }
 
-        return array_values(array_unique($keys));
+        return $this->createdEventKeys = array_values(array_unique($keys));
     }
 
     /**
@@ -417,9 +452,13 @@ final class LocaleReadinessChecker
      */
     private function namedEventKeys(): array
     {
+        if (null !== $this->namedEventKeys) {
+            return $this->namedEventKeys;
+        }
+
         $dir = $this->root . JsonDataConstants::DECREES_FOLDER . '/i18n';
         if (!is_dir($dir)) {
-            return [];
+            return $this->namedEventKeys = [];
         }
 
         $keys = [];
@@ -429,7 +468,7 @@ final class LocaleReadinessChecker
             }
         }
 
-        return array_values(array_unique($keys));
+        return $this->namedEventKeys = array_values(array_unique($keys));
     }
 
     /**
@@ -443,6 +482,12 @@ final class LocaleReadinessChecker
      */
     private function decrees(): ?array
     {
+        if ($this->decreesLoaded) {
+            return $this->decrees;
+        }
+
+        $this->decreesLoaded = true;
+
         $path = $this->root . JsonDataConstants::DECREES_FILE;
         if (!is_file($path)) {
             return null;
@@ -464,7 +509,7 @@ final class LocaleReadinessChecker
         }
 
         /** @var list<array<string, mixed>> $decoded */
-        return $decoded;
+        return $this->decrees = $decoded;
     }
 
     /**


### PR DESCRIPTION
Completes #904.

## What was already done, and what was not

PR #905 shipped `jsondata/supportedLocales.json`, the `SupportedLocales` service, and the graceful-degradation rule that fixed the live 500 on `?locale=hr`. `LocaleReadinessChecker` itself also already existed on `development` from an earlier session — **but the commit that added it claims "and guard official locales in CI", and no CI wiring was ever added.** Only a PHPUnit test. So the remaining work was the guard and the Health reporting.

## CI guard

`scripts/lint-locales.php`, a `lint:locales` composer script, and a `locale_readiness` job in `.github/workflows/main.yml` mirroring `jsondata_lint` (least privilege, `persist-credentials: false`).

Beyond running the checker it closes a hole the PHPUnit test cannot: `SupportedLocales` falls back to a built-in list when the resource is unreadable, so the script first asserts the list in use came **from** `supportedLocales.json`. Without that, CI could pass while guarding a list nobody wrote.

`jsondata/**` and `i18n/**` were added to the workflow's push path filter — both data guards there assert facts about data, and `phpunit.yml` already filters that way.

The guard was proved to fail as well as pass: removing `lectionary/sanctorum/nl.json` makes `lint:locales` exit 1 naming the exact file.

## Health

`Health::buildLocaleReadinessStatus()` plus a `locale_readiness` block, following the `source_data_writes` / `source_data_publisher` conventions exactly — including that a nested `warning` does **not** change the top-level `status` or the HTTP code.

## Does any official locale fail today?

**No.** All five (`en, fr, it, la, nl`) pass every gating probe.

Four fail only the **advisory** `decree_readings_populated` probe: `fr`, `it` and `nl` have 10 of 11 newly-created decreed events with blank readings, `la` has 9, `en` has 1. That is a real content gap, left non-gating deliberately — escalating it would fail every official locale at once and leave `/health` permanently yellow. It is now visible in CI output and in `/health`'s `advisories`.

Croatian remains unpromoted, blocked solely by the missing `StJohnNewman` name, exactly as the resource's `candidates` block records.

## Two supporting changes

- The checker now memoizes its three locale-independent corpus reads per instance. `checkOfficialLocales()` was decoding `decrees.json` ten times and every decrees i18n file five times over — too much for a polled endpoint.
- `buildLocaleReadinessStatus()` takes an optional checker, as `LocalesAdminHandler` already does, so the warning branch is tested against a symlink mirror with one corpus removed rather than by rewriting `supportedLocales.json` mid-suite.

## Not in scope

The admin curation UI. It is now unblocked (#902 has shipped all three phases) but needs an API write route and a resource-type decision first — filed as #926.

## Verification

`parallel-lint`, `lint`, `analyse` (PHPStan L10, no baseline weakened, no ignores added), `lint:md`, `lint:jsondata`, `lint:locales` all pass. `HealthLocaleReadinessTest` (5), `HealthHandlerTest` (5), `LocaleReadinessCheckerTest` (23) green. Remaining full-suite failures are the environmental `Routes/*` and `WebSocket/*` ones — see #922.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ueFDAmZFPEP3fhbe26JHj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a curated list of officially supported locales for consistent hosted and self-hosted deployments.
  * Added locale readiness information to the `/health` response, including incomplete locales and advisory notices.

* **Bug Fixes**
  * Unofficial locales with missing readings now return an empty result instead of an HTTP 500 error.
  * Locale readiness warnings no longer affect the overall health status or HTTP response code.

* **Chores**
  * Added automated checks to verify that officially supported locales have complete required data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->