### PR TITLE
feat(sourcedata): keep a real per-file base_sha, so rebase detection becomes possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,15 @@
   reviewer or a stopped poller, since an undetected merge is indistinguishable from an unreviewed one from
   this side. See `docs/ops/change-request-runbook.md`'s "Merge detection (phase 3)" section for the full
   operator playbook.
+* keep a genuine per-file `base_sha` on every source-data change request row, see issue
+  [#917](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/917). Submitting a change
+  request now records the git blob sha of the file the edit was authored against, and an accumulating
+  submission inherits its ancestor's rather than re-reading disk. The publisher's batch-level branch-head
+  commit sha, which used to be written over that column on every row of a published batch, moves to a new
+  `publish_base_sha` column; a migration backfills it from the existing values. Nothing an API client sees
+  changes — neither column is exposed by any endpoint — but a `base_sha` can now answer "did this file move
+  underneath this proposal?", which no row could previously. The rebase check that consumes it is not built
+  yet; see the runbook's "`base_sha` and `publish_base_sha` are two different shas".
 -->
 
 ## [v5.7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/releases/tag/v5.7) (December 15th 2025)

--- a/docs/ops/change-request-runbook.md
+++ b/docs/ops/change-request-runbook.md
@@ -173,7 +173,7 @@ separate status columns, and conflating them is the most common way to misread t
 - **`publication_status`** — GitHub's side of the same change: `none` → `queued` → `open` → `merged` /
   `closed`. The phase 2 publisher writes `queued` and `open`; the phase 3 merge poller writes `merged` and
   `closed`. See "Publishing to GitHub (phase 2)" below for exactly what each value means and what a row's
-  `branch`/`commit_sha`/`pr_number`/`base_sha` columns hold once filled, and "Merge detection (phase 3)"
+  `branch`/`commit_sha`/`pr_number`/`publish_base_sha` columns hold once filled, and "Merge detection (phase 3)"
   below for how `merged` and `closed` are decided.
 
 They are kept separate on purpose: an `approved` batch that failed to push must stay distinguishable from
@@ -345,11 +345,11 @@ Once a batch reaches `open`, `recordPublication()` also stamps four columns, on 
 - **`commit_sha`** — the sha of the commit this batch produced on that branch (the *latest* one, if the
   batch was ever re-published — see "The benign double-publish" below).
 - **`pr_number`** — the pull request's number on GitHub.
-- **`base_sha`** — the commit the publish branched from: the branch's own head if the branch already
-  existed, or the configured base branch's head (`GITHUB_BASE_BRANCH`, default `development`) if this was
-  the resource's first publish. This is a **batch-level** value, written across every row of the batch,
-  and is distinct from what a phase 1 reading of this column might suggest — it is not a per-file blob sha
-  and not per-file rebase bookkeeping.
+- **`publish_base_sha`** — the commit the publish branched from: the branch's own head if the branch
+  already existed, or the configured base branch's head (`GITHUB_BASE_BRANCH`, default `development`) if
+  this was the resource's first publish. This is a **batch-level** value, written across every row of the
+  batch. It is emphatically **not** `base_sha`, which is per-file and is never touched after submission —
+  see "`base_sha` and `publish_base_sha` are two different shas" below.
 
 ### Stranded-claim recovery and the grace period
 
@@ -810,9 +810,12 @@ not removed, exactly as the automatic path retains it.
   change — can pass in between. A batch approved against one schema and published after that schema
   changed produces a pull request whose CI fails `lint:jsondata` — visible, but a backstop on the wrong
   side of the gate.
-- **Per-file `base_sha` and rebase detection.** `recordPublication()` overwrites every row's `base_sha`
-  with the batch-level branch head, destroying the per-file bookkeeping a rebase check would need. See
-  "`base_sha` was speculative in phase 1 and is now defined" below.
+- **The rebase check itself.** The bookkeeping it needs now exists — every row records the blob sha its
+  file was authored against, and nothing overwrites it (see "`base_sha` and `publish_base_sha` are two
+  different shas" below). Nothing yet *compares* it: `SourceDataPublisher::publish()` does not read the
+  branch tree, so a batch whose file moved upstream between submission and publication still publishes
+  silently, reverting the upstream change in the resulting pull request. It is visible on the PR diff, and
+  a reviewer is the current backstop.
 
 Neither is an oversight to be quietly forgotten; both are required before this system is considered
 complete. Each has its own follow-up issue — see `docs/superpowers/2026-08-30-phase-3-handoff.md`.
@@ -821,11 +824,36 @@ Purging OpenFGA authorization tuples for a deleted calendar or test definition, 
 deferred to phase 3, is no longer on this list — see "Closed: a deleted resource's editors used to keep
 access" above.
 
-**`base_sha` was speculative in phase 1 and is now defined.** Phase 1's runbook predicted the column
-would eventually hold "GitHub's blob sha." That is not what phase 2 actually wrote: `recordPublication()`
-overwrites `base_sha` on **every row of a published batch** with the branch head commit sha the publish
-branched from (the `getRef()`/`getCommitTreeSha()` starting point in `SourceDataPublisher::publish()`),
-not a per-file blob sha and not per-file rebase bookkeeping. See "Publishing to GitHub (phase 2)" above.
+### `base_sha` and `publish_base_sha` are two different shas
+
+Phase 1 defined `base_sha` as the blob sha each file was authored against. Phase 2 then wrote something
+else entirely into it: `recordPublication()` stamped the batch-level branch-head COMMIT sha across every
+row of a published batch, so the per-file value did not survive publication and no row anywhere in the
+table could answer "did this file move underneath this proposal?". Issue #917 split the two.
+
+- **`base_sha`** — a git **blob** sha, **per file**, captured at submission by
+  `ChangeRequestSourceDataWriter::stage()` from the file as it stands in the deployed working tree. It is
+  directly comparable with the sha the same path carries in a GitHub tree. It is written once and never
+  touched again: nothing after submission knows what an edit was authored against, so anything a later
+  step wrote there would be a fabrication.
+- **`publish_base_sha`** — a **commit** sha, **per batch**, written by `recordPublication()`. See
+  "Publishing to GitHub (phase 2)" above.
+
+**Reading a NULL `base_sha`.** The row's `operation` disambiguates it:
+
+| `operation`        | `base_sha IS NULL` means                                                        |
+| ------------------ | ------------------------------------------------------------------------------- |
+| `create`           | there was no upstream file — the ordinary, expected value                       |
+| `update`/`delete`  | unknown: the row predates issue #917, or the file exists only as queued work    |
+
+A rebase check must treat the second case as "cannot check", not as "authored against nothing".
+
+**Accumulation carries the base forward.** When a submission accumulates onto the submitter's own
+unpublished row for a path (see "Superseding an aggregate file is accumulation, not replacement" above),
+the new row inherits that ancestor's `base_sha` rather than the disk sha just computed. The accumulated
+content was built from the ancestor's content, not re-read from disk, so it descends from the base the
+chain started at. Recording the current disk sha instead would claim the proposal was authored against a
+state it has never seen — and would answer "not stale" in exactly the case the check exists for.
 
 ## Retention / pruning
 

--- a/docs/superpowers/2026-08-30-phase-3-handoff.md
+++ b/docs/superpowers/2026-08-30-phase-3-handoff.md
@@ -67,6 +67,10 @@ and each now has its own filed follow-up issue (see "Follow-up issues filed" bel
    overwrites every row's `base_sha` with the batch-level branch head, destroying the per-file
    bookkeeping a rebase check would need. Not attempted in phase 3; filed as #917.
 
+   **Since addressed, in part.** #917 restored the bookkeeping: `base_sha` is written per file at
+   submission and the branch head moved to its own `publish_base_sha` column. The rebase check itself
+   is still unbuilt — see the runbook's "`base_sha` and `publish_base_sha` are two different shas".
+
 5. **Remains — schema re-validation before publication.** `approveBatch()` is still a single status
    `UPDATE`. A batch approved against one schema and published after that schema changed will produce a
    PR whose CI fails `lint:jsondata` — visible, but a backstop on the wrong side of the gate. Not

--- a/docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md
+++ b/docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md
@@ -442,6 +442,14 @@ behaviour the code does not have.
 the per-file bookkeeping a rebase check needs is not retained. Phase 3 must decide whether to keep per-file
 base shas before it can offer this at all.
 
+**Resolved (2026-08-30, [#917](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/917)).**
+The decision was to keep them. `ChangeRequestSourceDataWriter::stage()` now captures the git blob sha of the
+file on disk into `base_sha`, `submitBatch()` carries an accumulation ancestor's value forward rather than
+refreshing it, and the publisher's branch head moved to its own `publish_base_sha` column
+(`Version20260830130000`), so nothing overwrites the per-file value. The bookkeeping is in place; the
+comparison against the branch tree is not yet built — see the runbook's "`base_sha` and `publish_base_sha`
+are two different shas".
+
 Schema re-validation at the approval gate is likewise absent — `approveBatch()` is a single status `UPDATE`.
 The exposure is a batch approved against one schema and published after that schema changed. It is bounded
 rather than silent: the resulting pull request runs `lint:jsondata` and schema validation in CI, so an
@@ -563,7 +571,7 @@ needs reverting, because nothing was ever live.**
 | Failure                                           | Behaviour                                                                          |
 | ------------------------------------------------- | ---------------------------------------------------------------------------------- |
 | Schema-invalid payload at submit                  | Rejected at the handler, as today — no row created                                 |
-| `base_sha` moved between submit and approve       | **Phase 3, not built.** See the note below this table                              |
+| `base_sha` moved between submit and approve       | **Not built.** The per-file bookkeeping exists (#917); the comparison does not     |
 | Schema drift between submit and approve           | **Phase 3, not built.** See the note below this table                              |
 | GitHub unreachable                                | Claim released to `none`, run stops, exit 1; retried next tick. See the note below |
 | Publish terminal failure                          | **No DLQ.** Parked after repeated attempts, reported as `parked_batches`           |
@@ -644,9 +652,12 @@ exactly what it is today.
 - **Federated upstream submission.** A third `SourceDataWriter` that submits change requests to the
   upstream canonical API, so a self-hosting diocese pools its edits rather than forking to local
   disk. The interface exists for this; the implementation does not.
-- **Per-file `base_sha` and rebase detection.** `recordPublication()` overwrites every row's
-  `base_sha` with the batch-level branch head, so the bookkeeping a rebase check needs is already
-  gone. Restoring it changes what the publisher persists per row; deferred out of Phase 3.
+- **The rebase check itself.** The per-file bookkeeping it needs was restored in
+  [#917](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/917): `base_sha` holds the
+  blob sha each file was authored against, and the publisher's branch head lives in `publish_base_sha`.
+  What remains is the comparison — reading the branch tree at publish time and deciding what a stale
+  batch should do — which needs a `getTree()` on `GitHubGitDataClient` and a policy decision about
+  blocking versus annotating.
 - **Schema re-validation at the approval gate.** `approveBatch()` is a single status `UPDATE`. A
   batch approved against one schema and published after that schema changed fails `lint:jsondata`
   on the resulting pull request — visible, but a backstop on the wrong side of the gate.

--- a/docs/superpowers/specs/2026-08-30-sourcedata-merge-detection-design.md
+++ b/docs/superpowers/specs/2026-08-30-sourcedata-merge-detection-design.md
@@ -39,6 +39,10 @@ Deliberately out, each an issue of its own:
   `base_sha` with the batch-level branch head, so the per-file bookkeeping a rebase check needs is
   already gone. Restoring it changes what phase 2 persists per row, which is a larger change than
   merge detection and is not a prerequisite for it.
+
+  **Half-done since (2026-08-30, [#917](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/917)).**
+  The bookkeeping half landed: `base_sha` is per-file again and the branch head moved to
+  `publish_base_sha`. The rebase check itself is still unbuilt.
 - **Schema re-validation at the approval gate.** A batch approved against one schema and published
   after that schema changed produces a pull request whose CI fails `lint:jsondata` — visible, on
   the wrong side of the gate, and unchanged by anything here.

--- a/phpunit_tests/Handlers/ChangeRequestTraitHost.php
+++ b/phpunit_tests/Handlers/ChangeRequestTraitHost.php
@@ -39,8 +39,22 @@ final class ChangeRequestTraitHost
 
     private ?SourceDataPublishNotifier $publishNotifier = null;
 
+    private string $projectRoot = '/app/';
+
     public function __construct(private readonly SourceDataChangeRequestRepository $repository)
     {
+    }
+
+    /**
+     * Point the writer at a real directory, so `stage()`'s `base_sha` capture has actual
+     * files to hash. The default `/app/` is a path that does not exist, which is exactly
+     * what every other test here wants: it relativises paths without any disk I/O, and
+     * every staged row's `base_sha` comes out null.
+     */
+    public function setProjectRoot(string $projectRoot): void
+    {
+        $this->projectRoot = $projectRoot;
+        $this->writer      = null;
     }
 
     /** @param array<string, mixed> $user */
@@ -87,7 +101,7 @@ final class ChangeRequestTraitHost
             $this->repository,
             new ChangeRequestReview(new ResourceAdminService($this->fgaAnswering($this->administers), new CollectingLogger())),
             $this->oidcUser,
-            '/app/',
+            $this->projectRoot,
             $this->publishNotifier
         );
     }

--- a/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
@@ -290,7 +290,11 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
             self::assertSame('publish/us-2026-08-29', $row['branch']);
             self::assertSame('deadbeef', $row['commit_sha']);
             self::assertEquals(42, $row['pr_number']);
-            self::assertSame('basecommitsha', $row['base_sha']);
+            self::assertSame('basecommitsha', $row['publish_base_sha']);
+            // #917: the branch head goes in its OWN column. Writing it into base_sha
+            // destroyed the per-file blob sha submission captured there, which is the
+            // only thing a rebase check could ever have been built on.
+            self::assertNull($row['base_sha'], 'recordPublication() must not touch the per-file base_sha');
         }
     }
 
@@ -333,7 +337,7 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
             self::assertSame('litcal-data/national_calendar/roman/US', $row['branch'], 'B\'s branch must survive A\'s stale call');
             self::assertSame('b-sha', $row['commit_sha'], 'B\'s commit sha must survive A\'s stale call');
             self::assertEquals(42, $row['pr_number'], 'B\'s pull request number must survive A\'s stale call');
-            self::assertSame('base-b', $row['base_sha'], 'B\'s base sha must survive A\'s stale call');
+            self::assertSame('base-b', $row['publish_base_sha'], 'B\'s base sha must survive A\'s stale call');
         }
     }
 

--- a/phpunit_tests/Repositories/SourceDataChangeRequestSchemaTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestSchemaTest.php
@@ -79,6 +79,35 @@ final class SourceDataChangeRequestSchemaTest extends RepositoryTestCase
         self::assertSame('YES', $rows[1]['is_nullable']);
     }
 
+    /**
+     * `base_sha` and `publish_base_sha` are two different shas answering two different
+     * questions — a per-file blob sha captured at submission, and a batch-level commit sha
+     * captured at publish. They were one column until #917, which is why no row could answer
+     * the rebase question. Both must exist, and both must be nullable: a create has no
+     * upstream blob, and an unpublished batch has no branch head.
+     */
+    public function testBaseShaAndPublishBaseShaAreSeparateNullableColumns(): void
+    {
+        $stmt = self::$pdo->query(
+            "SELECT column_name, data_type, is_nullable
+               FROM information_schema.columns
+              WHERE table_name = 'sourcedata_change_requests'
+                AND column_name IN ('base_sha', 'publish_base_sha')
+              ORDER BY column_name"
+        );
+        self::assertNotFalse($stmt);
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        self::assertCount(2, $rows, 'base_sha and publish_base_sha must both exist');
+        self::assertSame('base_sha', $rows[0]['column_name']);
+        self::assertSame('character varying', $rows[0]['data_type']);
+        self::assertSame('YES', $rows[0]['is_nullable']);
+        self::assertSame('publish_base_sha', $rows[1]['column_name']);
+        self::assertSame('character varying', $rows[1]['data_type']);
+        self::assertSame('YES', $rows[1]['is_nullable']);
+    }
+
     public function testPhase3IndexesExist(): void
     {
         $stmt = self::$pdo->query(

--- a/phpunit_tests/Services/SourceData/ChangeRequestBaseShaTest.php
+++ b/phpunit_tests/Services/SourceData/ChangeRequestBaseShaTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Enum\ChangeOperation;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\ChangeResource;
+use LiturgicalCalendar\Api\Services\SourceData\ChangeRequestSourceDataWriter;
+use LiturgicalCalendar\Api\Services\SourceData\GitBlobSha;
+use LiturgicalCalendar\Tests\Handlers\ChangeRequestTraitHost;
+use LiturgicalCalendar\Tests\Repositories\RepositoryTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * `base_sha` end to end: the writer captures the blob sha of the file the edit was authored
+ * against, and it survives everything that happens to the row afterwards.
+ *
+ * This is the bookkeeping half of
+ * {@see https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/917}. Before it,
+ * nothing wrote a per-file base sha at all and `recordPublication()` overwrote the column on
+ * every row with the batch-level branch head, so no row anywhere could answer "did this file
+ * move underneath the proposal?".
+ */
+#[CoversClass(ChangeRequestSourceDataWriter::class)]
+#[CoversClass(SourceDataChangeRequestRepository::class)]
+final class ChangeRequestBaseShaTest extends RepositoryTestCase
+{
+    private const CALENDAR_FILE = 'jsondata/sourcedata/rite/roman/calendars/nations/US/US.json';
+
+    private const I18N_FILE = 'jsondata/sourcedata/rite/roman/calendars/nations/US/i18n/en_US.json';
+
+    private SourceDataChangeRequestRepository $repo;
+
+    private ChangeRequestTraitHost $host;
+
+    private string $projectRoot = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repo        = new SourceDataChangeRequestRepository(self::$pdo);
+        $this->projectRoot = sys_get_temp_dir() . '/litcal-basesha-' . bin2hex(random_bytes(6)) . '/';
+        mkdir($this->projectRoot . dirname(self::CALENDAR_FILE), 0o777, true);
+        mkdir($this->projectRoot . dirname(self::I18N_FILE), 0o777, true);
+
+        $this->host = new ChangeRequestTraitHost($this->repo);
+        $this->host->setProjectRoot($this->projectRoot);
+        $this->host->setSubmitter(['sub' => 'editor-1', 'name' => 'Alice', 'email' => 'alice@example.test', 'email_verified' => true]);
+        $this->host->setAdministers(false);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->projectRoot !== '' && is_dir($this->projectRoot)) {
+            self::removeTree(rtrim($this->projectRoot, '/'));
+        }
+
+        parent::tearDown();
+    }
+
+    private static function removeTree(string $dir): void
+    {
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $entry;
+            is_dir($path) ? self::removeTree($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    private function writeOnDisk(string $repoRelativePath, string $content): void
+    {
+        file_put_contents($this->projectRoot . $repoRelativePath, $content);
+    }
+
+    /** @return array<string, ?string> base_sha keyed by path */
+    private function baseShasOf(string $batchId): array
+    {
+        $bases = [];
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertIsString($row['path']);
+            $baseSha             = $row['base_sha'];
+            $bases[$row['path']] = is_string($baseSha) ? $baseSha : null;
+        }
+
+        return $bases;
+    }
+
+    private function submit(string $calendarContent, string $i18nContent = '{"key":"value"}'): string
+    {
+        $this->host->stageFile($this->projectRoot . self::CALENDAR_FILE, ChangeOperation::UPDATE, $calendarContent);
+        $this->host->stageFile($this->projectRoot . self::I18N_FILE, ChangeOperation::UPDATE, $i18nContent);
+
+        $result = $this->host->commitStagedFiles(ChangeResource::nationalCalendar(Rite::ROMAN, 'US'));
+        self::assertIsArray($result['change_request']);
+        self::assertIsString($result['change_request']['batch_id']);
+
+        return $result['change_request']['batch_id'];
+    }
+
+    public function testStageCapturesTheBlobShaOfTheFileOnDisk(): void
+    {
+        $this->writeOnDisk(self::CALENDAR_FILE, "{\"litcal\":[\"upstream\"]}\n");
+        $this->writeOnDisk(self::I18N_FILE, "{\"key\":\"upstream\"}\n");
+
+        $bases = $this->baseShasOf($this->submit('{"litcal":["mine"]}'));
+
+        self::assertSame(GitBlobSha::ofContent("{\"litcal\":[\"upstream\"]}\n"), $bases[self::CALENDAR_FILE]);
+        self::assertSame(GitBlobSha::ofContent("{\"key\":\"upstream\"}\n"), $bases[self::I18N_FILE]);
+    }
+
+    /**
+     * A create has no upstream blob, and null is how that is recorded. The row's `operation`
+     * is what tells a later reader that this null means "there was no file", rather than
+     * "unknown".
+     */
+    public function testBaseShaIsNullWhenThePathHasNoFileOnDisk(): void
+    {
+        $bases = $this->baseShasOf($this->submit('{"litcal":["mine"]}'));
+
+        self::assertNull($bases[self::CALENDAR_FILE]);
+        self::assertNull($bases[self::I18N_FILE]);
+    }
+
+    /**
+     * The regression this issue is about: `recordPublication()` used to stamp the batch-level
+     * branch head across every row's `base_sha`, so the per-file value did not survive
+     * publication and no rebase check could ever be built on it.
+     */
+    public function testRecordPublicationLeavesThePerFileBaseShaAlone(): void
+    {
+        $this->writeOnDisk(self::CALENDAR_FILE, "{\"litcal\":[\"upstream\"]}\n");
+        $this->writeOnDisk(self::I18N_FILE, "{\"key\":\"upstream\"}\n");
+
+        $batchId = $this->submit('{"litcal":["mine"]}');
+        $before  = $this->baseShasOf($batchId);
+
+        $this->repo->approveBatch($batchId, 'admin-1');
+        self::assertNotNull($this->repo->claimNextPublishableBatch());
+        $this->repo->recordPublication($batchId, 'litcal-data/national_calendar/roman/US', 'commitsha', 42, 'branchheadsha');
+
+        self::assertSame($before, $this->baseShasOf($batchId), 'per-file base_sha must survive publication');
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame('branchheadsha', $row['publish_base_sha'], 'the branch head belongs in its own column');
+        }
+    }
+
+    /**
+     * The accumulation case, and the reason `submitBatch()` overrides the writer's value.
+     *
+     * The second submission's content was built from the FIRST submission's content
+     * (`findUnpublishedContent()`), not re-read from disk — so it descends from the base the
+     * chain started at, whatever disk holds now. Recording the new disk sha would assert the
+     * proposal was authored against a state it has never seen, and a rebase check would then
+     * answer "not stale" in exactly the case it exists to catch.
+     */
+    public function testAccumulatingOntoOwnUnpublishedRowKeepsTheOriginalBaseSha(): void
+    {
+        $this->writeOnDisk(self::CALENDAR_FILE, "{\"litcal\":[\"v1\"]}\n");
+        $this->writeOnDisk(self::I18N_FILE, "{\"key\":\"v1\"}\n");
+        $originalBase = GitBlobSha::ofContent("{\"litcal\":[\"v1\"]}\n");
+
+        $first = $this->submit('{"litcal":["mine-1"]}');
+        self::assertSame($originalBase, $this->baseShasOf($first)[self::CALENDAR_FILE]);
+
+        // A deploy lands, moving the file underneath the in-flight proposal.
+        $this->writeOnDisk(self::CALENDAR_FILE, "{\"litcal\":[\"v2\"]}\n");
+        self::assertNotSame($originalBase, GitBlobSha::ofContent("{\"litcal\":[\"v2\"]}\n"));
+
+        $second = $this->submit('{"litcal":["mine-2"]}');
+
+        self::assertSame(
+            $originalBase,
+            $this->baseShasOf($second)[self::CALENDAR_FILE],
+            'the accumulation ancestor\'s base must win over the current disk sha'
+        );
+    }
+
+    /**
+     * The mirror image, and why the carry-forward tests `array_key_exists()` rather than `??`:
+     * an ancestor with a NULL base is a meaningful answer ("there was no upstream file"), and
+     * must not silently fall back to a disk sha that only appeared after the chain started.
+     */
+    public function testANullAncestorBaseShaIsCarriedForwardRatherThanRefreshedFromDisk(): void
+    {
+        $first = $this->submit('{"litcal":["mine-1"]}');
+        self::assertNull($this->baseShasOf($first)[self::CALENDAR_FILE]);
+
+        $this->writeOnDisk(self::CALENDAR_FILE, "{\"litcal\":[\"appeared-upstream\"]}\n");
+
+        $second = $this->submit('{"litcal":["mine-2"]}');
+        self::assertNull(
+            $this->baseShasOf($second)[self::CALENDAR_FILE],
+            'a null ancestor base is an answer, not an absence to be refilled from disk'
+        );
+    }
+
+    /**
+     * A row the incoming request does not restage is re-parented, not re-inserted, so its
+     * `base_sha` travels with it untouched — no carry-forward logic involved, but the
+     * guarantee is the same one and is worth pinning.
+     */
+    public function testACarriedForwardRowKeepsItsOwnBaseSha(): void
+    {
+        $this->writeOnDisk(self::I18N_FILE, "{\"key\":\"upstream\"}\n");
+        $i18nBase = GitBlobSha::ofContent("{\"key\":\"upstream\"}\n");
+
+        $first = $this->submit('{"litcal":["mine-1"]}');
+        self::assertSame($i18nBase, $this->baseShasOf($first)[self::I18N_FILE]);
+
+        // Restage ONLY the calendar file; the i18n row is re-parented onto the new batch.
+        $this->host->stageFile($this->projectRoot . self::CALENDAR_FILE, ChangeOperation::UPDATE, '{"litcal":["mine-2"]}');
+        $result = $this->host->commitStagedFiles(ChangeResource::nationalCalendar(Rite::ROMAN, 'US'));
+        self::assertIsArray($result['change_request']);
+        self::assertIsString($result['change_request']['batch_id']);
+
+        $bases = $this->baseShasOf($result['change_request']['batch_id']);
+        self::assertArrayHasKey(self::I18N_FILE, $bases, 'the non-restaged row must have been carried forward');
+        self::assertSame($i18nBase, $bases[self::I18N_FILE]);
+    }
+
+    /**
+     * Scoping: another submitter's in-flight row is never an accumulation ancestor, so it must
+     * not supply a base sha either. Editor B authored against disk and their row must say so.
+     */
+    public function testAnotherSubmittersRowIsNotAnAccumulationAncestor(): void
+    {
+        $this->writeOnDisk(self::CALENDAR_FILE, "{\"litcal\":[\"v1\"]}\n");
+        $this->submit('{"litcal":["alice"]}');
+
+        $this->writeOnDisk(self::CALENDAR_FILE, "{\"litcal\":[\"v2\"]}\n");
+        $this->host->setSubmitter(['sub' => 'editor-2', 'name' => 'Bob', 'email' => 'bob@example.test', 'email_verified' => true]);
+
+        $bob = $this->submit('{"litcal":["bob"]}');
+
+        self::assertSame(
+            GitBlobSha::ofContent("{\"litcal\":[\"v2\"]}\n"),
+            $this->baseShasOf($bob)[self::CALENDAR_FILE],
+            'editor-2 authored against disk, not against editor-1\'s in-flight proposal'
+        );
+    }
+}

--- a/phpunit_tests/Services/SourceData/GitBlobShaTest.php
+++ b/phpunit_tests/Services/SourceData/GitBlobShaTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Services\SourceData\GitBlobSha;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The expected shas here are not this implementation's own output frozen into an assertion —
+ * they were produced by `git hash-object`. That is the whole point of the class: the value has
+ * to match what git (and therefore GitHub's tree API) computes, or a rebase check comparing a
+ * stored `base_sha` against a GitHub blob sha would report every file as moved.
+ */
+#[CoversClass(GitBlobSha::class)]
+final class GitBlobShaTest extends TestCase
+{
+    /** `printf '' | git hash-object --stdin` */
+    private const EMPTY_BLOB = 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391';
+
+    /** `printf 'hello\n' | git hash-object --stdin` */
+    private const HELLO_BLOB = 'ce013625030ba8dba906f756967f9e9ca394464a';
+
+    /** `printf '{"litcal":[]}\n' | git hash-object --stdin` */
+    private const LITCAL_BLOB = '3bdbc3dff54ef565e0d675eb5bfa561c32a7238d';
+
+    /** `printf 'Ø†è\n' | git hash-object --stdin` — 7 BYTES, not 4 characters. */
+    private const MULTIBYTE_BLOB = 'efee047c3222b905519f04758d87ffbace10676c';
+
+    private string $tmpDir = '';
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/litcal-blobsha-' . bin2hex(random_bytes(6));
+        mkdir($this->tmpDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->tmpDir !== '' && is_dir($this->tmpDir)) {
+            foreach (glob($this->tmpDir . '/*') ?: [] as $file) {
+                unlink($file);
+            }
+            rmdir($this->tmpDir);
+        }
+    }
+
+    public function testEmptyContentHashesToGitsWellKnownEmptyBlob(): void
+    {
+        self::assertSame(self::EMPTY_BLOB, GitBlobSha::ofContent(''));
+    }
+
+    public function testContentHashesToTheSameShaGitHashObjectProduces(): void
+    {
+        self::assertSame(self::HELLO_BLOB, GitBlobSha::ofContent("hello\n"));
+        self::assertSame(self::LITCAL_BLOB, GitBlobSha::ofContent("{\"litcal\":[]}\n"));
+    }
+
+    /**
+     * git prefixes the object with its BYTE length. Using a character count instead would
+     * produce a sha that matches nothing GitHub ever returns, and only for non-ASCII files —
+     * which is most of `jsondata/sourcedata`.
+     */
+    public function testLengthInTheHeaderIsCountedInBytesNotCharacters(): void
+    {
+        self::assertSame(self::MULTIBYTE_BLOB, GitBlobSha::ofContent("Ø†è\n"));
+    }
+
+    public function testOfFileHashesTheFileContents(): void
+    {
+        $path = $this->tmpDir . '/US.json';
+        file_put_contents($path, "{\"litcal\":[]}\n");
+
+        self::assertSame(self::LITCAL_BLOB, GitBlobSha::ofFile($path));
+    }
+
+    /**
+     * Null is a value here, not a failure: it is what a change request that CREATES a file
+     * records, and what a file existing only as queued work records too.
+     */
+    public function testOfFileIsNullWhenThereIsNoFile(): void
+    {
+        self::assertNull(GitBlobSha::ofFile($this->tmpDir . '/absent.json'));
+    }
+
+    public function testOfFileIsNullForADirectory(): void
+    {
+        self::assertNull(GitBlobSha::ofFile($this->tmpDir));
+    }
+}

--- a/phpunit_tests/Services/SourceData/SourceDataPublisherTest.php
+++ b/phpunit_tests/Services/SourceData/SourceDataPublisherTest.php
@@ -175,8 +175,8 @@ final class SourceDataPublisherTest extends TestCase
         $repository = $this->createMock(SourceDataChangeRequestRepository::class);
         $repository->method('getBatch')->with(self::BATCH_ID)->willReturn($rows);
         $repository->method('recordPublication')->willReturnCallback(
-            function (string $batchId, string $branch, string $commitSha, ?int $prNumber, string $baseSha) use ($rows): int {
-                $this->recordedPublication = [$batchId, $branch, $commitSha, $prNumber, $baseSha];
+            function (string $batchId, string $branch, string $commitSha, ?int $prNumber, string $publishBaseSha) use ($rows): int {
+                $this->recordedPublication = [$batchId, $branch, $commitSha, $prNumber, $publishBaseSha];
 
                 return count($rows);
             }
@@ -280,7 +280,7 @@ final class SourceDataPublisherTest extends TestCase
         self::assertSame('litcal-data/national_calendar/roman/US', $result->branch);
         self::assertSame(self::NEW_COMMIT_SHA, $result->commitSha);
         self::assertSame(self::NEW_PR_NUMBER, $result->prNumber);
-        self::assertSame(self::BRANCH_HEAD_SHA, $result->baseSha);
+        self::assertSame(self::BRANCH_HEAD_SHA, $result->publishBaseSha);
 
         self::assertNotNull($this->recordedPublication, 'the batch must be recorded as published');
         self::assertSame(
@@ -310,7 +310,7 @@ final class SourceDataPublisherTest extends TestCase
         $result = $publisher->publish(self::BATCH_ID);
 
         self::assertTrue($this->createRefWasCalled);
-        self::assertSame(self::BASE_HEAD_SHA, $result->baseSha);
+        self::assertSame(self::BASE_HEAD_SHA, $result->publishBaseSha);
     }
 
     public function testADeleteOperationBecomesATreeEntryWithANullSha(): void

--- a/src/Migrations/Version20260830130000.php
+++ b/src/Migrations/Version20260830130000.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Give the publisher's branch-head sha its own column, so `base_sha` can go back to being
+ * per-file.
+ *
+ * Phase 1 defined `base_sha` as "the blob sha the edit was authored against; drives the
+ * rebase check". Phase 2 then wrote something else entirely into it: `recordPublication()`
+ * stamped the batch-level BRANCH HEAD COMMIT sha across every row of a published batch,
+ * overwriting whatever per-file value was there. Both values are wanted, and they are not
+ * the same kind of thing — one is a blob sha per file, captured at submission; the other is
+ * a commit sha per batch, captured at publish — so they get two columns rather than one that
+ * means whichever of the two was written last.
+ *
+ * The backfill moves every existing value, because every non-null `base_sha` in the table
+ * today was written by `recordPublication()`: nothing else has ever written the column.
+ * `base_sha` is then cleared on those rows rather than left holding a commit sha that a
+ * rebase check would compare against a blob sha and always find "moved".
+ *
+ * Rows in flight at the moment this migration runs keep a null `base_sha` — there is no way
+ * to reconstruct what they were authored against after the fact — and that null is readable:
+ * a null on an `update`/`delete` row means "unknown, predates the column being written",
+ * while a null on a `create` row means "there was no upstream file", which is the column's
+ * ordinary value for a create.
+ */
+final class Version20260830130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Split sourcedata_change_requests.base_sha (per-file blob) from .publish_base_sha (batch-level branch head)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql('ALTER TABLE sourcedata_change_requests ADD COLUMN publish_base_sha VARCHAR(64) NULL');
+
+        // Every non-null base_sha in the table was written by recordPublication() and is a
+        // commit sha, not a blob sha. Move it, then clear the column it was squatting in.
+        $this->addSql(
+            'UPDATE sourcedata_change_requests SET publish_base_sha = base_sha, base_sha = NULL WHERE base_sha IS NOT NULL'
+        );
+
+        $this->addSql(
+            'COMMENT ON COLUMN sourcedata_change_requests.base_sha IS '
+            . "'Per-file git blob sha the edit was authored against, captured at submission; null means no upstream file (a create) or a row predating this definition'"
+        );
+        $this->addSql(
+            'COMMENT ON COLUMN sourcedata_change_requests.publish_base_sha IS '
+            . "'Batch-level commit sha the publish branched from, written across every row by recordPublication()'"
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        // Restore the pre-split state: the branch head goes back into base_sha, discarding
+        // any genuine per-file blob sha captured while this migration was applied. That loss
+        // is the point of reverting — the old column cannot hold both.
+        $this->addSql(
+            'UPDATE sourcedata_change_requests SET base_sha = publish_base_sha WHERE publish_base_sha IS NOT NULL'
+        );
+        $this->addSql('ALTER TABLE sourcedata_change_requests DROP COLUMN IF EXISTS publish_base_sha');
+        $this->addSql('COMMENT ON COLUMN sourcedata_change_requests.base_sha IS NULL');
+    }
+}

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -267,7 +267,24 @@ class SourceDataChangeRequestRepository
      * reads: an approved batch is a decision, so it is never touched here — it is carried
      * forward as content instead.
      *
-     * @param list<array{path: string, operation: ChangeOperation, content: ?string}> $files
+     * # `base_sha` travels with the accumulation, not with the submission
+     *
+     * Each file may carry a `base_sha`: the git blob sha of the repository-side file the edit
+     * was authored against, computed from disk by
+     * {@see \LiturgicalCalendar\Api\Services\SourceData\ChangeRequestSourceDataWriter::stage()}.
+     * It is what a rebase check compares against the blob the same path carries on the branch a
+     * publish is about to land on, so it must describe the UPSTREAM state the proposed content
+     * descends from.
+     *
+     * When this submission accumulates onto the submitter's own unpublished row for a path, the
+     * supplied value is therefore discarded in favour of that row's — see
+     * {@see carriedForwardBaseShas()}. The accumulated content was built from
+     * {@see findUnpublishedContent()}, not re-read from disk, so it descends from the base the
+     * chain started at. Taking the current disk sha instead would assert that the content was
+     * authored against a state it has never seen, and would silently answer "not stale" in
+     * precisely the case — the file moved upstream mid-chain — that the check exists for.
+     *
+     * @param list<array{path: string, operation: ChangeOperation, content: ?string, base_sha?: ?string}> $files
      * @param array<string, mixed> $metadata
      * @return array{batch_id: string, superseded_batch_ids: list<string>} The new batch id, plus
      *         the ids of the submitter's own still-submitted batches this submission folded into
@@ -307,6 +324,12 @@ class SourceDataChangeRequestRepository
                 $pathParams[$key]   = $file['path'];
             }
             $pathList = implode(', ', $pathPlaceholders);
+
+            // BEFORE the supersede DELETE below removes the rows this would read: the base
+            // sha each incoming path's accumulation ancestor was authored against. See this
+            // method's docblock for why an ancestor's base wins over the freshly-computed
+            // disk one.
+            $carriedBaseShas = $this->carriedForwardBaseShas($submittedBySub, $pathList, $pathParams);
 
             // Which of the submitter's own still-submitted batches collide. Resolved as its
             // own SELECT rather than as a subquery inside the DELETE because the ids are
@@ -405,16 +428,23 @@ class SourceDataChangeRequestRepository
 
             $insert = $this->db->prepare(
                 'INSERT INTO sourcedata_change_requests
-                    (batch_id, resource_type, resource_id, path, operation, content,
+                    (batch_id, resource_type, resource_id, path, operation, content, base_sha,
                      submitted_by_sub, submitted_by_name, submitted_by_email, submitted_by_email_verified,
                      review_status, publication_status, metadata)
                  VALUES
-                    (:batch_id, :resource_type, :resource_id, :path, :operation, :content,
+                    (:batch_id, :resource_type, :resource_id, :path, :operation, :content, :base_sha,
                      :sub, :name, :email, :email_verified,
                      :review_status, :publication_status, :metadata)'
             );
 
             foreach ($files as $file) {
+                // array_key_exists, not ??: a null carried forward is a MEANINGFUL answer —
+                // "the ancestor was authored against no upstream file" — and must not fall
+                // back to a disk sha that appeared after the chain started.
+                $baseSha = array_key_exists($file['path'], $carriedBaseShas)
+                    ? $carriedBaseShas[$file['path']]
+                    : ( $file['base_sha'] ?? null );
+
                 $insert->execute([
                     'batch_id'           => $batchId,
                     'resource_type'      => $resource->type,
@@ -422,6 +452,7 @@ class SourceDataChangeRequestRepository
                     'path'               => $file['path'],
                     'operation'          => $file['operation']->value,
                     'content'            => $file['content'],
+                    'base_sha'           => $baseSha,
                     'sub'                => $submittedBySub,
                     'name'               => $submittedByName,
                     'email'              => $submittedByEmail,
@@ -462,6 +493,59 @@ class SourceDataChangeRequestRepository
             'merged'       => ChangePublicationStatus::MERGED->value,
             'merged_floor' => ChangePublicationStatus::MERGED->value,
         ];
+    }
+
+    /**
+     * The `base_sha` of the row {@see findUnpublishedContent()} would return, for each of
+     * several paths at once.
+     *
+     * This is the accumulation ancestor's base: the upstream blob the content a new submission
+     * is about to build on top of was itself authored against. {@see submitBatch()} prefers it
+     * over the disk sha the writer just computed, and its docblock explains why.
+     *
+     * The predicates and the ORDER BY are {@see findUnpublishedContent()}'s, verbatim, and must
+     * stay that way: this must resolve to the SAME row that supplied the content, or the base
+     * would describe a different ancestor than the one being accumulated onto. `DISTINCT ON`
+     * applies that ordering per path in one round trip, which is why the ordering repeats
+     * `path` first — Postgres requires the `DISTINCT ON` expression to lead the `ORDER BY`.
+     *
+     * A path with no ancestor is ABSENT from the result; a path whose ancestor has a null
+     * `base_sha` is PRESENT with a null value. The two are different answers ("nothing to carry
+     * forward" versus "carry forward: there was no upstream file"), so the caller distinguishes
+     * them with `array_key_exists()`.
+     *
+     * @param string                $pathList   The `:path_N` placeholder list {@see submitBatch()}
+     *                                          already built for its own supersede queries.
+     * @param array<string, string> $pathParams The values those placeholders bind to.
+     * @return array<string, ?string> Keyed by path.
+     */
+    private function carriedForwardBaseShas(string $submittedBySub, string $pathList, array $pathParams): array
+    {
+        $stmt = $this->db->prepare(
+            'SELECT DISTINCT ON (path) path, base_sha
+               FROM sourcedata_change_requests
+              WHERE submitted_by_sub = :sub
+                AND path IN (' . $pathList . ')
+                AND ' . self::UNPUBLISHED_PREDICATE . '
+                AND ' . self::NOT_SUPERSEDED_BY_PUBLISHED . '
+              ORDER BY path, ( review_status = :submitted ) DESC, created_at DESC, id DESC'
+        );
+        $stmt->execute([
+            'sub' => $submittedBySub,
+            ...self::unpublishedParams(),
+            ...$pathParams,
+        ]);
+
+        $bases = [];
+        /** @var array<int, array<string, mixed>> $rows */
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        foreach ($rows as $row) {
+            $path         = self::requireString($row['path'] ?? null, 'path');
+            $baseSha      = $row['base_sha'] ?? null;
+            $bases[$path] = is_string($baseSha) ? $baseSha : null;
+        }
+
+        return $bases;
     }
 
     /**
@@ -911,9 +995,21 @@ class SourceDataChangeRequestRepository
      * Sets `publication_status` to `open`, stamps the git-side identifiers the batch was
      * published under, and clears `publish_attempts` — the bound in {@see MAX_PUBLISH_ATTEMPTS}
      * counts CONSECUTIVE failures, so a batch that eventually succeeds must not carry the
-     * failures it recovered from into whatever phase 3 does with it. `base_sha` is the commit the publisher branched from — distinct
-     * from each row's own `base_sha`, which is per-file accumulation-base bookkeeping set
-     * at submission time.
+     * failures it recovered from into whatever phase 3 does with it.
+     *
+     * # `publish_base_sha`, and why it is not `base_sha`
+     *
+     * `publish_base_sha` is the COMMIT the publisher branched from — a batch-level value,
+     * identical across every row of the batch. It used to be written into `base_sha`, which
+     * destroyed that column's actual contents: a per-file BLOB sha, recorded at submission time,
+     * describing the upstream file each edit was authored against. Overwriting the one with the
+     * other left no row anywhere in the table able to answer "did this file move underneath this
+     * proposal?", which is the entire question `base_sha` exists for
+     * ({@see https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/917}).
+     *
+     * They are two different kinds of sha answering two different questions, so they get two
+     * columns. This method must never write `base_sha`: nothing after submission knows what a
+     * file was authored against, so anything it wrote there would be a fabrication.
      *
      * `WHERE ... AND publication_status = queued` guards a reachable overwrite: a slow runner
      * A can be outlived by {@see reclaimStaleClaims()} freeing its claim on the grace period,
@@ -944,7 +1040,7 @@ class SourceDataChangeRequestRepository
         string $branch,
         string $commitSha,
         ?int $prNumber,
-        string $baseSha
+        string $publishBaseSha
     ): int {
         $stmt = $this->db->prepare(
             'UPDATE sourcedata_change_requests
@@ -952,7 +1048,7 @@ class SourceDataChangeRequestRepository
                     branch              = :branch,
                     commit_sha          = :commit_sha,
                     pr_number           = :pr_number,
-                    base_sha            = :base_sha,
+                    publish_base_sha    = :publish_base_sha,
                     publish_attempts    = 0,
                     publish_claim_token = NULL,
                     updated_at          = NOW()
@@ -960,13 +1056,13 @@ class SourceDataChangeRequestRepository
                 AND publication_status = :queued'
         );
         $stmt->execute([
-            'open'       => ChangePublicationStatus::OPEN->value,
-            'branch'     => $branch,
-            'commit_sha' => $commitSha,
-            'pr_number'  => $prNumber,
-            'base_sha'   => $baseSha,
-            'batch_id'   => $batchId,
-            'queued'     => ChangePublicationStatus::QUEUED->value,
+            'open'             => ChangePublicationStatus::OPEN->value,
+            'branch'           => $branch,
+            'commit_sha'       => $commitSha,
+            'pr_number'        => $prNumber,
+            'publish_base_sha' => $publishBaseSha,
+            'batch_id'         => $batchId,
+            'queued'           => ChangePublicationStatus::QUEUED->value,
         ]);
 
         return $stmt->rowCount();

--- a/src/Services/SourceData/ChangeRequestSourceDataWriter.php
+++ b/src/Services/SourceData/ChangeRequestSourceDataWriter.php
@@ -21,7 +21,7 @@ use PDOException;
  */
 final class ChangeRequestSourceDataWriter implements SourceDataWriter
 {
-    /** @var list<array{path: string, operation: ChangeOperation, content: ?string}> */
+    /** @var list<array{path: string, operation: ChangeOperation, content: ?string, base_sha: ?string}> */
     private array $staged = [];
 
     /**
@@ -39,12 +39,28 @@ final class ChangeRequestSourceDataWriter implements SourceDataWriter
     ) {
     }
 
+    /**
+     * `base_sha` is captured HERE and nowhere later, because this is the only moment that knows
+     * what the edit was authored against: the file as it stands in the deployed working tree,
+     * which is what every read path served the editor. It is a git BLOB sha
+     * ({@see GitBlobSha}), directly comparable with the sha the same path carries in a GitHub
+     * tree, so a rebase check can ask "did this file move underneath the proposal?" without
+     * re-deriving anything.
+     *
+     * Null when there is no file there — an ordinary `create`, and also a file that so far
+     * exists only as this submitter's queued work. Deliberately NOT the accumulation base's own
+     * content: that content is the submitter's in-flight proposal, whose sha exists nowhere
+     * upstream, so hashing it would make every accumulating chain read as permanently stale.
+     * {@see SourceDataChangeRequestRepository::submitBatch()} overrides this value with the
+     * accumulation ancestor's when there is one, for the mirror-image reason.
+     */
     public function stage(string $absolutePath, ChangeOperation $operation, ?string $content): void
     {
         $this->staged[] = [
             'path'      => $this->repoRelativePath($absolutePath),
             'operation' => $operation,
             'content'   => $content,
+            'base_sha'  => GitBlobSha::ofFile($absolutePath),
         ];
     }
 

--- a/src/Services/SourceData/GitBlobSha.php
+++ b/src/Services/SourceData/GitBlobSha.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+/**
+ * The git object id of a file's contents — the same value GitHub's Git Data API
+ * returns as a tree entry's `sha` and as {@see \LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient::createBlob()}'s
+ * return value.
+ *
+ * A blob's object id is `sha1("blob " . byteLength . "\0" . contents)`. That is a git
+ * format constant, not an implementation detail of any particular git version, which is
+ * what makes it safe to compute locally and compare against a sha GitHub produced: a
+ * change request's `base_sha` is written here, from the file on disk at submission time,
+ * and a rebase check compares it against the blob sha the same path carries on the branch
+ * the publish is about to land on.
+ *
+ * SHA-1 is used because that is what a git object id IS. This is a content address for
+ * comparison against git's own, never a security primitive, so the collision weaknesses
+ * that rule SHA-1 out elsewhere are not in play here — an attacker who could produce a
+ * blob-sha collision would already have had to get the colliding content past the
+ * approval gate.
+ *
+ * Note the length is the byte length, so `strlen()` is correct and `mb_strlen()` would be
+ * wrong: git counts octets, and every source-data file this touches may contain multi-byte
+ * UTF-8.
+ */
+final class GitBlobSha
+{
+    /**
+     * The blob sha of `$content` exactly as git would compute it.
+     */
+    public static function ofContent(string $content): string
+    {
+        return sha1('blob ' . strlen($content) . "\0" . $content);
+    }
+
+    /**
+     * The blob sha of the file at `$absolutePath`, or null when there is no readable file
+     * there.
+     *
+     * Null is a value, not an error: a change request that CREATES a file was authored
+     * against no upstream blob at all, and that is exactly what a null `base_sha` records.
+     * See the `base_sha` notes in `docs/ops/change-request-runbook.md` for how a null is
+     * to be read back — the row's `operation` disambiguates "there was no file" from
+     * "this row predates the column being written".
+     */
+    public static function ofFile(string $absolutePath): ?string
+    {
+        if (!is_file($absolutePath) || !is_readable($absolutePath)) {
+            return null;
+        }
+
+        $content = file_get_contents($absolutePath);
+
+        return is_string($content) ? self::ofContent($content) : null;
+    }
+}

--- a/src/Services/SourceData/PublishResult.php
+++ b/src/Services/SourceData/PublishResult.php
@@ -21,11 +21,14 @@ final readonly class PublishResult
         public ?int $prNumber,
         /**
          * The commit `$branch` pointed at before this publish — the parent of `$commitSha`,
-         * and (on the branch's first publish) the base branch's head at that moment. Distinct
-         * from a row's own per-file `base_sha`, which is accumulation-base bookkeeping set at
-         * submission time.
+         * and (on the branch's first publish) the base branch's head at that moment.
+         *
+         * Persisted as `publish_base_sha`, and deliberately NOT as `base_sha`: a row's own
+         * `base_sha` is the per-file BLOB sha its edit was authored against, captured at
+         * submission time. Writing this commit sha over that was
+         * {@see https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/917}.
          */
-        public string $baseSha
+        public string $publishBaseSha
     ) {
     }
 }


### PR DESCRIPTION
Addresses #917.

## What the investigation found

`base_sha` had **one writer and zero readers**.

It was written only by `recordPublication()`, which stamped the batch-level branch-head *commit* sha across every row of a published batch. The `INSERT` in `submitBatch()` never mentioned the column, so **nothing ever wrote the per-file value phase 1 designed it for**. Nothing read it either: `PublishablePayload::fromBatchRows()` ignores it, `listBatches()` never selects it, and no handler, schema or `/health` block exposes it — so the change is invisible to API clients.

Two docblocks already *claimed* the per-file value was "accumulation-base bookkeeping set at submission time", describing behaviour that did not exist.

## What this does

- **`GitBlobSha`** — computes `sha1("blob " + byteLen + "\0" + content)`, the git object id, so a stored value is directly comparable with a GitHub tree entry's `sha`. Tested against real `git hash-object` output, including a byte-vs-character length case.
- **`ChangeRequestSourceDataWriter::stage()`** captures `base_sha` from the file on disk; null when absent.
- **`submitBatch()`** inserts it, and a new `carriedForwardBaseShas()` — same predicates and `ORDER BY` as `findUnpublishedContent()`, run *before* the supersede DELETE — makes an accumulation ancestor's base win over the fresh disk sha. It uses `array_key_exists`, not `??`, so a null ancestor base is carried forward rather than refilled from a disk state the content never saw.
- **`recordPublication()`** writes a new `publish_base_sha` and no longer touches `base_sha`. `PublishResult::$baseSha` is renamed `$publishBaseSha`.
- **Migration `Version20260830130000`** adds nullable `publish_base_sha`, backfills it from `base_sha`, and nulls `base_sha` where set — every existing non-null value was a commit sha.

## Two decisions worth a second opinion

**1. Carry-forward beats the fresh disk sha.** Accumulated content is built from `findUnpublishedContent()` and never re-read from disk, so a fresh sha would assert a base the content has never seen — silencing the check in the one scenario it exists for. The cost: a chain started before this migration inherits `NULL` forever. That is made readable rather than papered over — `operation` disambiguates "no upstream file" (create) from "unknown" (update/delete), documented in a runbook table.

**2. `base_sha` is the sha of the file *on disk*** — the last-deployed state, not the `development` branch head, which may be ahead. That matches "what the editor authored against", since disk is what every read path served them. But it means a check comparing it to the branch tree will report staleness for any file that moved upstream since the last deploy, whether or not it conflicts.

## What is deliberately not here

**The rebase check itself.** It needs a `getTree()` on `GitHubGitDataClient` (which can resolve a commit to a tree sha but cannot read tree entries), and a policy decision that belongs to the maintainer: does a stale batch **block** the publish — touching `PublishRunner`'s failure and parking semantics — or publish with an annotation on the pull request?

The issue asks for the bookkeeping "so rebase detection is possible", which is what this delivers. The remainder is stated explicitly in the runbook, both design specs, and the commit message.

## Verification

`parallel-lint`, `lint`, `analyse` (PHPStan L10), `test`, `lint:md` all pass — `Tests: 4251, Warnings: 1, Skipped: 14`, no failures or errors, run against an isolated database. The single warning (`DiskSourceDataWriter.php:101 mkdir(): File exists`) is pre-existing and in untouched code.

New tests: `GitBlobShaTest` (7), `ChangeRequestBaseShaTest` (7 DB-backed — capture, null, survival through publication, accumulation carry-forward including a deploy landing mid-chain, null-ancestor carry-forward, re-parented rows, cross-submitter scoping), plus schema and publish-queue additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ueFDAmZFPEP3fhbe26JHj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Source-data change requests now preserve the original file version associated with each submitted file.
  - Publication records now separately track the branch version used during publishing, improving the accuracy of change history.
  - Existing change-request records are migrated automatically to the updated tracking format.

- **Documentation**
  - Updated operational guidance and design documentation to explain the improved version tracking and remaining rebase-detection work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->