### PR TITLE
feat(sourcedata): re-validate a change request against the current schema before approving it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,19 @@
   reviewer or a stopped poller, since an undetected merge is indistinguishable from an unreviewed one from
   this side. See `docs/ops/change-request-runbook.md`'s "Merge detection (phase 3)" section for the full
   operator playbook.
+* re-validate a source-data change request against the **current** JSON schemas at the moment of approval,
+  see issue [#918](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/918). Content was
+  previously checked only when it was submitted, so a batch approved after its schema had tightened
+  produced a pull request that failed CI — the failure landing after the human decision rather than at it.
+  `POST /admin/change-requests/{batchId}/approve` now answers **422** when any still-`submitted` row no
+  longer validates, naming each offending file, the schema that refused it, and the violation; the batch is
+  left completely untouched, so its submitter can withdraw and re-submit, or a reviewer can reject it
+  (rejection is deliberately not gated on validation). Rows carrying no content — a delete — have nothing
+  to validate and are skipped; the predicate is the absence of content, never `operation = 'delete'`, which
+  also fires for an ordinary locale removal on a calendar that still exists. A path no schema governs is
+  treated as not validated rather than invalid, so a batch nothing has found fault with can never jam the
+  reviewer's queue. Auto-approved batches (a submitter who already administers the resource) are unaffected:
+  they are approved in the same request that just validated the payload.
 -->
 
 ## [v5.7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/releases/tag/v5.7) (December 15th 2025)

--- a/docs/ops/change-request-runbook.md
+++ b/docs/ops/change-request-runbook.md
@@ -245,9 +245,50 @@ someone else between the caller reading the queue and acting on it — `review_s
 `WHERE` predicate that makes a decision single-shot; re-deciding an already-decided batch matches zero
 rows.
 
+### Approval re-validates against the current schemas (422)
+
+Approval is not only a status change: before flipping anything, the handler re-checks every
+still-`submitted` row of the batch against the JSON schema that governs its path *right now*
+(`ChangeRequestSchemaValidator`, `SourceDataSchemaResolver`). If any row no longer validates, the
+approval is refused with a **422** naming each offending file, the schema that refused it, and the
+violation — and the batch is left completely untouched: still `submitted`, still holding every row.
+
+The window this closes is real but easy to misread. Content is validated once, by the handler that
+accepted it, and a batch can then sit in the queue for weeks. If a schema tightens in between, the batch
+is still `submitted` and looks approvable, and before #918 it *was* — the mismatch only surfaced later, as
+a failing CI run on the pull request the publisher had already opened. The check now happens where the
+decision happens.
+
+Two consequences worth knowing before you go looking for a bug:
+
+- **404 / 400 / 409 still take precedence.** The 422 is reached only after existence, authorization and
+  batch-id shape have passed, and it checks only rows a transition would actually move. A batch someone
+  else already decided answers **409**, not 422, even when its content would now fail — the transition is
+  not going to happen, so re-litigating its content would replace the true answer ("already decided") with
+  a misleading one.
+- **A refused batch is not stuck, but it cannot be repaired from the reviewer's side.** There is no
+  "approve anyway". Either the submitter withdraws it (`POST /auth/change-requests/{batchId}/withdraw`)
+  and re-submits content that satisfies the current schema, or you reject it — rejection is deliberately
+  *not* gated on validation, precisely so an invalid batch can always be cleared out of the queue.
+
+A path no schema claims — `SourceDataSchemaResolver` covers every family a write handler stages, and
+nothing else — is treated as *not validated*, never as invalid. Refusing there would jam the queue on a
+batch nothing has found fault with, for a reason no administrator could act on. If you add a new kind of
+stageable source data, add its family to that resolver or its content will pass this gate unchecked.
+
+Rows with no content are not checked, because there are no bytes for a schema to have an opinion about.
+The predicate is `content IS NULL`, **not** `operation = 'delete'` and **not**
+`metadata.deletes_resource` — see "Closed: a deleted resource's editors used to keep access" below for
+why those two mean different things and why neither is a safe stand-in here.
+
+The auto-approval path (`ChangeRequestSourceDataWriter::commit()`, for a submitter who already administers
+the resource) does **not** re-validate, and does not need to: it approves in the very same request that
+just validated the payload, so there is no interval in which a schema could have moved.
+
 If the API is unreachable, a direct SQL decision is the fallback — do this only when you have already
 confirmed (via the queries above) that you are looking at the right batch and that `review_status` is
-still `submitted`:
+still `submitted`. Note that this bypasses the schema re-validation above as well as the audit log, so
+satisfy yourself that the content is still valid before running it:
 
 ```sql
 UPDATE sourcedata_change_requests
@@ -804,12 +845,11 @@ not removed, exactly as the automatic path retains it.
 
 ## Deliberately not in phase 1, 2, or 3
 
-- **Re-validating a payload against its JSON schema at approval or publish time.** All three phases
-  validate once, at submit. Nothing re-checks a batch's content against its JSON schema between then and
-  the commit `SourceDataPublisher::publish()` pushes, even though real time — and potentially a schema
-  change — can pass in between. A batch approved against one schema and published after that schema
-  changed produces a pull request whose CI fails `lint:jsondata` — visible, but a backstop on the wrong
-  side of the gate.
+- **Re-validating at *publish* time.** #918 closed the approval half of this: approval now re-checks a
+  batch against the schemas in force at that moment (see "Approval re-validates against the current
+  schemas" above). The publisher still does not. The remaining window is between approval and the commit
+  `SourceDataPublisher::publish()` pushes — much narrower than the submit-to-publish window it replaced,
+  since a batch is normally published within minutes of approval, but not zero.
 - **Per-file `base_sha` and rebase detection.** `recordPublication()` overwrites every row's `base_sha`
   with the batch-level branch head, destroying the per-file bookkeeping a rebase check would need. See
   "`base_sha` was speculative in phase 1 and is now defined" below.

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -3603,7 +3603,7 @@
         ],
         "summary": "Approve a source-data change request batch",
         "operationId": "adminApproveChangeRequest",
-        "description": "Approve every still-`submitted` row in the batch. Requires the `admin` relation on the batch's resource (global admins bypass the OpenFGA check). Returns 404, never 403, when the caller does not administer the batch's resource — identical to an unknown batch id, so a 403 cannot confirm to the caller that a batch they cannot touch exists at all. Returns 409 if the batch was already approved, rejected, or withdrawn by someone else before this request landed. Approving in Phase 1 records the decision only: the batch is not published anywhere and `publication_status` stays `none` until the Phase 2 publisher exists — see the change-request runbook.",
+        "description": "Approve every still-`submitted` row in the batch. Requires the `admin` relation on the batch's resource (global admins bypass the OpenFGA check). Returns 404, never 403, when the caller does not administer the batch's resource — identical to an unknown batch id, so a 403 cannot confirm to the caller that a batch they cannot touch exists at all. Returns 409 if the batch was already approved, rejected, or withdrawn by someone else before this request landed.\n\nBefore anything is transitioned, every still-`submitted` row is re-validated against the JSON schema that governs its path **at this moment**, not the one in force when it was submitted. If any row no longer validates the approval is refused with 422, the batch is left untouched (still `submitted`, every row intact), and the `detail` names each offending file, the schema that refused it, and the violation. Rows carrying no content — a delete — have nothing to validate and are skipped. There is no override: the submitter must withdraw and re-submit against the current schema, or the batch must be rejected (rejection is deliberately not gated on validation). Approving records the decision; publication is the publisher's separate step, tracked by `publication_status` — see the change-request runbook.",
         "parameters": [
           {
             "name": "batchId",
@@ -3637,6 +3637,10 @@
           },
           "409": {
             "$ref": "#/components/responses/Conflict409"
+          },
+          "422": {
+            "description": "Unprocessable: one or more of the batch's proposed files no longer validate against the JSON schema currently governing their path. The batch is unchanged and still awaiting review.",
+            "$ref": "#/components/responses/ValidationError422"
           }
         }
       }

--- a/phpunit_tests/Handlers/ChangeRequestAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/ChangeRequestAdminHandlerTest.php
@@ -14,6 +14,7 @@ use LiturgicalCalendar\Api\Handlers\Admin\ChangeRequestAdminHandler;
 use LiturgicalCalendar\Api\Http\Exception\ConflictException;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
 use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Api\Services\ChangeResource;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier;
@@ -23,6 +24,7 @@ use Nyholm\Psr7\ServerRequest;
 use GuzzleHttp\Exception\ConnectException;
 use LiturgicalCalendar\Api\Enum\ChangeReviewStatus;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Http\Exception\UnprocessableContentException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -37,10 +39,24 @@ final class ChangeRequestAdminHandlerTest extends RepositoryTestCase
 {
     private SourceDataChangeRequestRepository $repo;
 
+    private string $savedApiFilePath = '';
+
     protected function setUp(): void
     {
         parent::setUp();
         $this->repo = new SourceDataChangeRequestRepository(self::$pdo);
+
+        // The #918 approval gate imports schemas through LitSchema::path(), which prefixes
+        // Router::$apiFilePath. Pin it to the project root the way AbstractHandlerTestCase
+        // does, and put it back afterwards so no other class inherits this one's value.
+        $this->savedApiFilePath = isset(Router::$apiFilePath) ? Router::$apiFilePath : '';
+        Router::$apiFilePath    = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
+    }
+
+    protected function tearDown(): void
+    {
+        Router::$apiFilePath = $this->savedApiFilePath;
+        parent::tearDown();
     }
 
     /**
@@ -71,15 +87,44 @@ final class ChangeRequestAdminHandlerTest extends RepositoryTestCase
         return new GuzzleResponse(200, [], json_encode(['allowed' => $allowed]));
     }
 
+    /**
+     * A national-calendar locale file, valid against `LitCalTranslation.json`.
+     *
+     * The path is a real one — {@see \LiturgicalCalendar\Api\Enum\JsonData::NATIONAL_CALENDAR_I18N_FILE}
+     * — and the content really does satisfy the schema that governs it, so approving one of
+     * these batches goes through the #918 re-validation gate rather than round it. A synthetic
+     * path would resolve to no schema and silently skip the very check most of these tests
+     * transit.
+     */
     private function submitFor(string $sub, string $nation): string
     {
+        return $this->submitContentFor(
+            $sub,
+            $nation,
+            'jsondata/sourcedata/rite/roman/calendars/nations/' . $nation . '/i18n/en.json',
+            ChangeOperation::UPDATE,
+            '{"StFrancisAssisi":"Saint Francis of Assisi"}'
+        );
+    }
+
+    /**
+     * As {@see submitFor()}, but with the staged file spelled out — for the tests that care
+     * what the row actually holds.
+     */
+    private function submitContentFor(
+        string $sub,
+        string $nation,
+        string $path,
+        ChangeOperation $operation,
+        ?string $content
+    ): string {
         return $this->repo->submitBatch(
             ChangeResource::nationalCalendar(Rite::ROMAN, $nation),
             [
                 [
-                    'path'      => 'jsondata/sourcedata/rite/roman/calendars/nation/' . $nation . '.json',
-                    'operation' => ChangeOperation::UPDATE,
-                    'content'   => '{"litcal":[]}',
+                    'path'      => $path,
+                    'operation' => $operation,
+                    'content'   => $content,
                 ],
             ],
             $sub,
@@ -335,5 +380,165 @@ final class ChangeRequestAdminHandlerTest extends RepositoryTestCase
         $handler->handle($this->request('POST', '/admin/change-requests/' . $batchId . '/reject', 'admin-1'));
 
         self::assertSame([], $notifier->notified, 'a rejected batch is never publishable');
+    }
+
+    /**
+     * The happy half of #918: content that still satisfies the schema governing its path is
+     * approved, and the notifier is told, exactly as before the gate existed.
+     */
+    public function testApprovingABatchWhoseContentStillValidatesSucceeds(): void
+    {
+        $batchId  = $this->submitFor('editor-1', 'USA');
+        $notifier = new RecordingPublishNotifier();
+
+        $handler  = $this->handler(['change-requests', $batchId, 'approve'], [self::allowed(true)], $notifier);
+        $response = $handler->handle($this->request('POST', '/admin/change-requests/' . $batchId . '/approve', 'admin-1'));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(ChangeReviewStatus::APPROVED->value, $this->repo->getBatch($batchId)[0]['review_status']);
+        self::assertSame([$batchId], $notifier->notified);
+    }
+
+    /**
+     * The defect half of #918. `LitCalTranslation.json` requires every value to be a string;
+     * a row holding a number therefore no longer validates. Standing in for real schema drift
+     * — the row was accepted once and the schema has since tightened — because the outcome the
+     * gate has to produce is identical either way: content in the queue that the schema in
+     * force now rejects.
+     */
+    public function testApprovingABatchWhoseContentNoLongerValidatesIsRefused(): void
+    {
+        $path    = 'jsondata/sourcedata/rite/roman/calendars/nations/USA/i18n/en.json';
+        $batchId = $this->submitContentFor('editor-1', 'USA', $path, ChangeOperation::UPDATE, '{"StFrancisAssisi":42}');
+
+        $notifier = new RecordingPublishNotifier();
+        $handler  = $this->handler(['change-requests', $batchId, 'approve'], [self::allowed(true)], $notifier);
+
+        try {
+            $handler->handle($this->request('POST', '/admin/change-requests/' . $batchId . '/approve', 'admin-1'));
+            self::fail('a batch that no longer validates must not be approvable');
+        } catch (UnprocessableContentException $e) {
+            self::assertSame(422, $e->getStatus());
+            // Actionable: which file, and which schema refused it.
+            self::assertStringContainsString($path, $e->getMessage());
+            self::assertStringContainsString('LitCalTranslation.json', $e->getMessage());
+        }
+
+        // Not silently approved, and not silently dropped: the batch is intact and still
+        // awaiting review, so its submitter can withdraw and re-submit it.
+        $rows = $this->repo->getBatch($batchId);
+        self::assertCount(1, $rows);
+        self::assertSame(ChangeReviewStatus::SUBMITTED->value, $rows[0]['review_status']);
+        self::assertNull($rows[0]['approved_by_sub']);
+        self::assertSame([], $notifier->notified, 'nothing may be announced for a refused approval');
+    }
+
+    /**
+     * A row whose content is not JSON at all is a violation too — it would reach the pull
+     * request as an unparseable file.
+     */
+    public function testApprovingABatchWhoseContentIsNotJsonIsRefused(): void
+    {
+        $path    = 'jsondata/sourcedata/rite/roman/calendars/nations/USA/i18n/en.json';
+        $batchId = $this->submitContentFor('editor-1', 'USA', $path, ChangeOperation::UPDATE, '{not json');
+
+        $handler = $this->handler(['change-requests', $batchId, 'approve'], [self::allowed(true)]);
+
+        $this->expectException(UnprocessableContentException::class);
+        $this->expectExceptionMessageMatches('/not valid JSON/');
+        $handler->handle($this->request('POST', '/admin/change-requests/' . $batchId . '/approve', 'admin-1'));
+    }
+
+    /**
+     * A DELETE row carries no content, so there is nothing for a schema to have an opinion
+     * about. Critically, the path here IS one the resolver recognises — an empty i18n file
+     * would fail `LitCalTranslation.json`'s `minProperties` — so the batch only approves
+     * because the gate keys on "are there bytes", not on the path.
+     *
+     * This is the ordinary locale-drop case, not a resource deletion: `RegionalDataHandler`
+     * stages exactly this DELETE for a locale removed from `metadata.locales` on a calendar
+     * that still exists, which is why `operation = 'delete'` must never be read as anything
+     * more than "no bytes proposed".
+     */
+    public function testADeleteRowIsApprovedWithoutBeingValidated(): void
+    {
+        $batchId = $this->submitContentFor(
+            'editor-1',
+            'USA',
+            'jsondata/sourcedata/rite/roman/calendars/nations/USA/i18n/de.json',
+            ChangeOperation::DELETE,
+            null
+        );
+
+        $handler  = $this->handler(['change-requests', $batchId, 'approve'], [self::allowed(true)]);
+        $response = $handler->handle($this->request('POST', '/admin/change-requests/' . $batchId . '/approve', 'admin-1'));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(ChangeReviewStatus::APPROVED->value, $this->repo->getBatch($batchId)[0]['review_status']);
+    }
+
+    /**
+     * A path outside every family {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataSchemaResolver}
+     * knows resolves to no schema, and "no schema claims these bytes" is not "these bytes are
+     * wrong". Refusing here would jam the reviewer's queue on a batch nothing has found fault
+     * with, for a reason no administrator could act on.
+     */
+    public function testAPathNoSchemaGovernsIsApprovedRatherThanRefused(): void
+    {
+        $batchId = $this->submitContentFor(
+            'editor-1',
+            'USA',
+            'jsondata/sourcedata/rite/roman/missals/propriumdetempore/propriumdetempore.json',
+            ChangeOperation::UPDATE,
+            '{"anything":"at all"}'
+        );
+
+        $handler  = $this->handler(['change-requests', $batchId, 'approve'], [self::allowed(true)]);
+        $response = $handler->handle($this->request('POST', '/admin/change-requests/' . $batchId . '/approve', 'admin-1'));
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * "Someone else already decided this" stays a 409, even when the decided batch's content
+     * would not pass the schemas in force now. The transition is not going to happen, so
+     * re-litigating its content would replace the true answer with a misleading one.
+     */
+    public function testAnAlreadyDecidedBatchStillConflictsRatherThanFailingValidation(): void
+    {
+        $batchId = $this->submitContentFor(
+            'editor-1',
+            'USA',
+            'jsondata/sourcedata/rite/roman/calendars/nations/USA/i18n/en.json',
+            ChangeOperation::UPDATE,
+            '{"StFrancisAssisi":42}'
+        );
+        $this->repo->approveBatch($batchId, 'admin-1');
+
+        $handler = $this->handler(['change-requests', $batchId, 'approve'], [self::allowed(true)]);
+
+        $this->expectException(ConflictException::class);
+        $handler->handle($this->request('POST', '/admin/change-requests/' . $batchId . '/approve', 'admin-2'));
+    }
+
+    /**
+     * Rejection is unaffected: a batch that can no longer be approved must still be
+     * dismissible, or an invalid batch would be stuck in the queue forever.
+     */
+    public function testABatchThatNoLongerValidatesCanStillBeRejected(): void
+    {
+        $batchId = $this->submitContentFor(
+            'editor-1',
+            'USA',
+            'jsondata/sourcedata/rite/roman/calendars/nations/USA/i18n/en.json',
+            ChangeOperation::UPDATE,
+            '{"StFrancisAssisi":42}'
+        );
+
+        $handler  = $this->handler(['change-requests', $batchId, 'reject'], [self::allowed(true)]);
+        $response = $handler->handle($this->request('POST', '/admin/change-requests/' . $batchId . '/reject', 'admin-1'));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(ChangeReviewStatus::REJECTED->value, $this->repo->getBatch($batchId)[0]['review_status']);
     }
 }

--- a/phpunit_tests/Services/SourceData/ChangeRequestSchemaValidatorTest.php
+++ b/phpunit_tests/Services/SourceData/ChangeRequestSchemaValidatorTest.php
@@ -102,6 +102,21 @@ final class ChangeRequestSchemaValidatorTest extends TestCase
     }
 
     /**
+     * A row carrying bytes but no usable path cannot be resolved to a schema, and must be passed
+     * over rather than reported as a violation — the same direction the unmapped-path case takes,
+     * and for the same reason: refusing an approval over something no schema claims would jam the
+     * queue on a batch nothing found fault with.
+     */
+    public function testARowWithAnEmptyPathIsSkippedRatherThanRefused(): void
+    {
+        $violations = ( new ChangeRequestSchemaValidator() )->violations(self::rows([
+            ['path' => '', 'operation' => ChangeOperation::UPDATE, 'content' => '{"nonsense":true}'],
+        ]));
+
+        self::assertSame([], $violations);
+    }
+
+    /**
      * A locale-drop batch: one DELETE for the locale file, one UPDATE restaging the calendar's
      * own translations. `operation = 'delete'` says nothing about the batch, and the row that
      * does carry content is checked exactly as it would be on its own.

--- a/phpunit_tests/Services/SourceData/ChangeRequestSchemaValidatorTest.php
+++ b/phpunit_tests/Services/SourceData/ChangeRequestSchemaValidatorTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Enum\ChangeOperation;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\SourceData\ChangeRequestSchemaValidator;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataSchemaResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ChangeRequestSchemaValidator::class)]
+final class ChangeRequestSchemaValidatorTest extends TestCase
+{
+    private const NATION_I18N = 'jsondata/sourcedata/rite/roman/calendars/nations/US/i18n/en.json';
+
+    private static string $projectRoot;
+
+    private string $savedApiFilePath = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$projectRoot = dirname(__DIR__, 3);
+    }
+
+    protected function setUp(): void
+    {
+        // LitSchema::path() prefixes Router::$apiFilePath, and the validator imports schemas
+        // through it. Pin it the way AbstractHandlerTestCase does, and restore afterwards.
+        $this->savedApiFilePath = isset(Router::$apiFilePath) ? Router::$apiFilePath : '';
+        Router::$apiFilePath    = self::$projectRoot . DIRECTORY_SEPARATOR;
+    }
+
+    protected function tearDown(): void
+    {
+        Router::$apiFilePath = $this->savedApiFilePath;
+    }
+
+    /**
+     * @param list<array{path: string, operation?: ChangeOperation, content: ?string}> $files
+     * @return array<int, array<string, mixed>>
+     */
+    private static function rows(array $files): array
+    {
+        return array_map(
+            static fn (array $f): array => [
+                'path'      => $f['path'],
+                'operation' => ( $f['operation'] ?? ChangeOperation::UPDATE )->value,
+                'content'   => $f['content'],
+            ],
+            $files
+        );
+    }
+
+    public function testContentThatSatisfiesItsSchemaProducesNoViolations(): void
+    {
+        $violations = ( new ChangeRequestSchemaValidator() )->violations(self::rows([
+            ['path' => self::NATION_I18N, 'content' => '{"StFrancisAssisi":"Saint Francis of Assisi"}'],
+        ]));
+
+        self::assertSame([], $violations);
+    }
+
+    public function testContentThatViolatesItsSchemaIsReportedWithPathAndSchemaName(): void
+    {
+        // LitCalTranslation.json's additionalProperties are strings; a number is not one.
+        $violations = ( new ChangeRequestSchemaValidator() )->violations(self::rows([
+            ['path' => self::NATION_I18N, 'content' => '{"StFrancisAssisi":42}'],
+        ]));
+
+        self::assertCount(1, $violations);
+        self::assertSame(self::NATION_I18N, $violations[0]['path']);
+        // The bare filename, never the server path — see LitSchema::name().
+        self::assertSame('LitCalTranslation.json', $violations[0]['schema']);
+        self::assertNotSame('', $violations[0]['detail']);
+    }
+
+    public function testUnparseableContentIsAViolation(): void
+    {
+        $violations = ( new ChangeRequestSchemaValidator() )->violations(self::rows([
+            ['path' => self::NATION_I18N, 'content' => '{"StFrancisAssisi": '],
+        ]));
+
+        self::assertCount(1, $violations);
+        self::assertStringContainsString('not valid JSON', $violations[0]['detail']);
+    }
+
+    /**
+     * The predicate is "does this row carry bytes", not the operation and not
+     * `metadata.deletes_resource`. An empty object would fail `LitCalTranslation.json`'s
+     * `minProperties`, so this only passes because a content-less row is never checked at all.
+     */
+    public function testARowWithNoContentIsNeverChecked(): void
+    {
+        $violations = ( new ChangeRequestSchemaValidator() )->violations(self::rows([
+            ['path' => self::NATION_I18N, 'operation' => ChangeOperation::DELETE, 'content' => null],
+        ]));
+
+        self::assertSame([], $violations);
+    }
+
+    /**
+     * A locale-drop batch: one DELETE for the locale file, one UPDATE restaging the calendar's
+     * own translations. `operation = 'delete'` says nothing about the batch, and the row that
+     * does carry content is checked exactly as it would be on its own.
+     */
+    public function testOnlyTheContentBearingRowsOfAMixedBatchAreChecked(): void
+    {
+        $violations = ( new ChangeRequestSchemaValidator() )->violations(self::rows([
+            [
+                'path'      => 'jsondata/sourcedata/rite/roman/calendars/nations/US/i18n/de.json',
+                'operation' => ChangeOperation::DELETE,
+                'content'   => null,
+            ],
+            ['path' => self::NATION_I18N, 'content' => '{"StFrancisAssisi":42}'],
+        ]));
+
+        self::assertCount(1, $violations);
+        self::assertSame(self::NATION_I18N, $violations[0]['path']);
+    }
+
+    public function testEveryOffendingRowIsReported(): void
+    {
+        $violations = ( new ChangeRequestSchemaValidator() )->violations(self::rows([
+            ['path' => self::NATION_I18N, 'content' => '{"StFrancisAssisi":42}'],
+            [
+                'path'    => 'jsondata/sourcedata/rite/roman/calendars/nations/US/i18n/it.json',
+                'content' => '{"not a valid event key":"x"}',
+            ],
+        ]));
+
+        self::assertCount(2, $violations);
+    }
+
+    public function testAPathNoSchemaGovernsIsNotAViolation(): void
+    {
+        $violations = ( new ChangeRequestSchemaValidator() )->violations(self::rows([
+            [
+                'path'    => 'jsondata/sourcedata/rite/roman/missals/propriumdetempore/propriumdetempore.json',
+                'content' => '{"anything":"at all"}',
+            ],
+        ]));
+
+        self::assertSame([], $violations);
+    }
+
+    /**
+     * The gate is only worth anything if it agrees with the repository it is guarding: every
+     * committed source file whose family this validator claims must pass it. A failure here
+     * means either the path table maps a family to the wrong schema, or `jsondata` has drifted
+     * from its own schemas — both of which would otherwise surface as spurious refusals of
+     * perfectly good change requests.
+     */
+    public function testEveryCommittedSourceFileTheResolverClaimsAlreadyValidates(): void
+    {
+        $rows     = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator(self::$projectRoot . '/jsondata', \FilesystemIterator::SKIP_DOTS)
+        );
+
+        /** @var \SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'json') {
+                continue;
+            }
+            $relative = substr($file->getPathname(), strlen(self::$projectRoot) + 1);
+            if (SourceDataSchemaResolver::forPath($relative) === null) {
+                continue;
+            }
+            $rows[] = [
+                'path'      => $relative,
+                'operation' => ChangeOperation::UPDATE->value,
+                'content'   => (string) file_get_contents($file->getPathname()),
+            ];
+        }
+
+        self::assertNotEmpty($rows, 'the resolver claimed no committed source file — the assertion would be vacuous');
+
+        $violations = ( new ChangeRequestSchemaValidator() )->violations($rows);
+
+        self::assertSame(
+            [],
+            $violations,
+            'committed source data must satisfy the schemas this gate enforces: '
+            . implode(', ', array_map(static fn (array $v): string => $v['path'], $violations))
+        );
+    }
+}

--- a/phpunit_tests/Services/SourceData/SourceDataSchemaResolverTest.php
+++ b/phpunit_tests/Services/SourceData/SourceDataSchemaResolverTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataSchemaResolver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SourceDataSchemaResolver::class)]
+final class SourceDataSchemaResolverTest extends TestCase
+{
+    /**
+     * One path per family a write handler can stage — the union of every `stageFile()` call
+     * site in `RegionalDataHandler`, `DecreesHandler` and `TestsHandler`.
+     *
+     * A `null` here would mean a change request whose content the #918 approval gate cannot
+     * check, so this list is the gate's actual coverage written down.
+     *
+     * @return array<string, array{string, LitSchema}>
+     */
+    public static function stageablePaths(): array
+    {
+        return [
+            'national calendar'            => ['jsondata/sourcedata/rite/roman/calendars/nations/US/US.json', LitSchema::NATIONAL],
+            'national calendar i18n'       => ['jsondata/sourcedata/rite/roman/calendars/nations/US/i18n/en.json', LitSchema::I18N],
+            'national calendar lectionary' => ['jsondata/sourcedata/rite/roman/calendars/nations/US/lectionary/en.json', LitSchema::LECTIONARY],
+            'diocesan calendar'            => ['jsondata/sourcedata/rite/roman/calendars/dioceses/US/boston_us/Archdiocese of Boston.json', LitSchema::DIOCESAN],
+            'diocesan calendar i18n'       => ['jsondata/sourcedata/rite/roman/calendars/dioceses/US/boston_us/i18n/en.json', LitSchema::I18N],
+            'diocesan calendar lectionary' => ['jsondata/sourcedata/rite/roman/calendars/dioceses/US/boston_us/lectionary/en.json', LitSchema::LECTIONARY],
+            'ambrosian diocesan calendar'  => ['jsondata/sourcedata/rite/ambrosian/calendars/dioceses/IT/milano_it/Milano.json', LitSchema::DIOCESAN],
+            'ambrosian diocesan i18n'      => ['jsondata/sourcedata/rite/ambrosian/calendars/dioceses/IT/milano_it/i18n/it.json', LitSchema::I18N],
+            'wider region'                 => ['jsondata/sourcedata/rite/roman/calendars/wider_regions/Americas/Americas.json', LitSchema::WIDERREGION],
+            'wider region i18n'            => ['jsondata/sourcedata/rite/roman/calendars/wider_regions/Americas/i18n/en.json', LitSchema::I18N],
+            'wider region lectionary'      => ['jsondata/sourcedata/rite/roman/calendars/wider_regions/Americas/lectionary/en.json', LitSchema::LECTIONARY],
+            'decrees corpus'               => ['jsondata/sourcedata/rite/roman/decrees/decrees.json', LitSchema::DECREES_SRC],
+            'decrees i18n sidecar'         => ['jsondata/sourcedata/rite/roman/decrees/i18n/en.json', LitSchema::I18N],
+            'decrees lectionary sidecar'   => ['jsondata/sourcedata/rite/roman/decrees/lectionary/en.json', LitSchema::LECTIONARY],
+            'roman test definition'        => ['jsondata/tests/roman/AllSaintsTest.json', LitSchema::TEST_SRC],
+            'ambrosian test definition'    => ['jsondata/tests/ambrosian/AllSaintsTest.json', LitSchema::TEST_SRC],
+        ];
+    }
+
+    #[DataProvider('stageablePaths')]
+    public function testEveryStageablePathFamilyResolvesToItsSchema(string $path, LitSchema $expected): void
+    {
+        self::assertSame($expected, SourceDataSchemaResolver::forPath($path));
+    }
+
+    /**
+     * The `path` column stores the unprefixed form, but a caller holding the leading-slash
+     * spelling must not silently get "no schema" — that would read as "not validated".
+     */
+    public function testALeadingSlashIsTolerated(): void
+    {
+        self::assertSame(
+            LitSchema::NATIONAL,
+            SourceDataSchemaResolver::forPath('/jsondata/sourcedata/rite/roman/calendars/nations/US/US.json')
+        );
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function unclaimedPaths(): array
+    {
+        return [
+            // No write handler stages a missal, a temporale or the lectionary corpus, so no
+            // pattern claims them. If one ever does, this expectation is the thing that has
+            // to change with it.
+            'missal sanctorale' => ['jsondata/sourcedata/rite/roman/missals/propriumdesanctis_1970/propriumdesanctis_1970.json'],
+            'temporale'         => ['jsondata/sourcedata/rite/roman/missals/propriumdetempore/propriumdetempore.json'],
+            'lectionary corpus' => ['jsondata/sourcedata/rite/roman/lectionary/sanctorum/en.json'],
+            'world dioceses'    => ['jsondata/world_dioceses.json'],
+            // A placeholder never crosses a `/`, so a deeper path is not swallowed by a
+            // shallower family's pattern.
+            'too deep'          => ['jsondata/sourcedata/rite/roman/calendars/nations/US/i18n/regional/en.json'],
+            'outside jsondata'  => ['src/Router.php'],
+            'empty'             => [''],
+        ];
+    }
+
+    #[DataProvider('unclaimedPaths')]
+    public function testAPathNoFamilyClaimsResolvesToNull(string $path): void
+    {
+        self::assertNull(SourceDataSchemaResolver::forPath($path));
+    }
+}

--- a/phpunit_tests/Services/SourceData/SourceDataSchemaResolverTest.php
+++ b/phpunit_tests/Services/SourceData/SourceDataSchemaResolverTest.php
@@ -14,6 +14,18 @@ use PHPUnit\Framework\TestCase;
 final class SourceDataSchemaResolverTest extends TestCase
 {
     /**
+     * The compiled pattern table is a process-lifetime static, and `phpunit_tests/Handlers/`
+     * sorts before `phpunit_tests/Services/`, so by the time this class runs in a full suite the
+     * table has already been built by a handler test and every assertion below would exercise
+     * only the lookup, never the construction it is meant to pin.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        SourceDataSchemaResolver::resetPatternCache();
+    }
+
+    /**
      * One path per family a write handler can stage — the union of every `stageFile()` call
      * site in `RegionalDataHandler`, `DecreesHandler` and `TestsHandler`.
      *
@@ -87,5 +99,23 @@ final class SourceDataSchemaResolverTest extends TestCase
     public function testAPathNoFamilyClaimsResolvesToNull(string $path): void
     {
         self::assertNull(SourceDataSchemaResolver::forPath($path));
+    }
+
+    /**
+     * The second lookup in a process takes the memo's early return rather than recompiling the
+     * table. Asserted behaviourally — the table itself is private — so this pins that a warm
+     * resolver keeps answering identically, which is the property the memo is there to preserve
+     * and the one a future change to the caching would have to keep.
+     */
+    public function testASecondLookupAnswersIdenticallyFromTheCompiledTable(): void
+    {
+        $first = SourceDataSchemaResolver::forPath('jsondata/sourcedata/rite/roman/calendars/nations/US/i18n/en.json');
+
+        // No reset between these two: setUp() has already cleared the table, so the first call
+        // above built it and this one exercises the reuse path.
+        $second = SourceDataSchemaResolver::forPath('jsondata/sourcedata/rite/roman/calendars/nations/US/i18n/en.json');
+
+        self::assertSame($first, $second);
+        self::assertNotNull($first);
     }
 }

--- a/src/Handlers/Admin/ChangeRequestAdminHandler.php
+++ b/src/Handlers/Admin/ChangeRequestAdminHandler.php
@@ -16,6 +16,7 @@ use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
 use LiturgicalCalendar\Api\Http\Exception\ConflictException;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Http\Exception\UnprocessableContentException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
 use LiturgicalCalendar\Api\Repositories\AuditLogRepository;
@@ -23,6 +24,7 @@ use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
 use LiturgicalCalendar\Api\Services\ChangeRequestReview;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Api\Services\ResourceAdminService;
+use LiturgicalCalendar\Api\Services\SourceData\ChangeRequestSchemaValidator;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -191,7 +193,7 @@ final class ChangeRequestAdminHandler extends AbstractHandler
         }
 
         return $action === 'approve'
-            ? $this->approve($response, $sub, $batchId, $rows[0])
+            ? $this->approve($response, $sub, $batchId, $rows)
             : $this->reject($request, $response, $sub, $batchId, $rows[0]);
     }
 
@@ -338,16 +340,38 @@ final class ChangeRequestAdminHandler extends AbstractHandler
      * transitioned means someone else decided the batch first — a 409, not a silent
      * success.
      *
-     * @param array<string, mixed> $firstRow One row of the batch, for the audit log.
+     * **The batch is re-validated against the current schemas first** (#918). Content is
+     * checked once at submission, and the schemas move afterwards; without this, a batch
+     * approved against one schema and published after that schema changed produces a pull
+     * request whose CI fails — the failure landing after the human decision instead of at
+     * it. See {@see ChangeRequestSchemaValidator}.
+     *
+     * A refusal is a 422, matching the status the write path already answers when the very
+     * same schema rejects the very same bytes ({@see \LiturgicalCalendar\Api\Handlers\RegionalDataHandler}
+     * throws `UnprocessableContentException` from `validateDataAgainstSchema()`). One
+     * failure, one meaning, wherever it is caught. It is emphatically NOT a 409: that
+     * status is already spoken for by "someone else decided this batch", and a client
+     * distinguishing "retry, it moved" from "this can never be approved as it stands" needs
+     * the two apart.
+     *
+     * **Nothing is dropped on refusal.** The batch keeps every row and stays `submitted`,
+     * so it remains withdrawable by its submitter and re-submittable as corrected content.
+     * Approving the valid rows and discarding the rest would publish a half-change — a
+     * calendar without the locale file it declares — which is worse than not approving.
+     *
+     * @param array<int, array<string, mixed>> $rows Every row of the batch. `$rows[0]` feeds
+     *                                               the audit log; all of them are validated.
      */
-    private function approve(ResponseInterface $response, string $sub, string $batchId, array $firstRow): ResponseInterface
+    private function approve(ResponseInterface $response, string $sub, string $batchId, array $rows): ResponseInterface
     {
+        $this->assertBatchStillValidatesAgainstCurrentSchemas($rows);
+
         $decided = $this->getRepository()->approveBatch($batchId, $sub);
         if ($decided === 0) {
             throw new ConflictException('Change request batch was already decided');
         }
 
-        $this->audit('change_request.approve', $sub, $batchId, $firstRow, []);
+        $this->audit('change_request.approve', $sub, $batchId, $rows[0], []);
 
         // AFTER the status UPDATE has committed, never before: a consumer that wakes on this
         // message claims from Postgres, so announcing an approval the database has not recorded
@@ -360,6 +384,51 @@ final class ChangeRequestAdminHandler extends AbstractHandler
             'batch_id' => $batchId,
             'status'   => ChangeReviewStatus::APPROVED->value,
         ]);
+    }
+
+    /**
+     * Refuse the approval if any row the transition would move no longer satisfies its schema.
+     *
+     * **Only rows still `submitted` are checked**, because those are exactly the rows
+     * `approveBatch()` would transition. A batch someone else already decided must keep
+     * answering 409 "already decided" — the honest description of what happened — rather than
+     * being re-litigated against schemas that have moved since it was decided, on a transition
+     * that is not going to occur anyway.
+     *
+     * @param array<int, array<string, mixed>> $rows
+     *
+     * @throws UnprocessableContentException Naming every offending file and its violation.
+     */
+    private function assertBatchStillValidatesAgainstCurrentSchemas(array $rows): void
+    {
+        $transitionable = array_values(array_filter(
+            $rows,
+            static fn (array $row): bool => ( $row['review_status'] ?? null ) === ChangeReviewStatus::SUBMITTED->value
+        ));
+
+        if ($transitionable === []) {
+            return;
+        }
+
+        $violations = ( new ChangeRequestSchemaValidator() )->violations($transitionable);
+        if ($violations === []) {
+            return;
+        }
+
+        $detail = implode('; ', array_map(
+            static fn (array $v): string => sprintf('%s (%s): %s', $v['path'], $v['schema'], $v['detail']),
+            $violations
+        ));
+
+        throw new UnprocessableContentException(sprintf(
+            'This change request can no longer be approved: %d of its %d proposed file(s) '
+            . 'no longer validate against the current JSON schemas. Approving it would open a '
+            . 'pull request that fails validation. Ask the submitter to withdraw and re-submit '
+            . 'against the current schemas, or reject it. Violations: %s',
+            count($violations),
+            count($transitionable),
+            $detail
+        ));
     }
 
     /**

--- a/src/Services/SourceData/ChangeRequestSchemaValidator.php
+++ b/src/Services/SourceData/ChangeRequestSchemaValidator.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use Swaggest\JsonSchema\Schema;
+
+/**
+ * Re-checks a change request's proposed content against the schema in force *now*.
+ *
+ * Content is validated once, at submission, by the handler that accepted it. Approval can
+ * come days later, and the schemas move in between — so a batch can be perfectly valid when
+ * it is submitted and no longer valid when a reviewer says yes to it. Without this, the
+ * mismatch surfaces on the pull request the publisher opens, as a red CI run on work an
+ * administrator has already blessed: the check lands on the wrong side of the gate. Issue #918.
+ *
+ * This deliberately reuses the same machinery the write path already uses — `swaggest/json-schema`
+ * over the files in `jsondata/schemas` — rather than introducing a second notion of validity.
+ * (Issue #826 tracks replacing that library; when it lands, it lands here too, in one place.)
+ *
+ * **What counts as a row to check.** Every row that carries content, whatever its `operation`.
+ * Neither `operation` nor `metadata.deletes_resource` is the right predicate here:
+ *
+ * - `operation = 'delete'` does NOT mean a resource is being removed. `RegionalDataHandler`
+ *   stages a DELETE for every locale file dropped from `metadata.locales` on a calendar that
+ *   very much still exists — and that same batch restages the calendar file itself, which must
+ *   be validated.
+ * - `metadata.deletes_resource` marks a batch that removes a whole resource. Those batches stage
+ *   nothing but DELETEs, so keying off it would change no outcome while adding a second, weaker
+ *   reason to skip a row.
+ *
+ * "Does this row carry bytes that will be written to a file" is the only question that matters,
+ * and `content !== null` answers it exactly. A DELETE writes no bytes, so there is nothing a
+ * schema could have an opinion about.
+ */
+final class ChangeRequestSchemaValidator
+{
+    /**
+     * Imported schemas, memoised per instance: one batch commonly stages several files
+     * governed by the same schema (a calendar plus a locale file per language).
+     *
+     * @var array<string, Schema>
+     */
+    private array $imported = [];
+
+    /**
+     * Every way the batch's rows fail the schemas currently in force, in row order.
+     *
+     * An empty list means the batch may be approved. Each entry names the offending file,
+     * the schema it was checked against by bare filename (never a server path — see
+     * {@see LitSchema::name()}), and what the violation was.
+     *
+     * **A path no schema claims is reported as valid, not as a violation.** The queue's rows
+     * are repo-relative paths, and {@see SourceDataSchemaResolver} covers every family a write
+     * handler can stage; a `null` there therefore means either a family that genuinely has no
+     * schema, or a handler that has grown a new one. Refusing on `null` would jam the reviewer's
+     * queue on a batch that is fine, with an error no administrator could act on and no
+     * workaround short of a redeploy — strictly worse than the bounded exposure this gate exists
+     * to narrow, which is a *failing* schema check, not a missing one. It also keeps this gate
+     * aligned with the CI it is anticipating: `SchemaValidationTest` likewise checks the files it
+     * has schemas for.
+     *
+     * @param array<int, array<string, mixed>> $rows Rows of one batch, as hydrated by
+     *                                               {@see \LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository::getBatch()}.
+     *
+     * @return list<array{path: string, schema: string, detail: string}>
+     */
+    public function violations(array $rows): array
+    {
+        $violations = [];
+
+        foreach ($rows as $row) {
+            $content = $row['content'] ?? null;
+            if (!is_string($content)) {
+                // No bytes proposed for this path — see the class docblock.
+                continue;
+            }
+
+            $path = is_string($row['path'] ?? null) ? $row['path'] : '';
+            if ($path === '') {
+                continue;
+            }
+
+            $schema = SourceDataSchemaResolver::forPath($path);
+            if ($schema === null) {
+                continue;
+            }
+
+            $detail = $this->check($schema, $content);
+            if ($detail !== null) {
+                $violations[] = [
+                    'path'   => $path,
+                    'schema' => $schema->name(),
+                    'detail' => $detail,
+                ];
+            }
+        }
+
+        return $violations;
+    }
+
+    /**
+     * Null when `$content` satisfies `$schema`; otherwise why it does not.
+     *
+     * A schema that cannot be imported at all is reported as a violation of that file rather
+     * than swallowed: a deployment whose `jsondata/schemas` is broken cannot honestly say a
+     * batch has been re-validated, and answering "valid" there would defeat the entire gate.
+     */
+    private function check(LitSchema $schema, string $content): ?string
+    {
+        try {
+            $decoded = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            return 'the proposed content is not valid JSON: ' . $e->getMessage();
+        }
+
+        try {
+            $this->import($schema)->in($decoded);
+        } catch (\Throwable $e) {
+            return self::truncate($e->getMessage());
+        }
+
+        return null;
+    }
+
+    private function import(LitSchema $schema): Schema
+    {
+        if (!isset($this->imported[$schema->value])) {
+            // Imported from the file path, not from decoded JSON, so relative $refs such as
+            // `./CommonDef.json#/definitions/EventKey` resolve — the same call the write
+            // handlers make.
+            $imported = Schema::import($schema->path());
+            if (!$imported instanceof Schema) {
+                throw new \RuntimeException('Schema ' . $schema->name() . ' did not import as a schema');
+            }
+            $this->imported[$schema->value] = $imported;
+        }
+
+        return $this->imported[$schema->value];
+    }
+
+    /**
+     * Schema libraries can emit very long messages for a failed `oneOf`, and this text ends up
+     * in an HTTP problem-details body. Keep the head of it — which is where the pointer to the
+     * offending property lives — and say plainly that the rest was cut.
+     */
+    private static function truncate(string $message): string
+    {
+        $limit = 500;
+
+        return mb_strlen($message) <= $limit
+            ? $message
+            : mb_substr($message, 0, $limit) . '… (truncated)';
+    }
+}

--- a/src/Services/SourceData/SourceDataSchemaResolver.php
+++ b/src/Services/SourceData/SourceDataSchemaResolver.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\Rite;
+
+/**
+ * Which JSON Schema governs a source-data file, given only its repo-relative path.
+ *
+ * This exists because a change request stores a *path*, not a category: by the time a
+ * reviewer approves a batch, the request that produced it is long gone, and the only
+ * thing left saying what a row's bytes are supposed to look like is where they are going.
+ *
+ * **Why not {@see \LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory}.**
+ * That inventory is the registry of source data that *exists* — it enumerates national,
+ * wider-region and diocesan calendars from `CalendarMetadataProvider::create()`, and
+ * registers `i18n` as a folder rather than per-locale files. Both properties are wrong for
+ * this job: a change request routinely proposes a calendar that does not exist yet (the
+ * whole point of a `PUT`), and it always names an individual locale file. Asking the
+ * inventory would answer `null` for every newly-created calendar, i.e. exactly the rows
+ * most worth checking.
+ *
+ * **Paths still come from {@see JsonData}.** The templates below are the very constants the
+ * write handlers build their paths from, with each `{placeholder}` widened to one path
+ * segment. This class must not become a second copy of the repository layout — if a family
+ * of source data moves, it moves in `JsonData` and this table follows for free.
+ *
+ * A path this table does not recognise resolves to `null`, meaning "nothing here claims to
+ * know what shape these bytes should have". See
+ * {@see ChangeRequestSchemaValidator::violations()} for why that is treated as "not
+ * validated" rather than "invalid".
+ */
+final class SourceDataSchemaResolver
+{
+    /**
+     * Compiled `pattern => schema`, built once per process.
+     *
+     * @var array<string, LitSchema>|null
+     */
+    private static ?array $patterns = null;
+
+    /**
+     * The schema governing `$repoRelativePath`, or null when no family claims it.
+     *
+     * `$repoRelativePath` is the form the `path` column stores — `jsondata/...`, with no
+     * leading slash and no deployment prefix (see
+     * {@see ChangeRequestSourceDataWriter::repoRelativePath()}). A leading slash is
+     * tolerated so a caller holding either spelling gets the same answer.
+     */
+    public static function forPath(string $repoRelativePath): ?LitSchema
+    {
+        $needle = ltrim($repoRelativePath, '/');
+
+        foreach (self::patterns() as $pattern => $schema) {
+            if (1 === preg_match($pattern, $needle)) {
+                return $schema;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Every path family a write handler can stage, most specific first.
+     *
+     * Order is defensive rather than load-bearing: no two templates here admit the same
+     * path, because a `{placeholder}` never crosses a `/` and the families differ in
+     * segment count. Listing the sidecars before their owning calendar keeps that true by
+     * construction if a template ever gains a segment.
+     *
+     * @return array<string, LitSchema>
+     */
+    private static function patterns(): array
+    {
+        if (self::$patterns !== null) {
+            return self::$patterns;
+        }
+
+        /** @var array<int, array{JsonData, LitSchema}> $templates */
+        $templates = [
+            // Calendar sidecars — one file per locale, under each calendar tier.
+            [JsonData::NATIONAL_CALENDAR_I18N_FILE, LitSchema::I18N],
+            [JsonData::NATIONAL_CALENDAR_LECTIONARY_FILE, LitSchema::LECTIONARY],
+            [JsonData::DIOCESAN_CALENDAR_I18N_FILE, LitSchema::I18N],
+            [JsonData::DIOCESAN_CALENDAR_LECTIONARY_FILE, LitSchema::LECTIONARY],
+            [JsonData::AMBROSIAN_DIOCESAN_CALENDAR_I18N_FILE, LitSchema::I18N],
+            [JsonData::WIDER_REGION_I18N_FILE, LitSchema::I18N],
+            [JsonData::WIDER_REGION_LECTIONARY_FILE, LitSchema::LECTIONARY],
+
+            // The decrees corpus and its two aggregate sidecar families.
+            [JsonData::DECREES_I18N_FILE, LitSchema::I18N],
+            [JsonData::LECTIONARY_DECREES_FILE, LitSchema::LECTIONARY],
+            [JsonData::DECREES_FILE, LitSchema::DECREES_SRC],
+
+            // The calendar files themselves.
+            [JsonData::NATIONAL_CALENDAR_FILE, LitSchema::NATIONAL],
+            [JsonData::DIOCESAN_CALENDAR_FILE, LitSchema::DIOCESAN],
+            [JsonData::AMBROSIAN_DIOCESAN_CALENDAR_FILE, LitSchema::DIOCESAN],
+            [JsonData::WIDER_REGION_FILE, LitSchema::WIDERREGION],
+        ];
+
+        $patterns = [];
+        foreach ($templates as [$template, $schema]) {
+            $patterns[self::templateToPattern($template->value)] = $schema;
+        }
+
+        // Test definitions have no `{name}.json` template of their own — TestsHandler
+        // composes `testsFolderFor($rite)->path() . '/' . $name . '.json'` — so the
+        // per-rite folders are turned into one-file-deep patterns here, from the same
+        // enum cases that handler resolves through.
+        foreach (Rite::cases() as $rite) {
+            $folder                                                           = JsonData::testsFolderFor($rite)->value;
+            $patterns[self::templateToPattern($folder . '/{test_name}.json')] = LitSchema::TEST_SRC;
+        }
+
+        self::$patterns = $patterns;
+
+        return $patterns;
+    }
+
+    /**
+     * A `JsonData` template such as `…/nations/{nation}/i18n/{locale}.json` as an anchored
+     * regex, with every placeholder widened to exactly one path segment.
+     *
+     * Placeholders are deliberately NOT narrowed to a locale/nation grammar. This resolver
+     * answers "which schema governs this location", and a path whose segment is malformed
+     * is still governed by that schema — narrowing here would silently downgrade a bad
+     * filename from "validated" to "unrecognised", which is the wrong direction for a gate.
+     */
+    private static function templateToPattern(string $template): string
+    {
+        $quoted = preg_quote($template, '#');
+
+        // preg_quote escapes `{` and `}`, so match them with or without the backslash rather
+        // than depending on which PHP version's escape set is in force.
+        $widened = preg_replace('#\\\\?\{[a-z_]+\\\\?\}#', '[^/]+', $quoted);
+
+        if (!is_string($widened)) {
+            throw new \RuntimeException('Could not compile a source-data path pattern from ' . $template);
+        }
+
+        return '#^' . $widened . '$#';
+    }
+}

--- a/src/Services/SourceData/SourceDataSchemaResolver.php
+++ b/src/Services/SourceData/SourceDataSchemaResolver.php
@@ -65,6 +65,21 @@ final class SourceDataSchemaResolver
     }
 
     /**
+     * Discard the compiled pattern table so the next call rebuilds it.
+     *
+     * @internal Exists for the test suite. The memo below survives for the life of the process,
+     *           so in a full-suite run whichever test touches this class FIRST builds the table
+     *           and every later test — including this class's own — takes the early return. That
+     *           left the construction path untested in practice while looking covered in
+     *           isolation, and it makes the dedicated unit test order-dependent on a handler test
+     *           in a different directory. Resetting in setUp() keeps that test self-contained.
+     */
+    public static function resetPatternCache(): void
+    {
+        self::$patterns = null;
+    }
+
+    /**
      * Every path family a write handler can stage, most specific first.
      *
      * Order is defensive rather than load-bearing: no two templates here admit the same


### PR DESCRIPTION
Closes #918.

`approveBatch()` was a bare status `UPDATE` — nothing stood between the reviewer's decision and the flip. A batch approved against one schema and published after that schema changed produced a pull request whose CI failed, surfacing the problem on the wrong side of the gate: an administrator approves something the system has already accepted, and only later does CI reveal it was no longer valid.

Approval now validates every still-`submitted` row against the **current** schema and refuses with `422`, naming each offending row.

## One correction to the issue's premise

**`composer lint:jsondata` is not a schema validator.** It is a canonical-encoding drift check. The CI that would actually go red on a drifted batch is `phpunit_tests/Schemas/SchemaValidationTest`, which validates committed source files against their schemas — so that is what this gate mirrors.

Also worth recording why `Models/ValidationsPath/CheckableInventory` was not reused despite looking like the natural path→schema registry: it enumerates source data that *exists* and registers i18n as a folder, so it answers `null` for every newly-created calendar — precisely the rows most worth checking.

## New pieces

- **`SourceDataSchemaResolver`** — repo-relative path → `LitSchema`, with patterns derived from the `JsonData` templates the handlers themselves use (placeholders widened to one path segment), so it is not a second copy of the repo layout. Covers all 14 stageable families plus per-rite test definitions.
- **`ChangeRequestSchemaValidator`** — returns *every* violation in a batch as `{path, schema, detail}`, memoising imported schemas. Unparseable JSON and un-importable schemas are reported as violations rather than thrown.

## Judgement calls to sanity-check

1. **`422`, not `409`.** `409` is already spoken for by "someone else decided this batch", and `422` is what the write path already answers when the same schema rejects the same bytes.
2. **Only still-`submitted` rows are validated.** An already-decided batch keeps answering `409` rather than being re-litigated on a transition that will not happen.
3. **Deletes are skipped on `content === null`** — deliberately *not* `operation = 'delete'` and *not* `metadata.deletes_resource`. `delete` also fires for a locale dropped from `metadata.locales` on a live calendar, and that same batch restages the calendar file, which **is** validated. A `deletes_resource` batch stages only content-less rows anyway, so keying on it would change nothing while adding a weaker reason to skip.
4. **An unmapped path is treated as not-validated, not invalid.** Refusing there would jam the queue on a batch nothing found fault with, with no operator workaround short of a redeploy — worse than the bounded exposure being closed. The runbook names this as the thing to update when a new stageable family is added.
5. **Auto-approval is deliberately ungated** — it approves in the same request that just validated the payload, so there is no drift window, and refusing there would strand an orphan submitted batch.

## A test fixture that was routing around the gate

`ChangeRequestAdminHandlerTest::submitFor()` used a synthetic path (`calendars/nation/USA.json`) with `{"litcal":[]}`, which the resolver maps to nothing — so it would have silently bypassed the new check. It now stages a real national-calendar i18n path with content that genuinely satisfies `LitCalTranslation.json`.

## Tests

12 new across three files, including a standing regression guard that walks all 166 committed source files the resolver claims and asserts they all pass — so a wrong mapping fails loudly rather than producing spurious refusals.

## Verification

`parallel-lint`, `lint`, `analyse` (PHPStan L10, no baseline weakened), `lint:md`, `lint:openapi`, `lint:jsondata` all pass. The 3447 non-server tests are green. `Routes/*` and `WebSocket/*` failures were confirmed pre-existing by checking out clean `development` in the same worktree and diffing the failing-test names — the set difference is empty. See #922.

`openapi.json` gained the documented `422` on approve, edited **as text** (0 `\uXXXX` escapes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ueFDAmZFPEP3fhbe26JHj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Approval now re-validates submitted source-data changes against the current JSON schemas.
  - Invalid batches receive a 422 response detailing affected files and violations.
  - Failed approvals leave the batch unchanged.
  - Deletions and paths without governing schemas are excluded from validation.

- **Documentation**
  - Updated the approval runbook and API documentation to describe re-validation behaviour and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->