### PR TITLE
fix(redis): one connection helper for eleven call sites, with TLS support and a plain-TCP warning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -162,6 +162,11 @@ HTTPS_ENFORCEMENT=true
 # REDIS_TLS_CA_FILE points at a specific bundle (a managed Redis with a private
 # CA); REDIS_TLS_VERIFY_PEER=false disables verification entirely and is for
 # development only — it defeats the point of the TLS this section configures.
+#
+# These two need phpredis >= 5.3: they are passed through connect()'s stream-context
+# argument, which older builds do not accept. tls:// and REDIS_TLS=true on their own
+# do not, so an older phpredis still gets an encrypted connection verified against
+# the system CA store.
 ##
 # REDIS_TLS=false
 # REDIS_TLS_CA_FILE=/etc/ssl/certs/redis-ca.pem

--- a/.env.example
+++ b/.env.example
@@ -121,16 +121,51 @@ API_KEY_DEFAULT_RATE_LIMIT=100
 HTTPS_ENFORCEMENT=true
 
 ##
-# Redis Configuration (for WebSocket server caching)
+# Redis Configuration (WebSocket server caching, outbox and publish stream notifications)
 # Uses Redis (or APCu fallback) for caching
 # Configure either Unix socket OR TCP connection (socket takes precedence)
 # If not configured, defaults to TCP 127.0.0.1:6379
+#
+# Every connection in the codebase is built by
+# src/Services/RedisConnection.php — see that class for the full contract.
 ##
 # Unix socket connection (recommended for local Redis):
 # REDIS_SOCKET=/var/run/redis/redis.sock
 # TCP connection:
 # REDIS_HOST=127.0.0.1
 # REDIS_PORT=6379
+
+##
+# Redis authentication
+#
+# CAVEAT: Redis AUTH sends the password as a plain command. Over an unencrypted
+# TCP connection the credential — and every command after it — crosses the
+# network in cleartext. Setting REDIS_PASSWORD while REDIS_HOST points at
+# anything that is NOT a UNIX socket, NOT a loopback address and NOT a TLS
+# endpoint logs a warning once per process. The connection is still made: this
+# warns, it does not refuse, so an existing deployment is never broken by an
+# upgrade. Secure it with one of: REDIS_SOCKET, a loopback REDIS_HOST, or the
+# TLS settings below.
+##
+# REDIS_PASSWORD=
+
+##
+# Redis over TLS
+#
+# Two equivalent ways to ask for TLS; use either, not both:
+#   REDIS_HOST=tls://redis.example.com   (ssl:// is accepted as a synonym)
+#   REDIS_TLS=true                       (with a plain REDIS_HOST)
+# A UNIX socket never leaves the host, so TLS settings are ignored when
+# REDIS_SOCKET is set.
+#
+# By default the server certificate is verified against the system CA store.
+# REDIS_TLS_CA_FILE points at a specific bundle (a managed Redis with a private
+# CA); REDIS_TLS_VERIFY_PEER=false disables verification entirely and is for
+# development only — it defeats the point of the TLS this section configures.
+##
+# REDIS_TLS=false
+# REDIS_TLS_CA_FILE=/etc/ssl/certs/redis-ca.pem
+# REDIS_TLS_VERIFY_PEER=true
 
 ##
 # OpenFGA outbox reconciliation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,21 @@
   reviewer or a stopped poller, since an undetected merge is indistinguishable from an unreviewed one from
   this side. See `docs/ops/change-request-runbook.md`'s "Merge detection (phase 3)" section for the full
   operator playbook.
+* support Redis over TLS, and warn when `REDIS_PASSWORD` would cross an unencrypted TCP connection, see
+  issue [#919](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/919). `REDIS_HOST` now
+  accepts a `tls://` (or `ssl://`) scheme prefix, and `REDIS_TLS=true` does the same without one;
+  `REDIS_TLS_CA_FILE` and `REDIS_TLS_VERIFY_PEER` cover a managed Redis behind a private CA. When
+  `REDIS_PASSWORD` is set and the endpoint is neither a UNIX socket, nor loopback, nor TLS, the process
+  logs a warning once per process — it warns, it does not refuse, so no running deployment is broken on
+  upgrade. Internally the eleven hand-rolled Redis connect/auth blocks are replaced by a single
+  `RedisConnection` helper, which also reconciles two divergences those copies had accumulated: the
+  2-second connect timeout now reaches all eleven (five previously inherited PHP's 60-second
+  `default_socket_timeout`), and all eleven now read their configuration from the process environment as
+  well as `$_ENV`, so a systemd `Environment=`/`EnvironmentFile=` setting is no longer silently ignored
+  under a CLI `variables_order` that excludes `E`. Redis remains an accelerator everywhere it was one: a
+  deployment with neither `REDIS_SOCKET` nor `REDIS_HOST` set, or without `ext-redis`, still degrades to
+  the cron/disk path exactly as before. See `docs/ops/openfga-outbox-runbook.md`'s "Redis connection
+  settings".
 -->
 
 ## [v5.7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/releases/tag/v5.7) (December 15th 2025)

--- a/bin/publish-sourcedata-consumer
+++ b/bin/publish-sourcedata-consumer
@@ -49,6 +49,7 @@ use LiturgicalCalendar\Api\Services\SourceData\PublishConsumerLoop;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisherFactory;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier;
 use LiturgicalCalendar\Api\Services\Outbox\RedisStreamConsumer;
+use LiturgicalCalendar\Api\Services\RedisConnection;
 
 // ---------------------------------------------------------------------------
 // Bootstrap: load environment from .env* files if present. Same chain as bin/reconcile-outbox
@@ -92,29 +93,14 @@ if (!extension_loaded('redis')) {
     exit(2);
 }
 
-$redis = new \Redis();
 try {
-    // Every env read here goes through SourceDataPublisherFactory::envString(), which checks
-    // $_ENV and THEN getenv(). That second layer is not belt-and-braces: Dotenv fills $_ENV from
-    // the .env* files, but PHP CLI commonly runs with `variables_order` excluding `E`, so a
-    // variable set by this process's systemd unit (`Environment=` / `EnvironmentFile=`) reaches
-    // getenv() and never $_ENV. The change-request runbook ships exactly such a unit, so reading
-    // only $_ENV would silently ignore the configuration mechanism we tell operators to use and
-    // connect to 127.0.0.1 instead. It also narrows `mixed` without a blind cast, which is what
-    // keeps this file clean under the standalone PHPStan level 10 pass.
-    $redisSocket   = SourceDataPublisherFactory::envString('REDIS_SOCKET');
-    $redisPassword = SourceDataPublisherFactory::envString('REDIS_PASSWORD');
-
-    if ('' !== $redisSocket) {
-        $redis->connect($redisSocket, 0, 2.0); // 2 second timeout
-    } else {
-        $redisHost = SourceDataPublisherFactory::envString('REDIS_HOST') ?: '127.0.0.1';
-        $redisPort = SourceDataPublisherFactory::envString('REDIS_PORT');
-        $redis->connect($redisHost, is_numeric($redisPort) ? (int) $redisPort : 6379, 2.0); // 2 second timeout
-    }
-    if ('' !== $redisPassword) {
-        $redis->auth($redisPassword);
-    }
+    // Socket-before-host precedence, the connect timeout, AUTH and — critically for a systemd
+    // unit — the $_ENV-then-getenv() env read all live in RedisConnection now (#919). That
+    // second env layer is not belt-and-braces: Dotenv fills $_ENV from the .env* files, but PHP
+    // CLI commonly runs with `variables_order` excluding `E`, so a variable set by this
+    // process's unit (`Environment=` / `EnvironmentFile=`) reaches getenv() and never $_ENV.
+    // The change-request runbook ships exactly such a unit.
+    $redis = RedisConnection::openOrFail();
 } catch (\Throwable $e) {
     // Redis being down at startup is this process's most likely failure, and it is this
     // process's entire reason to exist (see the ext-redis guard above) — so an unguarded

--- a/bin/publish-sourcedata-consumer
+++ b/bin/publish-sourcedata-consumer
@@ -100,7 +100,7 @@ try {
     // CLI commonly runs with `variables_order` excluding `E`, so a variable set by this
     // process's unit (`Environment=` / `EnvironmentFile=`) reaches getenv() and never $_ENV.
     // The change-request runbook ships exactly such a unit.
-    $redis = RedisConnection::openOrFail();
+    $redis = RedisConnection::openOrFail($logger);
 } catch (\Throwable $e) {
     // Redis being down at startup is this process's most likely failure, and it is this
     // process's entire reason to exist (see the ext-redis guard above) — so an unguarded

--- a/bin/reconcile-outbox
+++ b/bin/reconcile-outbox
@@ -20,6 +20,7 @@ use LiturgicalCalendar\Api\Services\Outbox\CascadeReconciler;
 use LiturgicalCalendar\Api\Services\Outbox\ConsumerLoop;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
 use LiturgicalCalendar\Api\Services\Outbox\RedisStreamConsumer;
+use LiturgicalCalendar\Api\Services\RedisConnection;
 
 $root = dirname(__DIR__);
 require $root . '/vendor/autoload.php';
@@ -95,18 +96,11 @@ if (!extension_loaded('redis')) {
     fwrite(STDERR, "ext-redis is required for consumer mode but is not installed.\n");
     exit(2);
 }
-$redis = new \Redis();
-if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
-    $redis->connect((string) $_ENV['REDIS_SOCKET']);
-} else {
-    $redis->connect(
-        (string) ($_ENV['REDIS_HOST'] ?? '127.0.0.1'),
-        (int) ($_ENV['REDIS_PORT'] ?? 6379),
-    );
-}
-if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
-    $redis->auth((string) $_ENV['REDIS_PASSWORD']);
-}
+// Socket-before-host precedence, the connect timeout and AUTH all live in RedisConnection
+// (#919). openOrFail(), not bestEffort(): this mode's entire reason to exist is the stream, so
+// an unreachable Redis must stop the process rather than leave it idling against nothing.
+// Uncaught by design — systemd restarts the unit and the message reaches the journal.
+$redis = RedisConnection::openOrFail();
 
 $streamName   = (string) ($_ENV['REDIS_OUTBOX_STREAM']        ?? 'litcal:reconcile-stream');
 $groupName    = (string) ($_ENV['REDIS_OUTBOX_GROUP']         ?? 'reconciler');

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "phpunit/phpunit": "^12.3@stable"
     },
     "suggest": {
-        "ext-redis": "Required only for the long-lived `bin/reconcile-outbox consumer` (XREADGROUP) and best-effort outbox notifications. The backstop drains everything regardless when ext-redis is absent."
+        "ext-redis": "Required only for the long-lived `bin/reconcile-outbox consumer` (XREADGROUP) and best-effort outbox notifications. The backstop drains everything regardless when ext-redis is absent. Any version serves those; the TLS options REDIS_TLS_CA_FILE and REDIS_TLS_VERIFY_PEER additionally need phpredis >= 5.3, whose connect() accepts the stream-context argument they are passed through."
     },
     "license": "Apache-2.0",
     "autoload": {

--- a/docs/ops/change-request-runbook.md
+++ b/docs/ops/change-request-runbook.md
@@ -678,8 +678,9 @@ cron scripts do not already provide on their own.
 Redis connection settings — socket vs host, the 2-second connect timeout, TLS, and the warning emitted
 when `REDIS_PASSWORD` would cross a plain TCP connection — are shared with the OpenFGA outbox consumer
 and documented once, in `docs/ops/openfga-outbox-runbook.md`'s "Redis connection settings". The systemd
-unit below sets them through `EnvironmentFile=`, which reaches `getenv()` and never `$_ENV`; the helper
-reads both layers, so that works.
+unit below sets them through `EnvironmentFile=`, which always reaches `getenv()` but reaches `$_ENV` only
+when PHP's `variables_order` includes `E` — which the CLI commonly omits. The helper reads both layers, so
+it works either way.
 
 Install it exactly as `deploy/systemd/liturgical-calendar-reconciler.service` installs the OpenFGA outbox
 consumer:

--- a/docs/ops/change-request-runbook.md
+++ b/docs/ops/change-request-runbook.md
@@ -634,6 +634,12 @@ broken feature — every approved batch still publishes, and every merge is stil
 cron interval. The consumer only removes that interval's latency; it introduces no new correctness the
 cron scripts do not already provide on their own.
 
+Redis connection settings — socket vs host, the 2-second connect timeout, TLS, and the warning emitted
+when `REDIS_PASSWORD` would cross a plain TCP connection — are shared with the OpenFGA outbox consumer
+and documented once, in `docs/ops/openfga-outbox-runbook.md`'s "Redis connection settings". The systemd
+unit below sets them through `EnvironmentFile=`, which reaches `getenv()` and never `$_ENV`; the helper
+reads both layers, so that works.
+
 Install it exactly as `deploy/systemd/liturgical-calendar-reconciler.service` installs the OpenFGA outbox
 consumer:
 

--- a/docs/ops/openfga-outbox-runbook.md
+++ b/docs/ops/openfga-outbox-runbook.md
@@ -42,6 +42,52 @@ curl -s http://localhost:8000/health | jq .openfga_outbox
 
 Should return an object with all-zero counts on a fresh install.
 
+## Redis connection settings
+
+Every Redis connection in the codebase — this consumer, the publish consumer, the best-effort notifiers
+on the request path, and the WebSocket cache — is built by one helper, `src/Services/RedisConnection.php`.
+Configure it once and all of them follow.
+
+| Variable                | Meaning                                                    |
+| ----------------------- | ---------------------------------------------------------- |
+| `REDIS_SOCKET`          | UNIX socket path. Wins over `REDIS_HOST` when set.         |
+| `REDIS_HOST`            | Hostname or IP. May carry a `tls://` (or `ssl://`) prefix. |
+| `REDIS_PORT`            | TCP port. Default 6379.                                    |
+| `REDIS_PASSWORD`        | Optional `AUTH` credential.                                |
+| `REDIS_TLS`             | `true` to use TLS without a scheme prefix on `REDIS_HOST`. |
+| `REDIS_TLS_CA_FILE`     | CA bundle for verifying the server certificate.            |
+| `REDIS_TLS_VERIFY_PEER` | `false` disables peer verification. Development only.      |
+
+All of them are read from `$_ENV` **and** from the process environment, so a systemd `Environment=` or
+`EnvironmentFile=` directive reaches them even when PHP CLI runs with `variables_order` excluding `E`.
+
+The connect timeout is 2 seconds at every site. It bounds the TCP handshake only — the consumer's
+blocking `XREADGROUP` is not affected by it.
+
+### `REDIS_PASSWORD` over plain TCP
+
+Redis `AUTH` sends the password as an ordinary command. Over an unencrypted TCP connection the credential,
+and every command after it, crosses the network in cleartext. On a UNIX socket or a loopback address that
+does not matter; the moment `REDIS_HOST` points at a managed Redis, a sidecar on another node, or anything
+across a network segment, it does.
+
+So when `REDIS_PASSWORD` is set and the endpoint is neither a socket, nor loopback, nor TLS, the process
+logs a warning **once per process** (once per FPM worker lifetime; once per run for a CLI entry point):
+
+```text
+REDIS_PASSWORD is being sent to redis.example.com:6379 over an unencrypted TCP connection: ...
+```
+
+It warns, it does not refuse — the connection is still made, so an upgrade never breaks a running
+deployment. To silence it honestly, pick one:
+
+- `REDIS_SOCKET=/var/run/redis/redis.sock` — never leaves the host.
+- Keep `REDIS_HOST` on loopback (`127.0.0.0/8`, `::1`, `localhost`) — never leaves the interface.
+- `REDIS_HOST=tls://redis.example.com`, or `REDIS_TLS=true` with a plain host — encrypted on the wire.
+
+For a managed Redis with a private CA, add `REDIS_TLS_CA_FILE=/path/to/ca.pem`. `REDIS_TLS_VERIFY_PEER=false`
+exists for local debugging and defeats the point of TLS in production.
+
 ## Diagnostic queries
 
 ```sql

--- a/phpunit_tests/Services/RedisConnectionTest.php
+++ b/phpunit_tests/Services/RedisConnectionTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use LiturgicalCalendar\Api\Services\RedisConnection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The eleven pre-#919 copies of the Redis connect/auth block had already drifted from one another
+ * (four passed a connect timeout, seven did not), so the point of these cases is to pin the
+ * decisions the single helper now makes for all of them: socket before host, the host/port
+ * defaults, and the connect timeout that reaches every site.
+ */
+#[CoversClass(RedisConnection::class)]
+final class RedisConnectionTest extends TestCase
+{
+    /**
+     * Every variable {@see RedisConnection::fromEnv()} consults, snapshotted and restored around
+     * each case so that a developer's `.env.local` (loaded into `$_ENV` by the bootstrap) can
+     * neither leak into an assertion nor be clobbered by one.
+     *
+     * @var list<string>
+     */
+    private const REDIS_ENV_VARS = [
+        'REDIS_SOCKET',
+        'REDIS_HOST',
+        'REDIS_PORT',
+        'REDIS_PASSWORD',
+    ];
+
+    /** @var array<string, string|null> */
+    private array $savedEnv = [];
+
+    /** @var array<string, string|false> */
+    private array $savedGetenv = [];
+
+    protected function setUp(): void
+    {
+        foreach (self::REDIS_ENV_VARS as $name) {
+            $value                    = $_ENV[$name] ?? null;
+            $this->savedEnv[$name]    = is_string($value) ? $value : null;
+            $this->savedGetenv[$name] = getenv($name);
+            unset($_ENV[$name]);
+            putenv($name);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (self::REDIS_ENV_VARS as $name) {
+            $saved = $this->savedEnv[$name] ?? null;
+            if (null === $saved) {
+                unset($_ENV[$name]);
+            } else {
+                $_ENV[$name] = $saved;
+            }
+
+            $original = $this->savedGetenv[$name] ?? false;
+            if (false === $original) {
+                putenv($name);
+            } else {
+                putenv($name . '=' . $original);
+            }
+        }
+    }
+
+    public function testNothingConfiguredIsNotConfigured(): void
+    {
+        $config = RedisConnection::fromEnv();
+
+        self::assertFalse($config->isConfigured());
+        self::assertFalse($config->usesSocket());
+        self::assertFalse($config->hasPassword());
+    }
+
+    public function testAnEmptyHostDoesNotCountAsConfigured(): void
+    {
+        $_ENV['REDIS_HOST'] = '   ';
+
+        self::assertFalse(RedisConnection::fromEnv()->isConfigured());
+    }
+
+    public function testHostAndPortAreReadFromEnv(): void
+    {
+        $_ENV['REDIS_HOST'] = 'redis.internal';
+        $_ENV['REDIS_PORT'] = '6380';
+
+        $config = RedisConnection::fromEnv();
+
+        self::assertTrue($config->isConfigured());
+        self::assertSame('redis.internal', $config->target());
+        self::assertSame(6380, $config->port);
+        self::assertSame('redis.internal:6380', $config->describe());
+    }
+
+    public function testANonNumericPortFallsBackToTheDefault(): void
+    {
+        $_ENV['REDIS_HOST'] = 'redis.internal';
+        $_ENV['REDIS_PORT'] = 'not-a-port';
+
+        self::assertSame(RedisConnection::DEFAULT_PORT, RedisConnection::fromEnv()->port);
+    }
+
+    /**
+     * Nine of the eleven pre-#919 copies defaulted a missing host to 127.0.0.1, and `Health`
+     * relies on that: with nothing configured at all it still tries the loopback default, as
+     * `.env.example` documents.
+     */
+    public function testAMissingHostDefaultsToLoopback(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('connect')
+            ->with(
+                self::identicalTo(RedisConnection::DEFAULT_HOST),
+                self::identicalTo(RedisConnection::DEFAULT_PORT),
+                self::identicalTo(RedisConnection::CONNECT_TIMEOUT_SECONDS),
+            )
+            ->willReturn(true);
+
+        self::assertTrue(RedisConnection::fromEnv()->connect($redis));
+    }
+
+    /**
+     * The socket wins over a host that is ALSO configured — the precedence every copy had, and
+     * the one an operator relies on when a `.env` file sets both.
+     */
+    public function testSocketTakesPrecedenceOverHost(): void
+    {
+        $_ENV['REDIS_SOCKET'] = '/var/run/redis/redis.sock';
+        $_ENV['REDIS_HOST']   = 'redis.internal';
+        $_ENV['REDIS_PORT']   = '6380';
+
+        $config = RedisConnection::fromEnv();
+        self::assertTrue($config->usesSocket());
+        self::assertSame('socket: /var/run/redis/redis.sock', $config->describe());
+
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('connect')
+            ->with(
+                self::identicalTo('/var/run/redis/redis.sock'),
+                self::identicalTo(0),
+                self::identicalTo(RedisConnection::CONNECT_TIMEOUT_SECONDS),
+            )
+            ->willReturn(true);
+
+        self::assertTrue($config->connect($redis));
+    }
+
+    /**
+     * A systemd `Environment=`/`EnvironmentFile=` variable reaches `getenv()` and never `$_ENV`
+     * when PHP CLI runs with `variables_order` excluding `E`. Nine of the eleven copies read
+     * `$_ENV` only, and so silently connected to 127.0.0.1 under exactly the unit the
+     * change-request runbook ships.
+     */
+    public function testConfigurationIsReadFromTheProcessEnvironmentToo(): void
+    {
+        putenv('REDIS_HOST=redis-from-systemd');
+        putenv('REDIS_PORT=6399');
+
+        $config = RedisConnection::fromEnv();
+
+        self::assertSame('redis-from-systemd', $config->target());
+        self::assertSame(6399, $config->port);
+    }
+
+    public function testExplicitEnvWinsOverTheProcessEnvironment(): void
+    {
+        $_ENV['REDIS_HOST'] = 'from-dotenv';
+        putenv('REDIS_HOST=from-systemd');
+
+        self::assertSame('from-dotenv', RedisConnection::fromEnv()->target());
+    }
+
+    public function testAuthenticateIsANoOpWithoutAPassword(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::never())->method('auth');
+
+        self::assertTrue(RedisConnection::fromEnv()->authenticate($redis));
+    }
+
+    public function testAuthenticateSendsThePassword(): void
+    {
+        $_ENV['REDIS_SOCKET']   = '/var/run/redis/redis.sock';
+        $_ENV['REDIS_PASSWORD'] = 's3cret';
+
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('auth')
+            ->with(self::identicalTo('s3cret'))
+            ->willReturn(true);
+
+        self::assertTrue(RedisConnection::fromEnv()->authenticate($redis));
+    }
+
+    public function testAuthenticateReportsAFailedAuth(): void
+    {
+        $_ENV['REDIS_SOCKET']   = '/var/run/redis/redis.sock';
+        $_ENV['REDIS_PASSWORD'] = 'wrong';
+
+        $redis = $this->createStub(\Redis::class);
+        $redis->method('auth')->willReturn(false);
+
+        self::assertFalse(RedisConnection::fromEnv()->authenticate($redis));
+    }
+
+    /** The password never reaches the log line or the health payload. */
+    public function testDescribeNeverLeaksThePassword(): void
+    {
+        $_ENV['REDIS_HOST']     = 'redis.internal';
+        $_ENV['REDIS_PASSWORD'] = 'super-secret';
+
+        self::assertStringNotContainsString('super-secret', RedisConnection::fromEnv()->describe());
+    }
+
+    /**
+     * The ordinary state for a self-hoster: `.env.example` comments both variables out, so the
+     * notifier sites get a null `\Redis` and fall back to their cron/disk path. This must stay
+     * true whether or not ext-redis happens to be installed on the machine running the suite.
+     */
+    public function testBestEffortReturnsNullWhenNothingIsConfigured(): void
+    {
+        self::assertNull(RedisConnection::bestEffort());
+    }
+
+    public function testBestEffortReturnsNullWhenExtRedisIsMissing(): void
+    {
+        if (extension_loaded('redis')) {
+            self::markTestSkipped('ext-redis is installed; the missing-extension branch cannot be reached here.');
+        }
+
+        $_ENV['REDIS_HOST'] = 'redis.internal';
+
+        self::assertNull(RedisConnection::bestEffort());
+    }
+}

--- a/phpunit_tests/Services/RedisConnectionTest.php
+++ b/phpunit_tests/Services/RedisConnectionTest.php
@@ -6,7 +6,9 @@ namespace LiturgicalCalendar\Tests\Services;
 
 use LiturgicalCalendar\Api\Services\RedisConnection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
 
 /**
  * The eleven pre-#919 copies of the Redis connect/auth block had already drifted from one another
@@ -29,6 +31,9 @@ final class RedisConnectionTest extends TestCase
         'REDIS_HOST',
         'REDIS_PORT',
         'REDIS_PASSWORD',
+        'REDIS_TLS',
+        'REDIS_TLS_CA_FILE',
+        'REDIS_TLS_VERIFY_PEER',
     ];
 
     /** @var array<string, string|null> */
@@ -46,6 +51,8 @@ final class RedisConnectionTest extends TestCase
             unset($_ENV[$name]);
             putenv($name);
         }
+
+        RedisConnection::resetPlainTcpWarningState();
     }
 
     protected function tearDown(): void
@@ -65,6 +72,8 @@ final class RedisConnectionTest extends TestCase
                 putenv($name . '=' . $original);
             }
         }
+
+        RedisConnection::resetPlainTcpWarningState();
     }
 
     public function testNothingConfiguredIsNotConfigured(): void
@@ -223,6 +232,266 @@ final class RedisConnectionTest extends TestCase
      * notifier sites get a null `\Redis` and fall back to their cron/disk path. This must stay
      * true whether or not ext-redis happens to be installed on the machine running the suite.
      */
+    // -----------------------------------------------------------------------------------------
+    // TLS (#919 option 1): make the secure configuration possible.
+    // -----------------------------------------------------------------------------------------
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function tlsSchemeProvider(): iterable
+    {
+        yield 'tls://'      => ['tls://'];
+        yield 'ssl://'      => ['ssl://'];
+        yield 'mixed case'  => ['TLS://'];
+    }
+
+    #[DataProvider('tlsSchemeProvider')]
+    public function testASchemePrefixOnTheHostEnablesTls(string $scheme): void
+    {
+        $_ENV['REDIS_HOST'] = $scheme . 'redis.example.com';
+        $_ENV['REDIS_PORT'] = '6380';
+
+        $config = RedisConnection::fromEnv();
+
+        self::assertTrue($config->tls);
+        // The scheme is stripped from the host and put back on the connect target, so that
+        // loopback detection and the describe() string both see the real host.
+        self::assertSame('redis.example.com', $config->host);
+        self::assertSame('tls://redis.example.com', $config->target());
+        self::assertSame('tls://redis.example.com:6380', $config->describe());
+        self::assertTrue($config->isTransportSecure());
+    }
+
+    public function testTheRedisTlsFlagEnablesTlsWithoutASchemePrefix(): void
+    {
+        $_ENV['REDIS_HOST'] = 'redis.example.com';
+        $_ENV['REDIS_TLS']  = 'true';
+
+        $config = RedisConnection::fromEnv();
+
+        self::assertTrue($config->tls);
+        self::assertSame('tls://redis.example.com', $config->target());
+    }
+
+    public function testAMistypedTlsFlagLeavesTlsOffRatherThanPretending(): void
+    {
+        $_ENV['REDIS_HOST'] = 'redis.example.com';
+        $_ENV['REDIS_TLS']  = 'ture';
+
+        self::assertFalse(RedisConnection::fromEnv()->tls);
+    }
+
+    /**
+     * The plain path must issue exactly the three-argument connect it issued before #919: no
+     * stream context, so no dependence on a phpredis new enough to accept one.
+     */
+    public function testAPlainConnectPassesNoStreamContext(): void
+    {
+        $_ENV['REDIS_HOST'] = 'redis.example.com';
+
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('connect')
+            ->with('redis.example.com', 6379, RedisConnection::CONNECT_TIMEOUT_SECONDS)
+            ->willReturn(true);
+
+        self::assertTrue(RedisConnection::fromEnv()->connect($redis));
+    }
+
+    /** TLS with no further options also needs no context — phpredis verifies the peer by default. */
+    public function testTlsWithoutOptionsPassesNoStreamContext(): void
+    {
+        $_ENV['REDIS_HOST'] = 'tls://redis.example.com';
+
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('connect')
+            ->with('tls://redis.example.com', 6379, RedisConnection::CONNECT_TIMEOUT_SECONDS)
+            ->willReturn(true);
+
+        self::assertTrue(RedisConnection::fromEnv()->connect($redis));
+    }
+
+    public function testACaFileAndDisabledVerificationReachTheStreamContext(): void
+    {
+        $_ENV['REDIS_HOST']            = 'tls://redis.example.com';
+        $_ENV['REDIS_TLS_CA_FILE']     = '/etc/ssl/certs/redis-ca.pem';
+        $_ENV['REDIS_TLS_VERIFY_PEER'] = 'false';
+
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('connect')
+            ->with(
+                'tls://redis.example.com',
+                6379,
+                RedisConnection::CONNECT_TIMEOUT_SECONDS,
+                null,
+                0,
+                0,
+                [
+                    'stream' => [
+                        'cafile'           => '/etc/ssl/certs/redis-ca.pem',
+                        'verify_peer'      => false,
+                        'verify_peer_name' => false,
+                    ],
+                ],
+            )
+            ->willReturn(true);
+
+        self::assertTrue(RedisConnection::fromEnv()->connect($redis));
+    }
+
+    /** A socket ignores TLS entirely: there is no wire for TLS to protect. */
+    public function testASocketIgnoresTlsOptions(): void
+    {
+        $_ENV['REDIS_SOCKET'] = '/var/run/redis/redis.sock';
+        $_ENV['REDIS_TLS']    = 'true';
+
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('connect')
+            ->with('/var/run/redis/redis.sock', 0, RedisConnection::CONNECT_TIMEOUT_SECONDS)
+            ->willReturn(true);
+
+        self::assertTrue(RedisConnection::fromEnv()->connect($redis));
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // The plain-TCP password warning (#919 option 3): say something, but never refuse.
+    // -----------------------------------------------------------------------------------------
+
+    public function testAPasswordOverPlainTcpWarns(): void
+    {
+        $_ENV['REDIS_HOST']     = 'redis.example.com';
+        $_ENV['REDIS_PASSWORD'] = 's3cret';
+
+        $logger = $this->recordingLogger();
+
+        $redis = $this->createStub(\Redis::class);
+        $redis->method('auth')->willReturn(true);
+
+        self::assertTrue(RedisConnection::fromEnv()->authenticate($redis, $logger));
+
+        self::assertCount(1, $logger->records);
+        self::assertStringContainsString('unencrypted TCP', $logger->records[0]);
+        self::assertStringContainsString('redis.example.com:6379', $logger->records[0]);
+        // The credential itself must never reach the log.
+        self::assertStringNotContainsString('s3cret', $logger->records[0]);
+    }
+
+    /**
+     * "Once" is per process, not per connection: the eleven sites connect lazily on many
+     * different request paths and warning at each would bury the message in its own repetition.
+     */
+    public function testTheWarningIsEmittedOnlyOncePerProcess(): void
+    {
+        $_ENV['REDIS_HOST']     = 'redis.example.com';
+        $_ENV['REDIS_PASSWORD'] = 's3cret';
+
+        $logger = $this->recordingLogger();
+        $redis  = $this->createStub(\Redis::class);
+        $redis->method('auth')->willReturn(true);
+
+        // Three separate configurations, as three separate call sites would build them.
+        RedisConnection::fromEnv()->authenticate($redis, $logger);
+        RedisConnection::fromEnv()->authenticate($redis, $logger);
+        RedisConnection::fromEnv()->authenticate($redis, $logger);
+
+        self::assertCount(1, $logger->records);
+    }
+
+    /**
+     * @return iterable<string, array{0: array<string, string>}>
+     */
+    public static function safeTransportProvider(): iterable
+    {
+        yield 'unix socket'      => [['REDIS_SOCKET' => '/var/run/redis/redis.sock']];
+        yield 'loopback ipv4'    => [['REDIS_HOST' => '127.0.0.1']];
+        yield 'loopback /8'      => [['REDIS_HOST' => '127.0.0.53']];
+        yield 'localhost'        => [['REDIS_HOST' => 'localhost']];
+        yield 'loopback ipv6'    => [['REDIS_HOST' => '[::1]']];
+        yield 'expanded ipv6'    => [['REDIS_HOST' => '0:0:0:0:0:0:0:1']];
+        yield 'tls scheme'       => [['REDIS_HOST' => 'tls://redis.example.com']];
+        yield 'tls flag'         => [['REDIS_HOST' => 'redis.example.com', 'REDIS_TLS' => 'true']];
+        yield 'tls over loopback' => [['REDIS_HOST' => 'tls://127.0.0.1']];
+    }
+
+    /**
+     * @param array<string, string> $env
+     */
+    #[DataProvider('safeTransportProvider')]
+    public function testNoWarningWhenTheTransportProtectsThePassword(array $env): void
+    {
+        foreach ($env as $name => $value) {
+            $_ENV[$name] = $value;
+        }
+        $_ENV['REDIS_PASSWORD'] = 's3cret';
+
+        $config = RedisConnection::fromEnv();
+        self::assertTrue($config->isTransportSecure());
+
+        $logger = $this->recordingLogger();
+        $redis  = $this->createStub(\Redis::class);
+        $redis->method('auth')->willReturn(true);
+
+        self::assertTrue($config->authenticate($redis, $logger));
+        self::assertSame([], $logger->records);
+    }
+
+    /** No password, no exposure, no warning — however remote and plain the endpoint is. */
+    public function testNoWarningWithoutAPassword(): void
+    {
+        $_ENV['REDIS_HOST'] = 'redis.example.com';
+
+        $logger = $this->recordingLogger();
+        RedisConnection::fromEnv()->warnIfPasswordTravelsInClear($logger);
+
+        self::assertSame([], $logger->records);
+    }
+
+    /**
+     * #919 rejected option 2 (fail closed) as deployment-breaking on upgrade. The unsafe
+     * combination must still authenticate.
+     */
+    public function testTheUnsafeCombinationStillAuthenticates(): void
+    {
+        $_ENV['REDIS_HOST']     = 'redis.example.com';
+        $_ENV['REDIS_PASSWORD'] = 's3cret';
+
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('auth')
+            ->with('s3cret')
+            ->willReturn(true);
+
+        self::assertTrue(RedisConnection::fromEnv()->authenticate($redis, $this->recordingLogger()));
+    }
+
+    /**
+     * A PSR-3 logger that keeps every message it is handed, so a test can count them.
+     *
+     * The return type is left off deliberately: the anonymous class' `$records` property is what
+     * the assertions read, and naming `LoggerInterface` here would hide it.
+     */
+    private function recordingLogger()
+    {
+        return new class extends AbstractLogger {
+            /** @var list<string> */
+            public array $records = [];
+
+            /**
+             * @param mixed             $level
+             * @param string|\Stringable $message
+             * @param array<mixed>      $context
+             */
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = (string) $message;
+            }
+        };
+    }
+
     public function testBestEffortReturnsNullWhenNothingIsConfigured(): void
     {
         self::assertNull(RedisConnection::bestEffort());

--- a/phpunit_tests/Services/RedisConnectionTest.php
+++ b/phpunit_tests/Services/RedisConnectionTest.php
@@ -227,11 +227,6 @@ final class RedisConnectionTest extends TestCase
         self::assertStringNotContainsString('super-secret', RedisConnection::fromEnv()->describe());
     }
 
-    /**
-     * The ordinary state for a self-hoster: `.env.example` comments both variables out, so the
-     * notifier sites get a null `\Redis` and fall back to their cron/disk path. This must stay
-     * true whether or not ext-redis happens to be installed on the machine running the suite.
-     */
     // -----------------------------------------------------------------------------------------
     // TLS (#919 option 1): make the secure configuration possible.
     // -----------------------------------------------------------------------------------------
@@ -492,6 +487,11 @@ final class RedisConnectionTest extends TestCase
         };
     }
 
+    /**
+     * The ordinary state for a self-hoster: `.env.example` comments both variables out, so the
+     * notifier sites get a null `\Redis` and fall back to their cron/disk path. This must stay
+     * true whether or not ext-redis happens to be installed on the machine running the suite.
+     */
     public function testBestEffortReturnsNullWhenNothingIsConfigured(): void
     {
         self::assertNull(RedisConnection::bestEffort());

--- a/src/Handlers/Admin/AccessRequestAdminHandler.php
+++ b/src/Handlers/Admin/AccessRequestAdminHandler.php
@@ -25,6 +25,7 @@ use LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
+use LiturgicalCalendar\Api\Services\RedisConnection;
 use LiturgicalCalendar\Api\Services\ResourceAdminService;
 use LiturgicalCalendar\Api\Services\RoleCascadeService;
 use LiturgicalCalendar\Api\Services\ZitadelService;
@@ -108,24 +109,8 @@ final class AccessRequestAdminHandler extends AbstractHandler
     private function getOutboxNotifier(): OutboxNotifier
     {
         if ($this->outboxNotifier === null) {
-            $redis = null;
-            if (extension_loaded('redis') && ( isset($_ENV['REDIS_HOST']) || isset($_ENV['REDIS_SOCKET']) )) {
-                try {
-                    $redis = new \Redis();
-                    if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
-                        $redis->connect((string) $_ENV['REDIS_SOCKET']);
-                    } else {
-                        $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
-                        $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
-                        $redis->connect($redisHost, $redisPort);
-                    }
-                    if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
-                        $redis->auth((string) $_ENV['REDIS_PASSWORD']);
-                    }
-                } catch (\Throwable) {
-                    $redis = null; // Best-effort; fall back to PG-only durability.
-                }
-            }
+            // Best-effort; null falls back to PG-only durability. See {@see RedisConnection}.
+            $redis                = RedisConnection::bestEffort();
             $redisStream          = is_string($_ENV['REDIS_OUTBOX_STREAM'] ?? null) ? $_ENV['REDIS_OUTBOX_STREAM'] : 'litcal:reconcile-stream';
             $streamName           = $redisStream;
             $this->outboxNotifier = new OutboxNotifier($redis, $streamName);

--- a/src/Handlers/Admin/ChangeRequestAdminHandler.php
+++ b/src/Handlers/Admin/ChangeRequestAdminHandler.php
@@ -22,6 +22,7 @@ use LiturgicalCalendar\Api\Repositories\AuditLogRepository;
 use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
 use LiturgicalCalendar\Api\Services\ChangeRequestReview;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\RedisConnection;
 use LiturgicalCalendar\Api\Services\ResourceAdminService;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier;
 use Psr\Http\Message\ResponseInterface;
@@ -96,24 +97,8 @@ final class ChangeRequestAdminHandler extends AbstractHandler
     private function getPublishNotifier(): SourceDataPublishNotifier
     {
         if ($this->publishNotifier === null) {
-            $redis = null;
-            if (extension_loaded('redis') && ( isset($_ENV['REDIS_HOST']) || isset($_ENV['REDIS_SOCKET']) )) {
-                try {
-                    $redis = new \Redis();
-                    if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
-                        $redis->connect((string) $_ENV['REDIS_SOCKET'], 0, 2.0); // 2 second timeout
-                    } else {
-                        $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
-                        $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
-                        $redis->connect($redisHost, $redisPort, 2.0); // 2 second timeout
-                    }
-                    if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
-                        $redis->auth((string) $_ENV['REDIS_PASSWORD']);
-                    }
-                } catch (\Throwable) {
-                    $redis = null; // Best-effort; fall back to PG-only durability.
-                }
-            }
+            // Best-effort; null falls back to PG-only durability. See {@see RedisConnection}.
+            $redis                 = RedisConnection::bestEffort();
             $streamName            = is_string($_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM'] ?? null)
                 ? $_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM']
                 : 'litcal:sourcedata-publish-stream';

--- a/src/Handlers/Admin/OutboxAdminHandler.php
+++ b/src/Handlers/Admin/OutboxAdminHandler.php
@@ -17,6 +17,7 @@ use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
 use LiturgicalCalendar\Api\Repositories\OutboxRepository;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxRow;
+use LiturgicalCalendar\Api\Services\RedisConnection;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -70,24 +71,8 @@ final class OutboxAdminHandler extends AbstractHandler
         if ($this->notifier !== null) {
             return $this->notifier;
         }
-        $redis = null;
-        if (extension_loaded('redis')) {
-            try {
-                $r = new \Redis();
-                if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
-                    $r->connect((string) $_ENV['REDIS_SOCKET']);
-                } elseif (isset($_ENV['REDIS_HOST']) && is_string($_ENV['REDIS_HOST']) && $_ENV['REDIS_HOST'] !== '') {
-                    $port = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
-                    $r->connect($_ENV['REDIS_HOST'], $port);
-                }
-                if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
-                    $r->auth($_ENV['REDIS_PASSWORD']);
-                }
-                $redis = $r;
-            } catch (\Throwable) {
-                $redis = null;
-            }
-        }
+        // Best-effort; null falls back to PG-only durability. See {@see RedisConnection}.
+        $redis          = RedisConnection::bestEffort();
         $stream         = isset($_ENV['REDIS_OUTBOX_STREAM']) && is_string($_ENV['REDIS_OUTBOX_STREAM']) && $_ENV['REDIS_OUTBOX_STREAM'] !== ''
             ? $_ENV['REDIS_OUTBOX_STREAM']
             : 'litcal:reconcile-stream';

--- a/src/Handlers/Admin/PermissionAdminHandler.php
+++ b/src/Handlers/Admin/PermissionAdminHandler.php
@@ -23,6 +23,7 @@ use LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
+use LiturgicalCalendar\Api\Services\RedisConnection;
 use LiturgicalCalendar\Api\Services\RoleCascadeService;
 use LiturgicalCalendar\Api\Services\ZitadelService;
 use Psr\Http\Message\ResponseInterface;
@@ -112,24 +113,8 @@ final class PermissionAdminHandler extends AbstractHandler
     private function getOutboxNotifier(): OutboxNotifier
     {
         if ($this->outboxNotifier === null) {
-            $redis = null;
-            if (extension_loaded('redis') && ( isset($_ENV['REDIS_HOST']) || isset($_ENV['REDIS_SOCKET']) )) {
-                try {
-                    $redis = new \Redis();
-                    if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
-                        $redis->connect((string) $_ENV['REDIS_SOCKET']);
-                    } else {
-                        $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
-                        $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
-                        $redis->connect($redisHost, $redisPort);
-                    }
-                    if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
-                        $redis->auth((string) $_ENV['REDIS_PASSWORD']);
-                    }
-                } catch (\Throwable) {
-                    $redis = null; // Best-effort; fall back to PG-only durability.
-                }
-            }
+            // Best-effort; null falls back to PG-only durability. See {@see RedisConnection}.
+            $redis                = RedisConnection::bestEffort();
             $redisStream          = is_string($_ENV['REDIS_OUTBOX_STREAM'] ?? null) ? $_ENV['REDIS_OUTBOX_STREAM'] : 'litcal:reconcile-stream';
             $streamName           = $redisStream;
             $this->outboxNotifier = new OutboxNotifier($redis, $streamName);

--- a/src/Handlers/Admin/PermissionAdminHandler.php
+++ b/src/Handlers/Admin/PermissionAdminHandler.php
@@ -114,7 +114,7 @@ final class PermissionAdminHandler extends AbstractHandler
     {
         if ($this->outboxNotifier === null) {
             // Best-effort; null falls back to PG-only durability. See {@see RedisConnection}.
-            $redis                = RedisConnection::bestEffort();
+            $redis                = RedisConnection::bestEffort($this->logger);
             $redisStream          = is_string($_ENV['REDIS_OUTBOX_STREAM'] ?? null) ? $_ENV['REDIS_OUTBOX_STREAM'] : 'litcal:reconcile-stream';
             $streamName           = $redisStream;
             $this->outboxNotifier = new OutboxNotifier($redis, $streamName);

--- a/src/Handlers/Concerns/WritesSourceData.php
+++ b/src/Handlers/Concerns/WritesSourceData.php
@@ -9,6 +9,7 @@ use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
 use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
 use LiturgicalCalendar\Api\Services\ChangeRequestReview;
 use LiturgicalCalendar\Api\Services\ChangeResource;
+use LiturgicalCalendar\Api\Services\RedisConnection;
 use LiturgicalCalendar\Api\Services\ResourceAdminService;
 use LiturgicalCalendar\Api\Services\SourceData\ChangeRequestSourceDataWriter;
 use LiturgicalCalendar\Api\Services\SourceData\DiskSourceDataWriter;
@@ -159,24 +160,8 @@ trait WritesSourceData
             return $this->sourceDataPublishNotifier;
         }
 
-        $redis = null;
-        if (extension_loaded('redis') && ( isset($_ENV['REDIS_HOST']) || isset($_ENV['REDIS_SOCKET']) )) {
-            try {
-                $redis = new \Redis();
-                if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
-                    $redis->connect((string) $_ENV['REDIS_SOCKET'], 0, 2.0); // 2 second timeout
-                } else {
-                    $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
-                    $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
-                    $redis->connect($redisHost, $redisPort, 2.0); // 2 second timeout
-                }
-                if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
-                    $redis->auth((string) $_ENV['REDIS_PASSWORD']);
-                }
-            } catch (\Throwable) {
-                $redis = null; // Best-effort; fall back to PG-only durability.
-            }
-        }
+        // Best-effort; null falls back to PG-only durability. See {@see RedisConnection}.
+        $redis = RedisConnection::bestEffort();
 
         $streamName = is_string($_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM'] ?? null)
             ? $_ENV['REDIS_SOURCEDATA_PUBLISH_STREAM']

--- a/src/Health.php
+++ b/src/Health.php
@@ -513,7 +513,7 @@ class Health implements MessageComponentInterface
                         // Optional authentication for production deployments
                         if ($redisConfig->hasPassword()) {
                             try {
-                                $authenticated = $redisConfig->authenticate(self::$redis);
+                                $authenticated = $redisConfig->authenticate(self::$redis, $logger);
                                 if (!$authenticated) {
                                     self::$redis = null;
                                     echo "Redis authentication failed, trying APCu fallback\n";

--- a/src/Health.php
+++ b/src/Health.php
@@ -32,6 +32,7 @@ use LiturgicalCalendar\Api\Models\Auth\TestTarget;
 use LiturgicalCalendar\Api\Models\Auth\WsCaller;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
+use LiturgicalCalendar\Api\Services\RedisConnection;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
 use LiturgicalCalendar\Api\Services\TestRunPolicy;
@@ -501,33 +502,18 @@ class Health implements MessageComponentInterface
             if (extension_loaded('redis')) {
                 try {
                     self::$redis = new \Redis();
-                    // Support Unix socket (REDIS_SOCKET) or TCP connection (REDIS_HOST/REDIS_PORT)
-                    $redisSocket = isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET'])
-                        ? $_ENV['REDIS_SOCKET']
-                        : null;
-                    if ($redisSocket !== null && $redisSocket !== '') {
-                        // Unix socket connection
-                        $connected      = self::$redis->connect($redisSocket, 0, 2.0); // 2 second timeout
-                        $connectionInfo = "socket: {$redisSocket}";
-                    } else {
-                        // TCP connection with configurable host/port
-                        $redisHost      = isset($_ENV['REDIS_HOST']) && is_string($_ENV['REDIS_HOST'])
-                            ? $_ENV['REDIS_HOST']
-                            : '127.0.0.1';
-                        $redisPort      = isset($_ENV['REDIS_PORT']) && is_numeric($_ENV['REDIS_PORT'])
-                            ? (int) $_ENV['REDIS_PORT']
-                            : 6379;
-                        $connected      = self::$redis->connect($redisHost, $redisPort, 2.0); // 2 second timeout
-                        $connectionInfo = "{$redisHost}:{$redisPort}";
-                    }
+                    // Socket-before-host precedence, the connect timeout and AUTH all live in
+                    // RedisConnection now (#919). What stays here is what makes this site
+                    // different from the other ten: it reports what happened and falls back to
+                    // APCu, where they fall silently back to a null \Redis.
+                    $redisConfig    = RedisConnection::fromEnv();
+                    $connected      = $redisConfig->connect(self::$redis);
+                    $connectionInfo = $redisConfig->describe();
                     if ($connected) {
                         // Optional authentication for production deployments
-                        $redisPassword = isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD'])
-                            ? $_ENV['REDIS_PASSWORD']
-                            : null;
-                        if ($redisPassword !== null && $redisPassword !== '') {
+                        if ($redisConfig->hasPassword()) {
                             try {
-                                $authenticated = self::$redis->auth($redisPassword);
+                                $authenticated = $redisConfig->authenticate(self::$redis);
                                 if (!$authenticated) {
                                     self::$redis = null;
                                     echo "Redis authentication failed, trying APCu fallback\n";
@@ -5206,28 +5192,14 @@ class Health implements MessageComponentInterface
 
         if (extension_loaded('redis')) {
             try {
+                // Socket-before-host precedence, the connect timeout and AUTH: see #919 and
+                // {@see RedisConnection}. Unlike the best-effort sites this one keeps its own
+                // reporting — a failure here becomes redis_reachable=false in the payload.
+                $redisConfig = RedisConnection::fromEnv();
                 $redis       = new \Redis();
-                $redisSocket = isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET'])
-                    ? $_ENV['REDIS_SOCKET']
-                    : null;
-                if ($redisSocket !== null && $redisSocket !== '') {
-                    $connected = $redis->connect($redisSocket, 0, 2.0);
-                } else {
-                    $redisHost = isset($_ENV['REDIS_HOST']) && is_string($_ENV['REDIS_HOST'])
-                        ? $_ENV['REDIS_HOST']
-                        : '127.0.0.1';
-                    $redisPort = isset($_ENV['REDIS_PORT']) && is_numeric($_ENV['REDIS_PORT'])
-                        ? (int) $_ENV['REDIS_PORT']
-                        : 6379;
-                    $connected = $redis->connect($redisHost, $redisPort, 2.0);
-                }
+                $connected   = $redisConfig->connect($redis);
                 if ($connected) {
-                    $redisPassword = isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD'])
-                        ? $_ENV['REDIS_PASSWORD']
-                        : null;
-                    if ($redisPassword !== null && $redisPassword !== '') {
-                        $redis->auth($redisPassword);
-                    }
+                    $redisConfig->authenticate($redis);
                     $redis->ping();
                     $consumer['redis_reachable'] = true;
                     $info                        = $redis->xInfo('GROUPS', $streamName);

--- a/src/Services/RedisConnection.php
+++ b/src/Services/RedisConnection.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+/**
+ * The single definition of "how this application reaches Redis".
+ *
+ * Before #919 the same block — read `REDIS_SOCKET`/`REDIS_HOST`/`REDIS_PORT`, prefer the socket,
+ * `auth()` with `REDIS_PASSWORD`, `catch (\Throwable) → null` — was copy-pasted at eleven call
+ * sites, and had already drifted: four of them passed a 2-second connect timeout and the other
+ * seven passed none, so a correctness fix applied once had failed to reach the rest. Everything
+ * about reaching Redis now lives here, and the eleven sites express only what they do differently.
+ *
+ * ## Configuration
+ *
+ * | Variable         | Meaning                                                           |
+ * | ---------------- | ----------------------------------------------------------------- |
+ * | `REDIS_SOCKET`   | UNIX socket path. Takes precedence over host/port when non-empty.  |
+ * | `REDIS_HOST`     | Hostname or IP.                                                    |
+ * | `REDIS_PORT`     | TCP port, default 6379.                                            |
+ * | `REDIS_PASSWORD` | Optional `AUTH` credential.                                        |
+ *
+ * ## Redis is an accelerator, never a dependency
+ *
+ * {@see self::bestEffort()} returns `null` — never throws — when `ext-redis` is missing, when
+ * neither `REDIS_SOCKET` nor `REDIS_HOST` is configured (the ordinary state for a self-hoster:
+ * both are commented out in `.env.example`), or when the connection or authentication fails.
+ * Every caller of it degrades to a Postgres-plus-cron or disk path. Only the long-lived consumer
+ * entry points, whose entire reason to exist is the stream, use {@see self::openOrFail()}.
+ *
+ * @package LiturgicalCalendar\Api\Services
+ */
+final class RedisConnection
+{
+    /** Host used when neither `REDIS_SOCKET` nor `REDIS_HOST` names one. */
+    public const DEFAULT_HOST = '127.0.0.1';
+
+    /** Port used when `REDIS_PORT` is unset or non-numeric. */
+    public const DEFAULT_PORT = 6379;
+
+    /**
+     * Connect timeout, in seconds, applied at every site.
+     *
+     * Reconciles the pre-#919 split: `Health` (both sites), `WritesSourceData`,
+     * `ChangeRequestAdminHandler`, `SourceDataPublisherFactory` and
+     * `bin/publish-sourcedata-consumer` passed 2.0; the remaining five passed nothing and so
+     * inherited phpredis' `default_socket_timeout` (60s on a stock php.ini). The bounded value
+     * wins because most of those five sit on a request-handling path where a Redis host that
+     * blackholes SYNs would otherwise stall the whole response for a minute to send a
+     * best-effort `XADD` that the cron backstop re-sends anyway.
+     *
+     * This is the CONNECT timeout only. phpredis keeps the read timeout as a separate argument,
+     * left at its 0 (unlimited) default here, so a blocking `XREADGROUP` in the consumer loop is
+     * unaffected.
+     */
+    public const CONNECT_TIMEOUT_SECONDS = 2.0;
+
+    /**
+     * @param string $socket   `REDIS_SOCKET`, or '' when not configured.
+     * @param string $host     `REDIS_HOST`, or '' when not configured.
+     * @param int    $port     `REDIS_PORT`, or {@see self::DEFAULT_PORT}.
+     * @param string $password `REDIS_PASSWORD`, or '' when not configured.
+     */
+    private function __construct(
+        public readonly string $socket,
+        public readonly string $host,
+        public readonly int $port,
+        public readonly string $password,
+    ) {
+    }
+
+    /** Build the connection description from the environment. */
+    public static function fromEnv(): self
+    {
+        $port = self::envString('REDIS_PORT');
+
+        return new self(
+            self::envString('REDIS_SOCKET'),
+            self::envString('REDIS_HOST'),
+            is_numeric($port) ? (int) $port : self::DEFAULT_PORT,
+            self::envString('REDIS_PASSWORD'),
+        );
+    }
+
+    /**
+     * Best-effort connection: a live `\Redis`, or `null` for every reason it could not be one.
+     *
+     * This is what the nine notifier/cache call sites want. `null` is not an error condition —
+     * see the class docblock — so nothing here throws, including a `\Throwable` raised inside
+     * phpredis itself.
+     *
+     * Unlike the pre-#919 copies, a `connect()` that returns `false` and an `auth()` that returns
+     * `false` both yield `null` rather than a `\Redis` that is not actually usable. The callers
+     * all treat a null `\Redis` as "no acceleration available", which is the honest answer in
+     * both cases.
+     *
+     * @param float|null $timeout Connect timeout override, in seconds.
+     */
+    public static function bestEffort(?float $timeout = null): ?\Redis
+    {
+        $config = self::fromEnv();
+
+        if (!extension_loaded('redis') || !$config->isConfigured()) {
+            return null;
+        }
+
+        try {
+            $redis = new \Redis();
+            if (false === $config->connect($redis, $timeout)) {
+                return null;
+            }
+            if (false === $config->authenticate($redis)) {
+                return null;
+            }
+
+            return $redis;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Connect or throw — for the entry points whose entire reason to exist is the stream.
+     *
+     * `ext-redis` being absent is the caller's guard, not this method's: both consumers exit 2
+     * on that, distinctly from the exit 1 they use for a configuration error, so an operator can
+     * tell "not installed" from "installed but misconfigured".
+     *
+     * @param float|null $timeout Connect timeout override, in seconds.
+     *
+     * @throws \RuntimeException When the connection or the authentication fails.
+     * @throws \RedisException   Propagated unchanged from phpredis.
+     */
+    public static function openOrFail(?float $timeout = null): \Redis
+    {
+        $config = self::fromEnv();
+        $redis  = new \Redis();
+
+        if (false === $config->connect($redis, $timeout)) {
+            throw new \RuntimeException(sprintf('Could not connect to Redis at %s.', $config->describe()));
+        }
+
+        if (false === $config->authenticate($redis)) {
+            throw new \RuntimeException(sprintf('Redis authentication failed for %s.', $config->describe()));
+        }
+
+        return $redis;
+    }
+
+    /**
+     * Is Redis configured at all?
+     *
+     * False for a self-hoster who has commented neither variable back in, which is the ordinary
+     * case. Deliberately NOT consulted by {@see self::connect()}: `Health` connects to the
+     * loopback default even with nothing configured, which is the documented behaviour in
+     * `.env.example` ("If not configured, defaults to TCP 127.0.0.1:6379") and must not regress.
+     */
+    public function isConfigured(): bool
+    {
+        return '' !== $this->socket || '' !== $this->host;
+    }
+
+    /** Will this connection go over a UNIX socket rather than TCP? */
+    public function usesSocket(): bool
+    {
+        return '' !== $this->socket;
+    }
+
+    /** Is there a `REDIS_PASSWORD` to send? */
+    public function hasPassword(): bool
+    {
+        return '' !== $this->password;
+    }
+
+    /** The first argument to `\Redis::connect()`: a socket path, or a host. */
+    public function target(): string
+    {
+        return $this->usesSocket() ? $this->socket : $this->hostOrDefault();
+    }
+
+    /**
+     * Human-readable endpoint, for logs and the health payload.
+     *
+     * Never includes the password. The two pre-#919 `Health` spellings —
+     * `"socket: /path"` and `"host:port"` — are preserved verbatim so that the health output an
+     * operator greps for does not change shape.
+     */
+    public function describe(): string
+    {
+        if ($this->usesSocket()) {
+            return "socket: {$this->socket}";
+        }
+
+        return $this->target() . ':' . $this->port;
+    }
+
+    /**
+     * Perform the connect, socket before host, and report phpredis' own boolean.
+     *
+     * @param float|null $timeout Connect timeout override; {@see self::CONNECT_TIMEOUT_SECONDS}
+     *                            when null.
+     *
+     * @throws \RedisException Propagated unchanged from phpredis.
+     */
+    public function connect(\Redis $redis, ?float $timeout = null): bool
+    {
+        $timeout ??= self::CONNECT_TIMEOUT_SECONDS;
+
+        if ($this->usesSocket()) {
+            return $redis->connect($this->socket, 0, $timeout);
+        }
+
+        return $redis->connect($this->target(), $this->port, $timeout);
+    }
+
+    /**
+     * Send `AUTH` when there is a password.
+     *
+     * Returns true when there is nothing to send, so callers can invoke it unconditionally.
+     *
+     * @throws \RedisException Propagated unchanged from phpredis.
+     */
+    public function authenticate(\Redis $redis): bool
+    {
+        if (false === $this->hasPassword()) {
+            return true;
+        }
+
+        // phpredis returns bool from AUTH, but the fluent-mode build returns $this instead;
+        // anything that is not an outright false counts as authenticated.
+        return false !== $redis->auth($this->password);
+    }
+
+    /** `REDIS_HOST`, or the loopback default when it is unset. */
+    private function hostOrDefault(): string
+    {
+        return '' !== $this->host ? $this->host : self::DEFAULT_HOST;
+    }
+
+    /**
+     * Read an environment variable from BOTH layers: `$_ENV` first, then `getenv()`.
+     *
+     * The two layers are not interchangeable. Dotenv populates `$_ENV` from the `.env*` FILES,
+     * but PHP CLI commonly runs with `variables_order` excluding `E`, so a variable exported by
+     * the shell or set by a systemd `Environment=`/`EnvironmentFile=` directive reaches
+     * `getenv()` and NEVER `$_ENV`. Reading only `$_ENV` — which nine of the eleven pre-#919
+     * copies did — silently ignores the configuration mechanism the change-request runbook's own
+     * systemd unit tells operators to use, and the process quietly falls back to 127.0.0.1
+     * instead of the configured Redis.
+     *
+     * Duplicated in shape (not shared) with
+     * {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisherFactory::envString()}
+     * and {@see \LiturgicalCalendar\Api\Services\OpenFgaClient}'s private helper, following the
+     * precedent those two set: a low-level connection helper should not depend on a GitHub
+     * publishing factory just to read a string.
+     *
+     * @return string The trimmed value, or '' when set in neither layer (or empty in both).
+     */
+    private static function envString(string $name): string
+    {
+        $value = $_ENV[$name] ?? null;
+        if (is_string($value) && '' !== trim($value)) {
+            return trim($value);
+        }
+
+        $fromProcess = getenv($name);
+        if (is_string($fromProcess) && '' !== trim($fromProcess)) {
+            return trim($fromProcess);
+        }
+
+        return '';
+    }
+}

--- a/src/Services/RedisConnection.php
+++ b/src/Services/RedisConnection.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Api\Services;
 
+use Psr\Log\LoggerInterface;
+
 /**
  * The single definition of "how this application reaches Redis".
  *
@@ -15,12 +17,24 @@ namespace LiturgicalCalendar\Api\Services;
  *
  * ## Configuration
  *
- * | Variable         | Meaning                                                           |
- * | ---------------- | ----------------------------------------------------------------- |
- * | `REDIS_SOCKET`   | UNIX socket path. Takes precedence over host/port when non-empty.  |
- * | `REDIS_HOST`     | Hostname or IP.                                                    |
- * | `REDIS_PORT`     | TCP port, default 6379.                                            |
- * | `REDIS_PASSWORD` | Optional `AUTH` credential.                                        |
+ * | Variable                | Meaning                                                           |
+ * | ----------------------- | ----------------------------------------------------------------- |
+ * | `REDIS_SOCKET`          | UNIX socket path. Takes precedence over host/port when non-empty. |
+ * | `REDIS_HOST`            | Hostname or IP; may carry a `tls://` or `ssl://` scheme prefix.   |
+ * | `REDIS_PORT`            | TCP port, default 6379.                                           |
+ * | `REDIS_PASSWORD`        | Optional `AUTH` credential.                                       |
+ * | `REDIS_TLS`             | `true` to wrap the TCP connection in TLS without a scheme prefix. |
+ * | `REDIS_TLS_CA_FILE`     | Optional CA bundle used to verify the server certificate.         |
+ * | `REDIS_TLS_VERIFY_PEER` | `false` to disable peer verification. Development only.           |
+ *
+ * ## The password-over-plain-TCP warning
+ *
+ * A `REDIS_PASSWORD` sent to anything that is not a UNIX socket, a loopback address or a TLS
+ * endpoint crosses the network in cleartext, and so does every command after it. Reaching that
+ * combination logs a warning once per process — see {@see self::warnIfPasswordTravelsInClear()}.
+ *
+ * It warns; it does NOT refuse. Failing closed was considered in #919 and rejected: it would
+ * break, on upgrade, every deployment already running that way.
  *
  * ## Redis is an accelerator, never a dependency
  *
@@ -57,30 +71,74 @@ final class RedisConnection
      */
     public const CONNECT_TIMEOUT_SECONDS = 2.0;
 
+    /** Scheme prefixes on `REDIS_HOST` that mean "wrap this connection in TLS". */
+    private const TLS_SCHEMES = ['tls://', 'ssl://'];
+
     /**
-     * @param string $socket   `REDIS_SOCKET`, or '' when not configured.
-     * @param string $host     `REDIS_HOST`, or '' when not configured.
-     * @param int    $port     `REDIS_PORT`, or {@see self::DEFAULT_PORT}.
-     * @param string $password `REDIS_PASSWORD`, or '' when not configured.
+     * Has the "password over unencrypted TCP" warning already been emitted in this process?
+     *
+     * Per-process is the only "once" a shared-nothing PHP application can honestly offer: under
+     * FPM it is once per worker, for that worker's lifetime; under CLI once per run. It is
+     * deliberately not per connection — the eleven sites connect lazily on many different request
+     * paths, and warning at each would bury the message in its own repetition.
+     */
+    private static bool $plainTcpPasswordWarned = false;
+
+    /**
+     * @param string $socket        `REDIS_SOCKET`, or '' when not configured.
+     * @param string $host          `REDIS_HOST` with any `tls://`/`ssl://` prefix stripped, or ''.
+     * @param int    $port          `REDIS_PORT`, or {@see self::DEFAULT_PORT}.
+     * @param string $password      `REDIS_PASSWORD`, or '' when not configured.
+     * @param bool   $tls           Whether the TCP connection should be wrapped in TLS.
+     * @param string $tlsCaFile     `REDIS_TLS_CA_FILE`, or '' when not configured.
+     * @param bool   $tlsVerifyPeer Whether the server certificate must verify. Default true.
      */
     private function __construct(
         public readonly string $socket,
         public readonly string $host,
         public readonly int $port,
         public readonly string $password,
+        public readonly bool $tls,
+        public readonly string $tlsCaFile,
+        public readonly bool $tlsVerifyPeer,
     ) {
     }
 
-    /** Build the connection description from the environment. */
+    /**
+     * Build the connection description from the environment.
+     *
+     * A `tls://` or `ssl://` prefix on `REDIS_HOST` is stripped into {@see self::$tls} rather
+     * than left on the host, so that loopback detection — and therefore
+     * {@see self::isTransportSecure()} and `describe()` — still recognise `tls://127.0.0.1`. The
+     * prefix is put back by {@see self::target()} at connect time.
+     */
     public static function fromEnv(): self
     {
+        $host = self::envString('REDIS_HOST');
+        $tls  = false;
+
+        foreach (self::TLS_SCHEMES as $scheme) {
+            if (0 === stripos($host, $scheme)) {
+                $tls  = true;
+                $host = substr($host, strlen($scheme));
+                break;
+            }
+        }
+
+        if (false === $tls) {
+            $tls = self::envBool('REDIS_TLS', false);
+        }
+
         $port = self::envString('REDIS_PORT');
 
         return new self(
             self::envString('REDIS_SOCKET'),
-            self::envString('REDIS_HOST'),
+            $host,
             is_numeric($port) ? (int) $port : self::DEFAULT_PORT,
             self::envString('REDIS_PASSWORD'),
+            $tls,
+            self::envString('REDIS_TLS_CA_FILE'),
+            self::envBool('REDIS_TLS_VERIFY_PEER', true),
         );
     }
 
@@ -96,9 +154,11 @@ final class RedisConnection
      * all treat a null `\Redis` as "no acceleration available", which is the honest answer in
      * both cases.
      *
-     * @param float|null $timeout Connect timeout override, in seconds.
+     * @param LoggerInterface|null $logger  Destination for the plain-TCP password warning;
+     *                                      `error_log()` when null.
+     * @param float|null           $timeout Connect timeout override, in seconds.
      */
-    public static function bestEffort(?float $timeout = null): ?\Redis
+    public static function bestEffort(?LoggerInterface $logger = null, ?float $timeout = null): ?\Redis
     {
         $config = self::fromEnv();
 
@@ -111,7 +171,7 @@ final class RedisConnection
             if (false === $config->connect($redis, $timeout)) {
                 return null;
             }
-            if (false === $config->authenticate($redis)) {
+            if (false === $config->authenticate($redis, $logger)) {
                 return null;
             }
 
@@ -128,12 +188,13 @@ final class RedisConnection
      * on that, distinctly from the exit 1 they use for a configuration error, so an operator can
      * tell "not installed" from "installed but misconfigured".
      *
-     * @param float|null $timeout Connect timeout override, in seconds.
+     * @param LoggerInterface|null $logger  Destination for the plain-TCP password warning.
+     * @param float|null           $timeout Connect timeout override, in seconds.
      *
      * @throws \RuntimeException When the connection or the authentication fails.
      * @throws \RedisException   Propagated unchanged from phpredis.
      */
-    public static function openOrFail(?float $timeout = null): \Redis
+    public static function openOrFail(?LoggerInterface $logger = null, ?float $timeout = null): \Redis
     {
         $config = self::fromEnv();
         $redis  = new \Redis();
@@ -142,7 +203,7 @@ final class RedisConnection
             throw new \RuntimeException(sprintf('Could not connect to Redis at %s.', $config->describe()));
         }
 
-        if (false === $config->authenticate($redis)) {
+        if (false === $config->authenticate($redis, $logger)) {
             throw new \RuntimeException(sprintf('Redis authentication failed for %s.', $config->describe()));
         }
 
@@ -174,10 +235,28 @@ final class RedisConnection
         return '' !== $this->password;
     }
 
-    /** The first argument to `\Redis::connect()`: a socket path, or a host. */
+    /**
+     * Would a password sent over this connection stay off the wire, or be encrypted on it?
+     *
+     * True for a UNIX socket (never leaves the host), for a loopback address (never leaves the
+     * interface), and for TLS. False is exactly the combination #919 is about: a credential
+     * crossing a network segment in cleartext, along with every command after it.
+     */
+    public function isTransportSecure(): bool
+    {
+        return $this->usesSocket() || $this->tls || $this->isLoopback();
+    }
+
+    /**
+     * The first argument to `\Redis::connect()`: a socket path, or a host carrying its scheme.
+     */
     public function target(): string
     {
-        return $this->usesSocket() ? $this->socket : $this->hostOrDefault();
+        if ($this->usesSocket()) {
+            return $this->socket;
+        }
+
+        return ( $this->tls ? 'tls://' : '' ) . $this->hostOrDefault();
     }
 
     /**
@@ -185,7 +264,8 @@ final class RedisConnection
      *
      * Never includes the password. The two pre-#919 `Health` spellings —
      * `"socket: /path"` and `"host:port"` — are preserved verbatim so that the health output an
-     * operator greps for does not change shape.
+     * operator greps for does not change shape; a TLS endpoint additionally carries its scheme,
+     * which is the whole point of reporting it.
      */
     public function describe(): string
     {
@@ -198,6 +278,10 @@ final class RedisConnection
 
     /**
      * Perform the connect, socket before host, and report phpredis' own boolean.
+     *
+     * The stream context is passed only when the TLS options actually require one, so the
+     * ordinary — and overwhelmingly common — plain path issues exactly the same three-argument
+     * call it issued before #919.
      *
      * @param float|null $timeout Connect timeout override; {@see self::CONNECT_TIMEOUT_SECONDS}
      *                            when null.
@@ -212,31 +296,149 @@ final class RedisConnection
             return $redis->connect($this->socket, 0, $timeout);
         }
 
-        return $redis->connect($this->target(), $this->port, $timeout);
+        $context = $this->streamContext();
+        if ([] === $context) {
+            return $redis->connect($this->target(), $this->port, $timeout);
+        }
+
+        // phpredis takes no named arguments, so the persistent-id, retry-interval and
+        // read-timeout defaults have to be restated to reach the context argument. The values
+        // below ARE phpredis' own defaults: null, 0, 0.
+        return $redis->connect($this->target(), $this->port, $timeout, null, 0, 0, $context);
     }
 
     /**
-     * Send `AUTH` when there is a password.
+     * Send `AUTH` when there is a password, warning first if it would cross the wire in the clear.
      *
      * Returns true when there is nothing to send, so callers can invoke it unconditionally.
      *
+     * @param LoggerInterface|null $logger Destination for the warning; `error_log()` when null.
+     *
      * @throws \RedisException Propagated unchanged from phpredis.
      */
-    public function authenticate(\Redis $redis): bool
+    public function authenticate(\Redis $redis, ?LoggerInterface $logger = null): bool
     {
         if (false === $this->hasPassword()) {
             return true;
         }
 
-        // phpredis returns bool from AUTH, but the fluent-mode build returns $this instead;
+        $this->warnIfPasswordTravelsInClear($logger);
+
+        // phpredis returns bool from AUTH, but its fluent-mode build returns $this instead;
         // anything that is not an outright false counts as authenticated.
         return false !== $redis->auth($this->password);
+    }
+
+    /**
+     * Emit the #919 warning at most once per process. A no-op when there is no password, or when
+     * the transport already protects it.
+     *
+     * This warns; it does NOT refuse. Failing closed on the password-over-plain-TCP combination
+     * was considered and rejected in #919: it would break, on upgrade, every deployment already
+     * running that way. An operator who wants the credential protected has three documented ways
+     * to do it, and the message names all three.
+     */
+    public function warnIfPasswordTravelsInClear(?LoggerInterface $logger = null): void
+    {
+        if (false === $this->hasPassword() || $this->isTransportSecure() || self::$plainTcpPasswordWarned) {
+            return;
+        }
+
+        self::$plainTcpPasswordWarned = true;
+
+        $message = sprintf(
+            'REDIS_PASSWORD is being sent to %s over an unencrypted TCP connection: the credential, '
+            . 'and every command after it, cross the network in cleartext. Reach Redis over a UNIX '
+            . 'socket (REDIS_SOCKET), keep it on loopback, or enable TLS (REDIS_TLS=true, or a '
+            . 'tls:// prefix on REDIS_HOST). See .env.example for the full set of options.',
+            $this->describe()
+        );
+
+        if ($logger instanceof LoggerInterface) {
+            $logger->warning($message);
+
+            return;
+        }
+
+        error_log($message);
+    }
+
+    /**
+     * Forget that the warning was emitted.
+     *
+     * @internal Exists for the test suite, which has to observe the first emission more than once
+     *           within a single process.
+     */
+    public static function resetPlainTcpWarningState(): void
+    {
+        self::$plainTcpPasswordWarned = false;
     }
 
     /** `REDIS_HOST`, or the loopback default when it is unset. */
     private function hostOrDefault(): string
     {
         return '' !== $this->host ? $this->host : self::DEFAULT_HOST;
+    }
+
+    /**
+     * Does the configured host resolve, literally, to this machine's loopback interface?
+     *
+     * Literal addresses and `localhost` only. A hostname that happens to carry a loopback A
+     * record cannot be recognised without resolving it, and a DNS lookup on a best-effort
+     * connect path is not worth the latency. Treating an unrecognised host as non-loopback is
+     * the safe direction: it warns rather than staying silent.
+     */
+    private function isLoopback(): bool
+    {
+        $host = strtolower(trim($this->hostOrDefault(), '[]'));
+
+        if ('localhost' === $host) {
+            return true;
+        }
+
+        $packed = @inet_pton($host);
+        if (false === $packed) {
+            return false;
+        }
+
+        // ::1 in any spelling, the fully expanded 0:0:0:0:0:0:0:1 included.
+        if ($packed === inet_pton('::1')) {
+            return true;
+        }
+
+        // The whole 127.0.0.0/8 block, not just 127.0.0.1.
+        return 4 === strlen($packed) && "\x7f" === $packed[0];
+    }
+
+    /**
+     * The `$context` argument for `\Redis::connect()`, or `[]` when phpredis' defaults will do.
+     *
+     * Peer verification is left to phpredis (which verifies) unless `REDIS_TLS_VERIFY_PEER` is
+     * explicitly falsy, so the context appears only when an operator has asked for something the
+     * defaults do not give them.
+     *
+     * @return array{stream?: array<string, bool|string>} Shaped to phpredis' own `$context`
+     *                                                      parameter, whose only other key
+     *                                                      (`auth`) this helper does not use.
+     */
+    private function streamContext(): array
+    {
+        if (false === $this->tls) {
+            return [];
+        }
+
+        $stream = [];
+
+        if ('' !== $this->tlsCaFile) {
+            $stream['cafile'] = $this->tlsCaFile;
+        }
+
+        if (false === $this->tlsVerifyPeer) {
+            $stream['verify_peer']      = false;
+            $stream['verify_peer_name'] = false;
+        }
+
+        return [] === $stream ? [] : ['stream' => $stream];
     }
 
     /**
@@ -271,5 +473,25 @@ final class RedisConnection
         }
 
         return '';
+    }
+
+    /**
+     * Read a boolean environment variable, falling back to `$default` when it is set in neither
+     * layer.
+     *
+     * Anything other than a recognised affirmative reads as false, so a typo disables a flag
+     * rather than silently enabling it — the safe direction for `REDIS_TLS_VERIFY_PEER`, and the
+     * loud one for `REDIS_TLS` (a mistyped `REDIS_TLS` leaves the warning firing rather than
+     * pretending the connection is protected).
+     */
+    private static function envBool(string $name, bool $default): bool
+    {
+        $raw = strtolower(self::envString($name));
+
+        if ('' === $raw) {
+            return $default;
+        }
+
+        return in_array($raw, ['1', 'true', 'yes', 'on'], true);
     }
 }

--- a/src/Services/RoleCascadeService.php
+++ b/src/Services/RoleCascadeService.php
@@ -42,7 +42,7 @@ class RoleCascadeService
     public static function fromEnv(?LoggerInterface $logger = null): self
     {
         // Best-effort; null falls back to PG-only durability. See {@see RedisConnection}.
-        $redis      = RedisConnection::bestEffort();
+        $redis      = RedisConnection::bestEffort($logger);
         $streamName = is_string($_ENV['REDIS_OUTBOX_STREAM'] ?? null) ? $_ENV['REDIS_OUTBOX_STREAM'] : 'litcal:reconcile-stream';
 
         return new self(

--- a/src/Services/RoleCascadeService.php
+++ b/src/Services/RoleCascadeService.php
@@ -41,24 +41,8 @@ class RoleCascadeService
      */
     public static function fromEnv(?LoggerInterface $logger = null): self
     {
-        $redis = null;
-        if (extension_loaded('redis') && ( isset($_ENV['REDIS_HOST']) || isset($_ENV['REDIS_SOCKET']) )) {
-            try {
-                $redis = new \Redis();
-                if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
-                    $redis->connect((string) $_ENV['REDIS_SOCKET']);
-                } else {
-                    $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
-                    $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
-                    $redis->connect($redisHost, $redisPort);
-                }
-                if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
-                    $redis->auth((string) $_ENV['REDIS_PASSWORD']);
-                }
-            } catch (\Throwable) {
-                $redis = null; // Best-effort; fall back to PG-only durability.
-            }
-        }
+        // Best-effort; null falls back to PG-only durability. See {@see RedisConnection}.
+        $redis      = RedisConnection::bestEffort();
         $streamName = is_string($_ENV['REDIS_OUTBOX_STREAM'] ?? null) ? $_ENV['REDIS_OUTBOX_STREAM'] : 'litcal:reconcile-stream';
 
         return new self(

--- a/src/Services/SourceData/SourceDataPublisherFactory.php
+++ b/src/Services/SourceData/SourceDataPublisherFactory.php
@@ -14,6 +14,7 @@ use LiturgicalCalendar\Api\Services\GitHub\GitHubAppAuth;
 use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
+use LiturgicalCalendar\Api\Services\RedisConnection;
 use LiturgicalCalendar\Api\Services\ResourceTuplePurgeService;
 use LiturgicalCalendar\Api\Services\ResourceTuplePurgeServiceInterface;
 use Psr\Log\LoggerInterface;
@@ -193,27 +194,9 @@ final class SourceDataPublisherFactory
 
     public function publishNotifier(): SourceDataPublishNotifier
     {
-        $socket   = self::envString('REDIS_SOCKET');
-        $host     = self::envString('REDIS_HOST');
-        $password = self::envString('REDIS_PASSWORD');
-
-        $redis = null;
-        if (extension_loaded('redis') && ( '' !== $socket || '' !== $host )) {
-            try {
-                $redis = new \Redis();
-                if ('' !== $socket) {
-                    $redis->connect($socket, 0, 2.0); // 2 second timeout
-                } else {
-                    $port = self::envString('REDIS_PORT');
-                    $redis->connect($host, is_numeric($port) ? (int) $port : 6379, 2.0); // 2 second timeout
-                }
-                if ('' !== $password) {
-                    $redis->auth($password);
-                }
-            } catch (\Throwable) {
-                $redis = null; // Best-effort; the publisher falls back to PG-plus-cron durability.
-            }
-        }
+        // Best-effort; null whenever Redis is unavailable, and the publisher then falls back to
+        // PG-plus-cron durability. See {@see RedisConnection} for every reason it can be null.
+        $redis = RedisConnection::bestEffort();
 
         $streamName = self::envString('REDIS_SOURCEDATA_PUBLISH_STREAM')
             ?: 'litcal:sourcedata-publish-stream';

--- a/stubs/Redis.php
+++ b/stubs/Redis.php
@@ -16,6 +16,39 @@ if (!class_exists(\Redis::class)) {
     class Redis
     {
         /**
+         * Signature mirrors phpredis 5.3+, whose 7th argument is the stream context that
+         * {@see \LiturgicalCalendar\Api\Services\RedisConnection} uses to carry TLS options.
+         *
+         * @param array<string, array<string, bool|string>>|null $context
+         */
+        public function connect(
+            string $host,
+            int $port = 6379,
+            float $timeout = 0,
+            ?string $persistentId = null,
+            int $retryInterval = 0,
+            float $readTimeout = 0,
+            ?array $context = null,
+        ): bool {
+            return false;
+        }
+
+        /**
+         * @param  string|array<int|string, string> $credentials
+         * @return bool|Redis
+         */
+        public function auth(#[\SensitiveParameter] string|array $credentials): bool|Redis
+        {
+            return false;
+        }
+
+        /** @return bool|Redis|string */
+        public function ping(?string $message = null): bool|Redis|string
+        {
+            return false;
+        }
+
+        /**
          * @param array<string, string> $fields
          * @return string|false
          */


### PR DESCRIPTION
Closes #919.

Implements the maintainer's stated preference from the issue — **option (1) plus (3)**: make the secure configuration possible, and say something when it is not being used, without breaking a running deployment on upgrade. It warns; it never refuses.

Two commits, so the mechanical change is reviewable apart from the behavioural one:

1. extract the helper and migrate all eleven sites
2. add TLS support and the plain-TCP warning

## The helper

`src/Services/RedisConnection.php` — a value object built by `fromEnv()`, reading `REDIS_SOCKET` / `HOST` / `PORT` / `PASSWORD` / `TLS` / `TLS_CA_FILE` / `TLS_VERIFY_PEER` from **both** `$_ENV` and `getenv()`.

- `::bestEffort(?LoggerInterface, ?float): ?\Redis` — never throws; null when ext-redis is missing, nothing is configured, or connect/auth returns false. Used by 9 sites, each now a one-line assignment.
- `::openOrFail(...)` — throws. Used by the two `bin/` entry points.
- A granular form (`connect()`, `authenticate()`, `describe()`, `isConfigured()`, `isTransportSecure()`, …) that `Health` uses to keep its own reporting.

## Divergences reconciled — please check these three

**Connect timeout → 2.0s everywhere.** Five sites previously passed nothing and inherited `default_socket_timeout` (60s); most sit on a request path. It bounds the handshake only, so the consumer's blocking `XREADGROUP` is unaffected.

**Env layer → both `$_ENV` and `getenv()` at all eleven.** Nine read `$_ENV` only, which silently ignored a systemd `EnvironmentFile=` — the exact mechanism the change-request runbook tells operators to use.

**`Health` reporting is not regressed.** `describe()` reproduces the old `"socket: /path"` / `"host:port"` strings verbatim, and all its echo + logger warnings, the APCu fallback, the auth-failure/ping distinction and the `redis_reachable` flag are untouched. `isConfigured()` gates `bestEffort()`, **not** `connect()`, so `Health` still tries the loopback default with nothing configured, as `.env.example` documents.

## Behaviour changes to be aware of

- **`REDIS_HOST` set to an empty or whitespace value now reads as "not configured"**, where three sites previously treated `isset()` as configured and connected to the loopback default. More sensible, but it *is* a change for anyone with a blank `REDIS_HOST=` in `.env`.
- `connect()`/`auth()` returning false now yields null rather than an unusable `\Redis`, and `bin/reconcile-outbox` reports an unreachable Redis instead of proceeding to `XREADGROUP` against nothing.

## Warn-once scope

A private static flag — **once per PHP process**: once per FPM worker for its lifetime, once per CLI run. Not once per connection. That is the only "once" a shared-nothing runtime can give, and it is stated plainly in the class docblock, `.env.example` and the runbook.

## Caveats

- **The TLS path is untested against a real TLS Redis** — no such endpoint was available. The stream context is passed only when `REDIS_TLS_CA_FILE` or `REDIS_TLS_VERIFY_PEER` is set, deliberately, so nothing depends on a phpredis new enough to take a 7th argument unless the operator opts in.
- `stubs/Redis.php` gained `connect()`/`auth()`/`ping()` so the tests can mock them without ext-redis; signatures mirror phpredis 5.3+.

## Verification

`parallel-lint`, `lint`, `analyse` (PHPStan L10, no ignores or baseline added), `lint:md` all clean. 36 new tests in `RedisConnectionTest` covering socket precedence, host/port defaults, both env layers, TLS scheme/flag/context, and the warning firing once and *not* firing for socket, loopback (including `127.0.0.0/8`, `::1`, expanded IPv6) and TLS.

Full suite matches the pre-change baseline bit for bit. Note the environmental caveats in #921 and #922 — a failing run can leave the decrees corpus deleted, and the `Routes/*` failures are a stale container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ueFDAmZFPEP3fhbe26JHj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Redis-over-TLS support, including custom CA certificates and peer verification controls.
  * Added consistent Redis configuration through environment variables, with UNIX socket preference and standard connection timeouts.
  * Added clear warnings when passwords are transmitted over unsecured network connections.
* **Bug Fixes**
  * Improved Redis connection consistency across health checks, notifications, publishing and background processing.
  * Redis outages continue to support graceful fallback where applicable, while critical consumers stop and restart through service supervision.
* **Documentation**
  * Updated configuration guidance, operational runbooks and the changelog with Redis security and connection details.
* **Tests**
  * Added comprehensive coverage for configuration, TLS, authentication, warnings and fallback behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->