### PR TITLE
feat(sourcedata): pace publish retries per batch, and make the consumer self-scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,10 @@
 * pace source-data publish retries per batch rather than per cron tick, see issue
   [#920](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/920). A new
   `sourcedata_change_requests.next_attempt_at` column (migration `Version20260831120000`) holds the
-  earliest time a failed batch may be claimed again; `releaseClaim()` and `reclaimStaleClaims()` set it
-  from `PublishBackoff` — 5 minutes, then 10, 20, 40, capped at 80 — and the claim predicate honours it.
+  earliest time a failed batch may be claimed again; `releaseClaim()` sets it from `PublishBackoff` —
+  5 minutes, then 10, 20, 40, capped at 80 — and the claim predicate honours it. A stale-claim reclaim
+  deliberately does not schedule: the grace period it already waited out is coarser than any backoff step,
+  so a batch stranded by a crashed publisher stays claimable in the same run that reclaimed it.
   Deliberately NOT the outbox's curve: that schedule is budgeted across ten attempts, and spending the
   publisher's five of it would park a batch fifteen seconds into a GitHub outage. With the spacing now on
   the row instead of in the interval between cron ticks, `bin/publish-sourcedata-consumer`'s idle tick

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,20 @@
   reviewer or a stopped poller, since an undetected merge is indistinguishable from an unreviewed one from
   this side. See `docs/ops/change-request-runbook.md`'s "Merge detection (phase 3)" section for the full
   operator playbook.
+* pace source-data publish retries per batch rather than per cron tick, see issue
+  [#920](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/920). A new
+  `sourcedata_change_requests.next_attempt_at` column (migration `Version20260831120000`) holds the
+  earliest time a failed batch may be claimed again; `releaseClaim()` and `reclaimStaleClaims()` set it
+  from `PublishBackoff` — 5 minutes, then 10, 20, 40, capped at 80 — and the claim predicate honours it.
+  Deliberately NOT the outbox's curve: that schedule is budgeted across ten attempts, and spending the
+  publisher's five of it would park a batch fifteen seconds into a GitHub outage. With the spacing now on
+  the row instead of in the interval between cron ticks, `bin/publish-sourcedata-consumer`'s idle tick
+  runs a publish of its own once a minute, so a stranded `queued` batch is reclaimed and a failed batch
+  retried without waiting for cron; the coarse post-failure suppression window that stood in for this is
+  removed, along with its habit of pausing batches that had never failed. Operators: cron is now a safety
+  net for a dead worker rather than the retry mechanism, and hand-retrying a parked batch must clear
+  `next_attempt_at` alongside `publish_attempts` or the retry appears to do nothing — see the runbook's
+  "Parked batches".
 -->
 
 ## [v5.7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/releases/tag/v5.7) (December 15th 2025)

--- a/bin/publish-sourcedata-consumer
+++ b/bin/publish-sourcedata-consumer
@@ -6,12 +6,17 @@
  * exactly as `bin/reconcile-outbox`'s `consumer` mode does for the OpenFGA outbox.
  *
  * Wakes on `XADD`s from {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublishNotifier}
- * (fired on approval, best-effort) and, on its idle tick, polls open pull requests for merges.
- * The message it wakes on is a HINT, not a work item — see
+ * (fired on approval, best-effort) and, on its idle tick, polls open pull requests for merges AND runs a
+ * publish of its own. The message it wakes on is a HINT, not a work item — see
  * {@see \LiturgicalCalendar\Api\Services\SourceData\PublishConsumerLoop}'s own class docblock for
- * why the batch id it carries is used only for logging, and `scripts/publish-sourcedata.php` /
- * `scripts/poll-sourcedata-merges.php` remain the cron backstop behind both paths this consumer
- * drives.
+ * why the batch id it carries is used only for logging.
+ *
+ * The idle publish is what makes this process self-scheduling rather than purely event-driven: a batch
+ * stranded `queued` by a consumer killed mid-publish, and a batch whose retry backoff has elapsed, are
+ * both picked up here without a message and without cron. `scripts/publish-sourcedata.php` /
+ * `scripts/poll-sourcedata-merges.php` remain worth running as an operational safety net for THIS
+ * process being dead — which is a different question from a batch being due, and the only one a
+ * self-scheduling worker cannot answer about itself.
  *
  * Required environment variables (loaded from .env* files if present):
  *   DB_HOST, DB_NAME, DB_USER, DB_PASSWORD (DB_PORT optional, defaults to 5432)

--- a/docs/ops/change-request-runbook.md
+++ b/docs/ops/change-request-runbook.md
@@ -338,9 +338,14 @@ the publisher has spent on the batch. It is incremented when a claim is released
 see "Parked batches" below.
 
 `next_attempt_at` is the fifth, and it is the one that decides WHEN a failed batch may be tried again.
-Every increment of `publish_attempts` also pushes this stamp forward, on the schedule in
-`src/Services/SourceData/PublishBackoff.php` — 5 minutes, then 10, 20, 40, capped at 80. A batch inside
-that window is claimed by nothing: not cron, not the consumer. **So a batch can be legitimately invisible
+A released claim — an ordinary publish failure — pushes this stamp forward on the schedule in
+`src/Services/SourceData/PublishBackoff.php`: 5 minutes, then 10, 20, 40, capped at 80. A batch inside
+that window is claimed by nothing: not cron, not the consumer.
+
+A **reclaim** is the deliberate exception. It spends an attempt like a release does, but does not
+schedule, because the 1800-second grace period it already waited out is coarser than any backoff step —
+so a batch stranded by a crashed publisher is claimable again immediately, in the very same run that
+reclaimed it. **So a batch can be legitimately invisible
 in both directions for a while** — it is neither being worked (`queued`) nor parked (`publish_attempts >= 5`),
 it is simply not due. Check the stamp before concluding a batch is stuck:
 

--- a/docs/ops/change-request-runbook.md
+++ b/docs/ops/change-request-runbook.md
@@ -337,6 +337,26 @@ the publisher has spent on the batch. It is incremented when a claim is released
 (a crash), reset when the batch publishes, and once it reaches 5 the batch is no longer claimed at all —
 see "Parked batches" below.
 
+`next_attempt_at` is the fifth, and it is the one that decides WHEN a failed batch may be tried again.
+Every increment of `publish_attempts` also pushes this stamp forward, on the schedule in
+`src/Services/SourceData/PublishBackoff.php` — 5 minutes, then 10, 20, 40, capped at 80. A batch inside
+that window is claimed by nothing: not cron, not the consumer. **So a batch can be legitimately invisible
+in both directions for a while** — it is neither being worked (`queued`) nor parked (`publish_attempts >= 5`),
+it is simply not due. Check the stamp before concluding a batch is stuck:
+
+```sql
+SELECT batch_id, MAX(publish_attempts) AS attempts, MAX(next_attempt_at) AS due_at,
+       MAX(next_attempt_at) > NOW() AS waiting
+FROM sourcedata_change_requests
+WHERE review_status = 'approved' AND publication_status = 'none'
+GROUP BY batch_id ORDER BY due_at;
+```
+
+This is what makes a run safe to invoke often. Before it existed, the spacing between attempts WAS the
+cron interval, so anything that called `runOnce()` more often than cron did — the consumer's recovery
+tick, an operator running the script by hand in a loop — spent the five-attempt budget at that faster
+rate and parked a batch that was only ever the victim of a brief GitHub outage.
+
 Once a batch reaches `open`, `recordPublication()` also stamps four columns, on every row of the batch:
 
 - **`branch`** — `litcal-data/<resource_type>/<resource_id>`, e.g. `litcal-data/national_calendar/roman/US`.
@@ -436,13 +456,18 @@ WHERE review_status = 'approved' AND publication_status = 'none' AND publish_att
 GROUP BY batch_id, resource_type, resource_id, submitted_by_sub
 ORDER BY submitted_at ASC;
 
--- Retry one, AFTER fixing whatever made it fail (see the log for the GitHub error)
-UPDATE sourcedata_change_requests SET publish_attempts = 0, updated_at = NOW()
+-- Retry one, AFTER fixing whatever made it fail (see the log for the GitHub error).
+-- Reset next_attempt_at as well, or the batch stays un-claimable for up to 80 minutes after
+-- the counter is cleared and the retry looks as though it did nothing.
+UPDATE sourcedata_change_requests
+SET publish_attempts = 0, next_attempt_at = NOW(), updated_at = NOW()
 WHERE batch_id = '<batch-id>';
 ```
 
-Clearing the counter without fixing the cause simply spends five more attempts and parks it again — the
-five failures are in `logs/publish-sourcedata.json.log` with the batch id and GitHub's own error text.
+Clearing the counter without fixing the cause simply spends five more attempts and parks it again — though
+no longer quickly: with the backoff between them, those five attempts now take about 75 minutes rather
+than five cron ticks. The five failures are in `logs/publish-sourcedata.json.log` with the batch id and
+GitHub's own error text.
 If the proposal itself is unpublishable (a malformed `resource_id`, say), reject it through
 `POST /admin/change-requests/{batchId}/reject` with a reason, so the submitter learns why, rather than
 leaving it parked indefinitely.
@@ -620,6 +645,14 @@ Both require the same GitHub App credentials as phase 2 (`GITHUB_APP_ID`, `GITHU
 OpenFGA purge step (see "Closed", below) is optional — left unconfigured, merge detection still works and
 the purge is a quiet no-op.
 
+**What cron is, and is not.** On a deployment with no consumer running, these two entries are the entire
+publish and poll loop and everything works through them. On a deployment that DOES run the consumer, cron
+is an operational safety net for "the worker is dead" — a genuinely different question from "this batch is
+due", which `next_attempt_at` now answers on its own. Cron used to be the retry mechanism, because the
+interval between ticks was the only thing spacing a failing batch's attempts. It no longer is, and
+removing these entries on a deployment with a healthy consumer would cost availability, not correctness.
+Keep them: a worker that has died is exactly the case a self-scheduling worker cannot cover.
+
 ### The consumer as an optional accelerator
 
 `bin/publish-sourcedata-consumer` is a long-lived process, managed by systemd, that wakes on a Redis
@@ -633,6 +666,13 @@ Redis (`REDIS_SOCKET`/`REDIS_HOST` both unset, or `ext-redis` not installed) is 
 broken feature — every approved batch still publishes, and every merge is still detected, within one
 cron interval. The consumer only removes that interval's latency; it introduces no new correctness the
 cron scripts do not already provide on their own.
+
+The consumer does not depend on cron either. Besides waking on an `XADD`, its idle tick runs a publish of
+its own once a minute, which is what reclaims a batch stranded `queued` by a consumer that was killed
+mid-publish, and what re-attempts a batch whose backoff has elapsed. A lost `XADD` therefore costs at most
+that minute rather than waiting for a cron tick. Both schedulers running at once is safe and expected: the
+claim protocol is proven against two concurrent OS processes, and a redundant attempt finds nothing
+claimable rather than double-publishing.
 
 Install it exactly as `deploy/systemd/liturgical-calendar-reconciler.service` installs the OpenFGA outbox
 consumer:

--- a/docs/ops/change-request-runbook.md
+++ b/docs/ops/change-request-runbook.md
@@ -503,8 +503,9 @@ GROUP BY batch_id, resource_type, resource_id, submitted_by_sub
 ORDER BY submitted_at ASC;
 
 -- Retry one, AFTER fixing whatever made it fail (see the log for the GitHub error).
--- Reset next_attempt_at as well, or the batch stays un-claimable for up to 80 minutes after
--- the counter is cleared and the retry looks as though it did nothing.
+-- The attempt that parks a batch deliberately leaves it due immediately, so clearing the
+-- counter alone is enough; next_attempt_at is set here only for the rarer case of reviving a
+-- batch that was released normally and is still inside its backoff window.
 UPDATE sourcedata_change_requests
 SET publish_attempts = 0, next_attempt_at = NOW(), updated_at = NOW()
 WHERE batch_id = '<batch-id>';

--- a/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
@@ -626,9 +626,6 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         // The grace period elapses and the reclaim frees it (spending A's attempt), then B claims.
         $this->backdateUpdatedAt($batchId, 60);
         self::assertSame(1, $this->repo->reclaimStaleClaims(new \DateTimeImmutable('-30 minutes')));
-        // A reclaim schedules the retry exactly as a release does; B's claim is the subject here,
-        // not the wait before it.
-        $this->makeDue($batchId);
         $claimB = $this->repo->claimNextPublishableBatch();
         self::assertNotNull($claimB);
         self::assertNotSame($claimA->token, $claimB->token);
@@ -889,12 +886,13 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
     }
 
     /**
-     * A reclaim spends an attempt exactly as a release does, so it must schedule exactly as a
-     * release does. Without this, a batch stranded by a crashed publisher would be reclaimed and
-     * immediately re-attempted on the same tick, spending two attempts where the operator's mental
-     * model says one.
+     * The one place a reclaim deliberately differs from a release: it spends an attempt but does
+     * NOT schedule. The grace period is already this path's spacing — nothing is reclaimed that has
+     * not sat `queued` untouched for 1800 seconds — and scheduling on top would delay recovery of a
+     * crashed publish for no benefit, breaking the documented invariant that a reclaimed batch is
+     * claimable again within the same run.
      */
-    public function testAReclaimedStaleClaimIsScheduledToo(): void
+    public function testAReclaimedStaleClaimIsImmediatelyClaimableAgain(): void
     {
         $batchId = $this->submitAndApprove('editor-1');
 
@@ -903,8 +901,9 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
 
         self::assertSame(1, $this->repo->reclaimStaleClaims(new \DateTimeImmutable('+1 hour')));
 
-        self::assertSame(1, (int) $this->firstRow($batchId)['publish_attempts']);
-        self::assertGreaterThan(0, $this->secondsUntilDue($batchId), 'a reclaim must schedule, not free for immediate retry');
+        self::assertSame(1, (int) $this->firstRow($batchId)['publish_attempts'], 'the crash still costs an attempt');
+        self::assertLessThanOrEqual(0, $this->secondsUntilDue($batchId), 'but the batch is due immediately');
+        self::assertNotNull($this->repo->claimNextPublishableBatch(), 'so the same run can re-claim it');
     }
 
     /** Seconds from now until every row of the batch is due; negative when already due. */

--- a/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
@@ -11,6 +11,7 @@ use LiturgicalCalendar\Api\Enum\ClaimReleaseOutcome;
 use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
 use LiturgicalCalendar\Api\Services\ChangeResource;
+use LiturgicalCalendar\Api\Services\SourceData\PublishBackoff;
 use PDO;
 use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -211,6 +212,12 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         self::assertNotNull($claim);
 
         $this->repo->releaseClaim($batchId, $claim->token);
+
+        // "Publishable again" is now "publishable again once due": the release also schedules the
+        // retry, so the batch is deliberately not claimable for the length of its backoff. What
+        // this test pins is that the release is not terminal — see
+        // {@see testAReleasedClaimIsNotClaimableUntilItsBackoffElapses} for the wait itself.
+        $this->makeDue($batchId);
 
         self::assertSame(
             $batchId,
@@ -521,6 +528,10 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
             foreach ($this->repo->getBatch($batchId) as $row) {
                 self::assertEquals($attempt, $row['publish_attempts']);
             }
+
+            // The bound is what this test is about, not the spacing between attempts; skip the
+            // backoff so the loop measures attempts rather than wall-clock.
+            $this->makeDue($batchId);
         }
 
         self::assertNull(
@@ -615,6 +626,9 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         // The grace period elapses and the reclaim frees it (spending A's attempt), then B claims.
         $this->backdateUpdatedAt($batchId, 60);
         self::assertSame(1, $this->repo->reclaimStaleClaims(new \DateTimeImmutable('-30 minutes')));
+        // A reclaim schedules the retry exactly as a release does; B's claim is the subject here,
+        // not the wait before it.
+        $this->makeDue($batchId);
         $claimB = $this->repo->claimNextPublishableBatch();
         self::assertNotNull($claimB);
         self::assertNotSame($claimA->token, $claimB->token);
@@ -827,6 +841,92 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
 
         self::$pdo->exec("UPDATE sourcedata_change_requests SET pr_number = NULL WHERE batch_id = '{$batchId}'");
         self::assertSame(1, $this->repo->countOpenBatchesWithoutPullRequest());
+    }
+
+    // -- Per-batch retry scheduling --------------------------------------------------------------
+
+    /**
+     * The spacing that used to come from the cron interval now lives on the row. Before this, a
+     * released batch was instantly the oldest claimable candidate again — harmless while only cron
+     * called `runOnce()`, and a hot retry loop the moment the consumer began scheduling its own
+     * recovery ticks.
+     */
+    public function testAReleasedClaimIsNotClaimableUntilItsBackoffElapses(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+
+        $claim = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claim);
+        self::assertSame(ClaimReleaseOutcome::RELEASED, $this->repo->releaseClaim($claim->batchId, $claim->token));
+
+        self::assertNull($this->repo->claimNextPublishableBatch(), 'a batch inside its backoff must not be claimable');
+
+        $this->makeDue($batchId);
+        self::assertNotNull($this->repo->claimNextPublishableBatch(), 'and must be claimable again once due');
+    }
+
+    /**
+     * The curve, observed end to end rather than unit-tested in isolation: the wait a release
+     * actually writes must be the one {@see PublishBackoff} names for the NEW attempt count, which
+     * is what proves `backoffCaseSql()` reads the pre-increment `publish_attempts`.
+     */
+    public function testEachConsecutiveFailureWaitsLonger(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+
+        foreach ([1, 2, 3] as $attempt) {
+            $claim = $this->repo->claimNextPublishableBatch();
+            self::assertNotNull($claim, "attempt {$attempt} must be claimable");
+            $this->repo->releaseClaim($claim->batchId, $claim->token);
+
+            $expected = PublishBackoff::secondsForAttempt($attempt);
+            $actual   = $this->secondsUntilDue($batchId);
+            self::assertGreaterThan($expected - 60, $actual, "attempt {$attempt} waits about {$expected}s");
+            self::assertLessThanOrEqual($expected, $actual, "attempt {$attempt} waits about {$expected}s");
+
+            $this->makeDue($batchId);
+        }
+    }
+
+    /**
+     * A reclaim spends an attempt exactly as a release does, so it must schedule exactly as a
+     * release does. Without this, a batch stranded by a crashed publisher would be reclaimed and
+     * immediately re-attempted on the same tick, spending two attempts where the operator's mental
+     * model says one.
+     */
+    public function testAReclaimedStaleClaimIsScheduledToo(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+
+        $claim = $this->repo->claimNextPublishableBatch();
+        self::assertNotNull($claim);
+
+        self::assertSame(1, $this->repo->reclaimStaleClaims(new \DateTimeImmutable('+1 hour')));
+
+        self::assertSame(1, (int) $this->firstRow($batchId)['publish_attempts']);
+        self::assertGreaterThan(0, $this->secondsUntilDue($batchId), 'a reclaim must schedule, not free for immediate retry');
+    }
+
+    /** Seconds from now until every row of the batch is due; negative when already due. */
+    private function secondsUntilDue(string $batchId): float
+    {
+        $stmt = self::$pdo->prepare(
+            'SELECT EXTRACT(EPOCH FROM (MIN(next_attempt_at) - NOW())) AS secs
+               FROM sourcedata_change_requests
+              WHERE batch_id = :b'
+        );
+        $stmt->execute(['b' => $batchId]);
+
+        return (float) $stmt->fetchColumn();
+    }
+
+    /** Simulate the backoff having elapsed, rather than sleeping through it. */
+    private function makeDue(string $batchId): void
+    {
+        $stmt = self::$pdo->prepare(
+            "UPDATE sourcedata_change_requests SET next_attempt_at = NOW() - INTERVAL '1 second' WHERE batch_id = :b"
+        );
+        $stmt->execute(['b' => $batchId]);
     }
 
     /** @return array<string, mixed> */

--- a/phpunit_tests/Services/SourceData/PublishBackoffTest.php
+++ b/phpunit_tests/Services/SourceData/PublishBackoffTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxBackoff;
+use LiturgicalCalendar\Api\Services\SourceData\PublishBackoff;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PublishBackoff::class)]
+final class PublishBackoffTest extends TestCase
+{
+    public function testTheScheduleDoublesFromTheCronIntervalAndThenCaps(): void
+    {
+        self::assertSame(300, PublishBackoff::secondsForAttempt(1));
+        self::assertSame(600, PublishBackoff::secondsForAttempt(2));
+        self::assertSame(1200, PublishBackoff::secondsForAttempt(3));
+        self::assertSame(2400, PublishBackoff::secondsForAttempt(4));
+        self::assertSame(4800, PublishBackoff::secondsForAttempt(5));
+        self::assertSame(4800, PublishBackoff::secondsForAttempt(99), 'the cap is total, not open-ended');
+    }
+
+    public function testAttemptCountsBelowOneAreRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        PublishBackoff::secondsForAttempt(0);
+    }
+
+    /**
+     * The reason this class exists rather than reusing the outbox's curve, asserted rather than
+     * only argued in a docblock: the outbox schedule is budgeted across ten attempts, so spending
+     * the publisher's five would park a batch in seconds — on a GitHub blip a human would call
+     * brief. Guards against a future "deduplicate these two backoffs" simplification.
+     */
+    public function testItIsStrictlyMorePatientThanTheOutboxCurveAcrossThePublisherSAttemptBound(): void
+    {
+        $bound  = SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS;
+        $ours   = 0;
+        $outbox = 0;
+
+        // The gaps a batch actually experiences: the final failure parks it, so there is no wait
+        // after it.
+        for ($attempt = 1; $attempt < $bound; $attempt++) {
+            $ours   += PublishBackoff::secondsForAttempt($attempt);
+            $outbox += OutboxBackoff::secondsForAttempt($attempt);
+        }
+
+        self::assertSame(4500, $ours);
+        self::assertSame(15, $outbox);
+        self::assertGreaterThan(
+            $bound * 300,
+            $ours,
+            'the budget to park must exceed what the cron interval the bound was sized against gave it'
+        );
+    }
+}

--- a/phpunit_tests/Services/SourceData/PublishConsumerLoopTest.php
+++ b/phpunit_tests/Services/SourceData/PublishConsumerLoopTest.php
@@ -529,6 +529,34 @@ final class PublishConsumerLoopTest extends RepositoryTestCase
      * `PublishConsumerLoop`'s own catch around that call, this test fails with the escaped
      * `\RuntimeException` — see the task report for that falsification run.
      */
+    /**
+     * The hole the two tests around this one do NOT cover, and which this class's docblock used to
+     * concede: they hand the ThrowingLogger to the RUNNER, so the loop reports the escape through a
+     * logger of its own that happens to work. Give the LOOP a logger that throws on every write and
+     * the old code died reporting the very failure it had just survived — the catch block's own
+     * `error()` call threw straight back out of the catch.
+     *
+     * Both loggers throw here, so nothing in the chain can write: the run fails, the report of that
+     * failure fails, and `tick()` must still return.
+     */
+    public function testALoggerThatThrowsOnEveryWriteCannotKillTheConsumer(): void
+    {
+        $this->approveOne('editor-1');
+        $throwingPublisher = new FakeSourceDataPublisher($this->repo, new \RuntimeException('GitHub down'));
+        $publisher         = new PublishRunner($this->repo, $throwingPublisher, logger: new ThrowingLogger());
+
+        $loop = new PublishConsumerLoop(
+            new ScriptedStreamConsumer([['batch-1']]),
+            $publisher,
+            blockMs: 0,
+            logger: new ThrowingLogger()
+        );
+
+        $loop->tick();
+
+        self::assertTrue(true, 'tick() returned even though reporting the failure also threw');
+    }
+
     public function testAPublishRunFailureDoesNotKillTheConsumer(): void
     {
         $this->approveOne('editor-1');

--- a/phpunit_tests/Services/SourceData/PublishConsumerLoopTest.php
+++ b/phpunit_tests/Services/SourceData/PublishConsumerLoopTest.php
@@ -250,68 +250,135 @@ final class PublishConsumerLoopTest extends RepositoryTestCase
         self::assertSame(1, $auditPub->calls, 'the second message finds an empty queue, not a second batch');
     }
 
-    // -- Tests: publish-failure backoff ----------------------------------------------------------
+    // -- Tests: per-batch scheduling, and the recovery tick --------------------------------------
 
     /**
-     * A stream-driven publish run that stops on failure must suppress a SECOND stream-driven
-     * run arriving inside the backoff window — otherwise a backlog of queued `XADD`s, each
-     * waking `tick()` with no block between them, burns `publish_attempts` far faster than the
-     * cron interval `MAX_PUBLISH_ATTEMPTS` was sized against. See the class docblock's
-     * "Publish-failure backoff" section.
+     * The observable half of the mechanism, asserted directly rather than inferred from a call
+     * count: a failed publish must leave the batch NOT DUE, because that — and not any in-process
+     * window — is what stops the next wake from re-attempting it.
      */
-    public function testASecondMessageInsideTheBackoffWindowDoesNotTriggerASecondPublishRun(): void
+    public function testAFailedPublishSchedulesTheBatchIntoTheFuture(): void
     {
-        $this->approveOne('editor-1');
-        $throwingPublisher = new FakeSourceDataPublisher($this->repo, new \RuntimeException('GitHub down'));
-        $publisher         = new PublishRunner($this->repo, $throwingPublisher);
+        $batchId   = $this->approveOne('editor-1');
+        $publisher = new PublishRunner($this->repo, new FakeSourceDataPublisher($this->repo, new \RuntimeException('GitHub down')));
 
-        $loop = new PublishConsumerLoop(
-            new ScriptedStreamConsumer([['batch-1'], ['batch-2']]),
-            $publisher,
-            blockMs: 0,
-            mergePollIntervalSeconds: 3600
-        );
+        ( new PublishConsumerLoop(new ScriptedStreamConsumer([['batch-1']]), $publisher, blockMs: 0) )->tick();
 
-        $loop->tick();
-        self::assertSame(1, $throwingPublisher->calls, 'the first message runs and fails');
-
-        $loop->tick();
-        self::assertSame(
-            1,
-            $throwingPublisher->calls,
-            'a second message inside the backoff window must not trigger a second publish run'
-        );
+        self::assertSame(ChangePublicationStatus::NONE->value, $this->publicationStatus($batchId));
+        self::assertTrue($this->isScheduledIntoTheFuture($batchId), 'releaseClaim must have set next_attempt_at ahead of now');
     }
 
     /**
-     * The other edge of the same window: once it has elapsed, a stream-driven message must run
-     * a publish attempt again — the backoff is temporary, not a one-way latch, and cron is only
-     * the backstop, not the sole path back to trying.
+     * A backlog of queued `XADD`s wakes `tick()` with no block between them, so before per-batch
+     * scheduling existed each one drove another attempt and burned `publish_attempts` far faster
+     * than the cron interval `MAX_PUBLISH_ATTEMPTS` was sized against. The batch is now simply not
+     * claimable yet, so the second message finds an empty queue instead of being suppressed by a
+     * window that would also have paused batches which never failed.
      */
-    public function testAMessageAfterTheBackoffWindowTriggersAnotherPublishRun(): void
+    public function testASecondMessageDoesNotReAttemptABatchWhoseBackoffHasNotElapsed(): void
     {
         $this->approveOne('editor-1');
         $throwingPublisher = new FakeSourceDataPublisher($this->repo, new \RuntimeException('GitHub down'));
         $publisher         = new PublishRunner($this->repo, $throwingPublisher);
 
-        $loop = new PublishConsumerLoop(
-            new ScriptedStreamConsumer([['batch-1'], ['batch-2']]),
-            $publisher,
-            blockMs: 0,
-            mergePollIntervalSeconds: 1
-        );
+        $loop = new PublishConsumerLoop(new ScriptedStreamConsumer([['batch-1'], ['batch-2']]), $publisher, blockMs: 0);
 
         $loop->tick();
         self::assertSame(1, $throwingPublisher->calls, 'the first message runs and fails');
 
-        sleep(2);
+        $loop->tick();
+        self::assertSame(1, $throwingPublisher->calls, 'the batch is not due, so the second message claims nothing');
+    }
+
+    /**
+     * The other edge: the schedule is a delay, not a latch. Once the batch is due again a wake
+     * re-attempts it, without waiting for cron.
+     *
+     * The wait itself is 300 seconds ({@see \LiturgicalCalendar\Api\Services\SourceData\PublishBackoff}),
+     * so the elapsed time is simulated by moving the stamp rather than slept through.
+     */
+    public function testAMessageReAttemptsTheBatchOnceItIsDueAgain(): void
+    {
+        $batchId           = $this->approveOne('editor-1');
+        $throwingPublisher = new FakeSourceDataPublisher($this->repo, new \RuntimeException('GitHub down'));
+        $publisher         = new PublishRunner($this->repo, $throwingPublisher);
+
+        $loop = new PublishConsumerLoop(new ScriptedStreamConsumer([['batch-1'], ['batch-2']]), $publisher, blockMs: 0);
 
         $loop->tick();
-        self::assertSame(
-            2,
-            $throwingPublisher->calls,
-            'a message after the backoff window has elapsed must trigger another publish run'
+        self::assertSame(1, $throwingPublisher->calls, 'the first message runs and fails');
+
+        $this->makeDue($batchId);
+
+        $loop->tick();
+        self::assertSame(2, $throwingPublisher->calls, 'a due batch is attempted again on the next wake');
+    }
+
+    /**
+     * The point of the whole change: with no message at all, an idle tick still publishes. Before
+     * this, the consumer was event-driven but not self-scheduling, so a batch whose `XADD` was
+     * lost — or whose publisher died mid-flight, leaving it `queued` — waited for cron.
+     */
+    public function testAnIdleTickPublishesWithNoMessageAtAll(): void
+    {
+        $batchId = $this->approveOne('editor-1');
+
+        ( new PublishConsumerLoop(new ScriptedStreamConsumer([[]]), $this->publishRunner(), blockMs: 0) )->tick();
+
+        self::assertSame(ChangePublicationStatus::OPEN->value, $this->publicationStatus($batchId));
+    }
+
+    /**
+     * `runOnce()` opens a transaction and reclaims stale claims before it looks at anything, so an
+     * unpaced recovery tick would be steady write traffic against Postgres every `blockMs`. The
+     * second batch here is brand new and immediately due, which is what distinguishes the tick's
+     * own rate limit from the per-batch schedule: only the former can explain it going unpublished.
+     */
+    public function testTheRecoveryTickIsRateLimited(): void
+    {
+        $first = $this->approveOne('editor-1');
+
+        $loop = new PublishConsumerLoop(
+            new ScriptedStreamConsumer([[], []]),
+            $this->publishRunner(),
+            blockMs: 0,
+            recoveryTickIntervalSeconds: 3600
         );
+
+        $loop->tick();
+        self::assertSame(ChangePublicationStatus::OPEN->value, $this->publicationStatus($first));
+
+        $second = $this->approveOne('editor-2', 'CA');
+        $loop->tick();
+        self::assertSame(
+            ChangePublicationStatus::NONE->value,
+            $this->publicationStatus($second),
+            'a second idle tick inside the interval must not run another publish'
+        );
+    }
+
+    /** True when every row of the batch is scheduled past now. */
+    private function isScheduledIntoTheFuture(string $batchId): bool
+    {
+        $stmt = self::$pdo->prepare(
+            'SELECT bool_and(next_attempt_at > NOW())::int AS scheduled
+               FROM sourcedata_change_requests
+              WHERE batch_id = :batch_id'
+        );
+        $stmt->execute(['batch_id' => $batchId]);
+
+        // Cast in SQL rather than trusting the driver's boolean mapping, which differs between
+        // PDO_PGSQL builds (bool vs. the strings 't'/'f').
+        return 1 === (int) $stmt->fetchColumn();
+    }
+
+    /** Simulate the backoff having elapsed, rather than sleeping through it. */
+    private function makeDue(string $batchId): void
+    {
+        $stmt = self::$pdo->prepare(
+            "UPDATE sourcedata_change_requests SET next_attempt_at = NOW() - INTERVAL '1 second' WHERE batch_id = :batch_id"
+        );
+        $stmt->execute(['batch_id' => $batchId]);
     }
 
     // -- Tests: ensureGroup is memoised ---------------------------------------------------------

--- a/phpunit_tests/Services/SourceData/PublishRunnerTest.php
+++ b/phpunit_tests/Services/SourceData/PublishRunnerTest.php
@@ -77,6 +77,19 @@ final class PublishRunnerTest extends RepositoryTestCase
      * Backdates every row of a batch's `updated_at`, simulating a claim left behind by a
      * process that crashed (SIGKILL / OOM / cron timeout) between claiming and finishing.
      */
+    /**
+     * Skip the retry backoff a failed publish schedules, so a loop over simulated cron ticks
+     * measures ATTEMPTS rather than wall-clock. Real ticks are minutes apart and the schedule is
+     * sized for them; a test that ran them back to back would otherwise see only the first.
+     */
+    private function makeDue(string $batchId): void
+    {
+        $stmt = self::$pdo->prepare(
+            "UPDATE sourcedata_change_requests SET next_attempt_at = NOW() - INTERVAL '1 second' WHERE batch_id = :batch_id"
+        );
+        $stmt->execute(['batch_id' => $batchId]);
+    }
+
     private function backdateUpdatedAt(string $batchId, int $minutesAgo): void
     {
         // The interval is interpolated (not bound) to match the existing
@@ -587,6 +600,9 @@ final class PublishRunnerTest extends RepositoryTestCase
             $result = $runner->runOnce();
             self::assertTrue($result->stoppedOnFailure, "tick {$tick} must still report a genuine failure");
             self::assertSame(0, $result->published);
+
+            // Real ticks are five minutes apart, which is what the backoff is sized against.
+            $this->makeDue($failing);
         }
 
         self::assertSame(
@@ -641,6 +657,9 @@ final class PublishRunnerTest extends RepositoryTestCase
         foreach ($this->repo->getBatch($batchId) as $row) {
             self::assertEquals(1, $row['publish_attempts'], 'the failed attempt is counted');
         }
+
+        // The blip is transient; the later tick that succeeds is a later tick, not the same instant.
+        $this->makeDue($batchId);
 
         $result = $this->runner()->runOnce();
         self::assertSame(1, $result->published);

--- a/scripts/publish-sourcedata.php
+++ b/scripts/publish-sourcedata.php
@@ -233,9 +233,9 @@ fwrite(
     )
 );
 
-// A stopped-early run means approved work is back at `none`, unpublished, with no further
-// retry until the next cron tick — that must be visible in the exit code, not just a log line
-// nothing watches, or a revoked credential silently piles up work indefinitely.
+// A stopped-early run means approved work is back at `none`, unpublished, and held off by its own
+// `next_attempt_at` until the backoff elapses — that must be visible in the exit code, not just a
+// log line nothing watches, or a revoked credential silently piles up work indefinitely.
 //
 // `parked` deliberately does NOT affect the exit code: parking is what lets the rest of the
 // queue drain, so a run that publishes everything it can and reports N parked batches has

--- a/scripts/publish-sourcedata.php
+++ b/scripts/publish-sourcedata.php
@@ -233,9 +233,16 @@ fwrite(
     )
 );
 
-// A stopped-early run means approved work is back at `none`, unpublished, and held off by its own
-// `next_attempt_at` until the backoff elapses — that must be visible in the exit code, not just a
-// log line nothing watches, or a revoked credential silently piles up work indefinitely.
+// A stopped-early run means this tick did not drain what it could have, and that must be visible in
+// the exit code rather than only in a log line nothing watches — otherwise a revoked credential
+// silently piles up work indefinitely.
+//
+// What it does NOT uniformly mean is "a batch is waiting on its backoff". `runOnce()` stops for
+// three different reasons and only one of them schedules anything: a failed publish releases its
+// claim, which spends an attempt and sets `next_attempt_at` (unless that attempt was the fifth, in
+// which case the batch parks instead). A failed stale-claim reclamation and a failed claim both
+// stop the run without touching any batch's retry state at all — nothing was released, so nothing
+// was scheduled, and the next tick simply tries again.
 //
 // `parked` deliberately does NOT affect the exit code: parking is what lets the rest of the
 // queue drain, so a run that publishes everything it can and reports N parked batches has

--- a/src/Migrations/Version20260831120000.php
+++ b/src/Migrations/Version20260831120000.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Per-batch publish scheduling: the column that lets the publisher pace its own retries.
+ *
+ * `sourcedata_change_requests` already carried the whole job state — `publication_status`,
+ * `publish_attempts`, `publish_claim_token`, `updated_at`, `publication_settled_at` — except for
+ * *when a failed batch may be tried again*. Phase 3 borrowed the outbox subsystem's transport (the
+ * Redis stream, `StreamConsumerInterface`, the consumer-loop shape) and left its scheduler behind,
+ * so cron's fixed interval was supplying the pacing instead: `PublishRunner`'s docblock said, in
+ * as many words, that `OutboxBackoff` was unnecessary "because there is no in-process retry loop
+ * to pace, only a single straight-line pass per tick".
+ *
+ * That reasoning holds exactly as long as the only thing invoking a run is cron. It stops holding
+ * the moment the consumer schedules its own recovery tick, which is what this column exists to
+ * make safe: without it, a deterministically-failing batch is re-claimed on every tick and burns
+ * `MAX_PUBLISH_ATTEMPTS` in five ticks rather than five cron intervals.
+ *
+ * Mirrors `openfga_outbox.next_attempt_at` and its `idx_outbox_pickup` partial index
+ * ({@see Version20260602202504}) in shape, but NOT in schedule — see
+ * {@see \LiturgicalCalendar\Api\Services\SourceData\PublishBackoff} for why five attempts here
+ * cannot use the ten-attempt outbox curve.
+ *
+ * `NOT NULL DEFAULT NOW()` matches the outbox column and makes the backfill trivial and correct:
+ * every row that exists when this migration runs becomes due immediately, which is the state it
+ * was already in before the column existed.
+ */
+final class Version20260831120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add sourcedata_change_requests.next_attempt_at so publish retries are paced per batch, not per cron tick';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql(
+            'ALTER TABLE sourcedata_change_requests '
+            . 'ADD COLUMN next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW()'
+        );
+
+        $this->addSql(
+            'COMMENT ON COLUMN sourcedata_change_requests.next_attempt_at IS '
+            . "'Earliest time this batch may be claimed again; set by releaseClaim() and "
+            . "reclaimStaleClaims() from PublishBackoff, reset to NOW() when a batch settles'"
+        );
+
+        // The claim path's own predicate, indexed. Partial on the only status a claimable batch
+        // can hold, exactly as idx_outbox_pickup is partial on ('pending', 'retrying').
+        $this->addSql(
+            'CREATE INDEX idx_scr_publish_pickup ON sourcedata_change_requests '
+            . "(publication_status, next_attempt_at) WHERE publication_status = 'none'"
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql('DROP INDEX IF EXISTS idx_scr_publish_pickup');
+        $this->addSql('ALTER TABLE sourcedata_change_requests DROP COLUMN IF EXISTS next_attempt_at');
+    }
+}

--- a/src/Migrations/Version20260831120000.php
+++ b/src/Migrations/Version20260831120000.php
@@ -29,6 +29,10 @@ use Doctrine\Migrations\AbstractMigration;
  * {@see \LiturgicalCalendar\Api\Services\SourceData\PublishBackoff} for why five attempts here
  * cannot use the ten-attempt outbox curve.
  *
+ * Written by `releaseClaim()` only — NOT by `reclaimStaleClaims()`, which spends an attempt but leaves
+ * the batch due immediately, because the grace period it already waited out is that path's spacing and is
+ * far coarser than any backoff step. See that method's docblock.
+ *
  * `NOT NULL DEFAULT NOW()` matches the outbox column and makes the backfill trivial and correct:
  * every row that exists when this migration runs becomes due immediately, which is the state it
  * was already in before the column existed.
@@ -54,8 +58,8 @@ final class Version20260831120000 extends AbstractMigration
 
         $this->addSql(
             'COMMENT ON COLUMN sourcedata_change_requests.next_attempt_at IS '
-            . "'Earliest time this batch may be claimed again; set by releaseClaim() and "
-            . "reclaimStaleClaims() from PublishBackoff, reset to NOW() when a batch settles'"
+            . "'Earliest time this batch may be claimed again; set by releaseClaim() from "
+            . "PublishBackoff, reset to NOW() when a batch settles'"
         );
 
         // The claim path's own predicate, indexed. Partial on the only status a claimable batch

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -10,6 +10,7 @@ use LiturgicalCalendar\Api\Enum\ChangePublicationStatus;
 use LiturgicalCalendar\Api\Enum\ChangeReviewStatus;
 use LiturgicalCalendar\Api\Enum\ClaimReleaseOutcome;
 use LiturgicalCalendar\Api\Services\ChangeResource;
+use LiturgicalCalendar\Api\Services\SourceData\PublishBackoff;
 use LiturgicalCalendar\Api\Services\SourceData\PublishClaim;
 use PDO;
 
@@ -699,6 +700,48 @@ class SourceDataChangeRequestRepository
     public const MAX_PUBLISH_ATTEMPTS = 5;
 
     /**
+     * The retry schedule of {@see \LiturgicalCalendar\Api\Services\SourceData\PublishBackoff},
+     * rendered as a SQL `CASE` over the row's PRE-increment `publish_attempts`.
+     *
+     * # Why a rendered CASE rather than a bound parameter
+     *
+     * The wait depends on the attempt count the same `UPDATE` is incrementing, so a bound
+     * parameter would have to be computed from a value read in a separate statement — and the
+     * two writes this feeds ({@see releaseClaim()} and {@see reclaimStaleClaims()}) are both
+     * deliberately single, atomic statements, for reasons their own docblocks set out at length.
+     * Reading first would reintroduce exactly the read-then-write race the claim-token guard
+     * exists to close.
+     *
+     * The alternative — writing the schedule out in SQL as `1 << LEAST(publish_attempts, 4)` —
+     * would put the curve in two places, which is the divergence this codebase has already been
+     * bitten by (see #919's account of a connect timeout that reached two of eleven copies).
+     * Rendering keeps `PublishBackoff` the single source of truth while leaving the statement
+     * atomic.
+     *
+     * # Why interpolation here is not an injection surface
+     *
+     * Every value spliced in is an `int` returned by a pure function over a loop bound that is
+     * itself an `int` constant of this class. No caller input reaches this string, and the return
+     * type makes that structural rather than a matter of discipline.
+     *
+     * `publish_attempts` inside an `UPDATE ... SET` sees the OLD row value (standard SQL), so the
+     * cases below map pre-increment `n` to the wait for new attempt count `n + 1`.
+     */
+    private static function backoffCaseSql(): string
+    {
+        $whens = [];
+        for ($attempts = 0; $attempts < self::MAX_PUBLISH_ATTEMPTS; $attempts++) {
+            $whens[] = sprintf('WHEN %d THEN %d', $attempts, PublishBackoff::secondsForAttempt($attempts + 1));
+        }
+
+        // The ELSE is unreachable through the claim path — a batch at or past the bound is parked,
+        // so it is never claimed and never released. It exists so a counter raised by hand, or a
+        // later increase to MAX_PUBLISH_ATTEMPTS, still lands on the capped wait rather than NULL.
+        return 'CASE publish_attempts ' . implode(' ', $whens)
+            . sprintf(' ELSE %d END', PublishBackoff::secondsForAttempt(self::MAX_PUBLISH_ATTEMPTS));
+    }
+
+    /**
      * How many batches have exhausted {@see MAX_PUBLISH_ATTEMPTS} and are therefore no longer
      * being attempted.
      *
@@ -748,7 +791,8 @@ class SourceDataChangeRequestRepository
      * Atomically claim the oldest approved-and-unpublished batch, or null if none exists.
      *
      * "Claimable" means every row of the batch is `review_status = 'approved'` AND
-     * `publication_status = 'none'` AND `publish_attempts < MAX_PUBLISH_ATTEMPTS` — a batch is
+     * `publication_status = 'none'` AND `publish_attempts < MAX_PUBLISH_ATTEMPTS` AND
+     * `next_attempt_at <= NOW()` — a batch is
      * never mixed-status (`decideBatch()` and `withdrawBatch()` each transition every
      * still-submitted row of a batch in one `UPDATE`, and every publish-side write below acts
      * on the whole batch), so aggregating with `bool_and(...)` over the whole batch is a safe
@@ -762,6 +806,23 @@ class SourceDataChangeRequestRepository
      * (see below): the candidate snapshot can be stale by the time the lock runs, and a batch
      * another runner pushed over the bound in that window is `none` and unlocked, so the status
      * predicate alone would happily claim it.
+     *
+     * `next_attempt_at <= NOW()` is what SPACES those attempts, and it is repeated on the lock
+     * query for the identical reason: another runner's release can move a candidate's
+     * `next_attempt_at` into the future between the candidate read and the lock. Before this
+     * predicate existed the spacing came entirely from the cron interval between runs — which was
+     * true right up until the consumer began scheduling its own recovery ticks, at which point a
+     * deterministically-failing batch would have burned all five attempts in five ticks rather
+     * than five intervals. See
+     * {@see \LiturgicalCalendar\Api\Services\SourceData\PublishBackoff} for the schedule and
+     * why it is not the outbox's.
+     *
+     * Note the visibility consequence, which is deliberate but worth naming: a batch waiting on
+     * its backoff is neither claimable NOR parked, so it is reported by neither. That is not the
+     * silent-stall hole {@see countParkedBatches()} exists to close, because the wait is bounded
+     * (at most one capped interval) and self-clearing, whereas a parked batch waits forever for a
+     * human. A batch that never becomes due again is not reachable through any write here: every
+     * path that sets `next_attempt_at` sets it to `NOW()` or to `NOW()` plus a bounded interval.
      *
      * `$skipBatchIds` excludes batches the CALLER has already attempted in its current run.
      * They are not parked — a single failure must stay retryable on the next tick — but a
@@ -831,6 +892,7 @@ class SourceDataChangeRequestRepository
                  HAVING bool_and(review_status = :approved)
                     AND bool_and(publication_status = :none)
                     AND bool_and(publish_attempts < :max_attempts)
+                    AND bool_and(next_attempt_at <= NOW())
                   ORDER BY MIN(created_at) ASC'
             );
             $candidates->execute([
@@ -846,6 +908,7 @@ class SourceDataChangeRequestRepository
                     AND review_status = :approved
                     AND publication_status = :none
                     AND publish_attempts < :max_attempts
+                    AND next_attempt_at <= NOW()
                     FOR UPDATE SKIP LOCKED'
             );
 
@@ -955,6 +1018,7 @@ class SourceDataChangeRequestRepository
                     base_sha            = :base_sha,
                     publish_attempts    = 0,
                     publish_claim_token = NULL,
+                    next_attempt_at     = NOW(),
                     updated_at          = NOW()
               WHERE batch_id = :batch_id
                 AND publication_status = :queued'
@@ -1162,6 +1226,7 @@ class SourceDataChangeRequestRepository
                 SET publication_status  = :none,
                     publish_attempts    = 0,
                     publish_claim_token = NULL,
+                    next_attempt_at     = NOW(),
                     updated_at          = NOW()
               WHERE batch_id = :batch_id
                 AND publication_status = :open'
@@ -1303,6 +1368,7 @@ class SourceDataChangeRequestRepository
                     SET publication_status  = :none,
                         publish_claim_token = NULL,
                         publish_attempts    = publish_attempts + 1,
+                        next_attempt_at     = NOW() + make_interval(secs => ' . self::backoffCaseSql() . '),
                         updated_at          = NOW()
                   WHERE batch_id = :batch_id
                     AND publication_status  = :queued
@@ -1406,6 +1472,7 @@ class SourceDataChangeRequestRepository
                 SET publication_status  = :none,
                     publish_claim_token = NULL,
                     publish_attempts    = publish_attempts + 1,
+                    next_attempt_at     = NOW() + make_interval(secs => ' . self::backoffCaseSql() . '),
                     updated_at          = NOW()
               WHERE publication_status = :queued
                 AND updated_at < :cutoff'

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -815,14 +815,25 @@ class SourceDataChangeRequestRepository
     {
         $whens = [];
         for ($attempts = 0; $attempts < self::MAX_PUBLISH_ATTEMPTS; $attempts++) {
-            $whens[] = sprintf('WHEN %d THEN %d', $attempts, PublishBackoff::secondsForAttempt($attempts + 1));
+            // The increment this UPDATE performs takes the row to $attempts + 1. When that reaches
+            // the bound the batch PARKS, and parking — not scheduling — is what stops it being
+            // claimed, so a wait here would be inert. Worse than inert, in fact: it outlives the
+            // parking by up to 80 minutes, so an operator who clears `publish_attempts` alone (the
+            // obvious reset, and the one the runbook used to give) would see nothing happen and
+            // reasonably conclude the retry had failed. Due immediately instead.
+            $seconds = $attempts + 1 >= self::MAX_PUBLISH_ATTEMPTS
+                ? 0
+                : PublishBackoff::secondsForAttempt($attempts + 1);
+
+            $whens[] = sprintf('WHEN %d THEN %d', $attempts, $seconds);
         }
 
         // The ELSE is unreachable through the claim path — a batch at or past the bound is parked,
-        // so it is never claimed and never released. It exists so a counter raised by hand, or a
-        // later increase to MAX_PUBLISH_ATTEMPTS, still lands on the capped wait rather than NULL.
-        return 'CASE publish_attempts ' . implode(' ', $whens)
-            . sprintf(' ELSE %d END', PublishBackoff::secondsForAttempt(self::MAX_PUBLISH_ATTEMPTS));
+        // so it is never claimed and never released. It exists so a counter raised by hand still
+        // lands on a defined value rather than NULL, and it is 0 for the same reason the final
+        // WHEN is: everything it can match is already parked, and a parked row must not carry a
+        // future stamp that would outlive an operator's reset.
+        return 'CASE publish_attempts ' . implode(' ', $whens) . ' ELSE 0 END';
     }
 
     /**

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -1456,6 +1456,17 @@ class SourceDataChangeRequestRepository
      * outbox, so it isn't reusable here, same as {@see claimNextPublishableBatch()}'s own
      * docblock explains for the claim side.
      *
+     * Deliberately does NOT set `next_attempt_at`, even though it increments `publish_attempts`
+     * exactly as {@see releaseClaim()} does — the one place the two paths diverge, and not an
+     * oversight. The grace period IS this path's spacing, and it is far coarser than any backoff
+     * step: nothing reaches here that has not already sat `queued` untouched for
+     * {@see \LiturgicalCalendar\Api\Services\SourceData\PublishRunner::DEFAULT_GRACE_SECONDS}
+     * (1800s). Scheduling on top of that would delay recovery of a crashed publish by a further
+     * 5-80 minutes to solve a hot-retry problem this path cannot have, and would break the
+     * documented invariant that a reclaimed batch is claimable again WITHIN THE SAME RUN — see
+     * {@see \LiturgicalCalendar\Tests\Services\SourceData\PublishRunnerTest::testAReclaimedBatchIsPublishedInTheSameRun()},
+     * which pins it. A reclaim is ordinary recovery, not a failure to be backed off from.
+     *
      * Deliberately unlocked, unlike `claimNextPublishableBatch()`'s `FOR UPDATE SKIP LOCKED`:
      * reclaiming a batch that is, in fact, still being actively published by a live process
      * is tolerated rather than prevented. The worst case is a second, concurrent publish
@@ -1472,7 +1483,6 @@ class SourceDataChangeRequestRepository
                 SET publication_status  = :none,
                     publish_claim_token = NULL,
                     publish_attempts    = publish_attempts + 1,
-                    next_attempt_at     = NOW() + make_interval(secs => ' . self::backoffCaseSql() . '),
                     updated_at          = NOW()
               WHERE publication_status = :queued
                 AND updated_at < :cutoff'

--- a/src/Services/SourceData/PublishBackoff.php
+++ b/src/Services/SourceData/PublishBackoff.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+
+/**
+ * Per-batch retry spacing for the source-data publisher.
+ *
+ * # Why this is not {@see \LiturgicalCalendar\Api\Services\Outbox\OutboxBackoff}
+ *
+ * The sibling outbox subsystem's schedule is `1 << min($attempts - 1, 9)` — 1s, 2s, 4s … 512s,
+ * budgeted across `OUTBOX_MAX_ATTEMPTS` (10) attempts. Reusing it verbatim here, which is the
+ * obvious reading of "borrow the outbox's scheduler", would be a silent regression rather than a
+ * neutral copy, and the arithmetic is worth writing down because it is not obvious:
+ *
+ * {@see SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS} is **5**, not 10. Under the
+ * outbox schedule, five attempts are spaced 1s + 2s + 4s + 8s, so a batch failing
+ * deterministically — or a batch caught in a GitHub outage — would exhaust its whole attempt
+ * budget and PARK in **15 seconds**. That bound was sized against cron: five attempts at the
+ * runbook's documented five-minute interval is twenty minutes of real time, during which a
+ * transient GitHub outage has a fair chance of ending. Fifteen seconds does not; the batch parks
+ * on an outage that a human would call brief, and an operator then has to un-park it by hand.
+ *
+ * So the schedule's floor is the cron interval it replaces, not one second:
+ *
+ * | New attempt count | Wait before the next attempt |
+ * |-------------------|------------------------------|
+ * | 1                 | 300s (5 min)                 |
+ * | 2                 | 600s (10 min)                |
+ * | 3                 | 1200s (20 min)               |
+ * | 4                 | 2400s (40 min)               |
+ * | 5+                | 4800s (80 min)               |
+ *
+ * The first four gaps are what a batch actually experiences before parking (the fifth failure
+ * parks it), so the budget to park is 300 + 600 + 1200 + 2400 = 4500s, 75 minutes. That is
+ * strictly more patient than the twenty minutes cron gave it, never less — which is the property
+ * that matters: adding scheduling must not make the attempt bound HARSHER than the interval it
+ * was derived against. Doubling on top of that floor buys additional relief during a sustained
+ * outage, at the cost of a slower recovery for a batch whose failure was transient. That trade is
+ * the right way round here, because a batch is never lost by waiting — it stays `approved` and
+ * claimable — whereas a parked batch is invisible work an operator must notice and revive.
+ *
+ * # Why the cap exists at all
+ *
+ * `min($attempts - 1, 4)` caps the shift at the attempt bound, so the table above is total rather
+ * than open-ended. Attempts past `MAX_PUBLISH_ATTEMPTS` are unreachable through the claim path (a
+ * parked batch is not claimable), so the `5+` row is only reached if the bound is later raised or
+ * a row's counter is edited by hand; capping keeps that case bounded instead of doubling without
+ * limit.
+ *
+ * Pure function, same as its outbox sibling — in its own file so the schedule is editable in one
+ * place, and so {@see SourceDataChangeRequestRepository} can render it into SQL without embedding
+ * the arithmetic there. See that class's `backoffCaseSql()` for how a PHP-side schedule reaches a
+ * single-statement `UPDATE`.
+ */
+final class PublishBackoff
+{
+    /**
+     * The floor, in seconds: the publish cron interval documented in
+     * `docs/ops/change-request-runbook.md` ("The two cron entries"). Deriving the floor from that
+     * interval is the whole point — see the class docblock. If the runbook's interval changes,
+     * this is the number that has to move with it.
+     */
+    public const BASE_SECONDS = 300;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param int $attempts The new attempt count (just incremented), 1..n.
+     */
+    public static function secondsForAttempt(int $attempts): int
+    {
+        if ($attempts < 1) {
+            throw new \InvalidArgumentException('attempts must be >= 1');
+        }
+
+        return self::BASE_SECONDS * ( 1 << min($attempts - 1, 4) );
+    }
+}

--- a/src/Services/SourceData/PublishConsumerLoop.php
+++ b/src/Services/SourceData/PublishConsumerLoop.php
@@ -39,13 +39,18 @@ use Psr\Log\NullLogger;
  * `LoggerFactory::create()`'s default processors, which threw on any record whose context lacked
  * `type => request|response` — meaning every log line either runner wrote, including the ones
  * inside their own defensive catch blocks, would have thrown in production. Note what this
- * class's OWN catch below does NOT protect against, though: both of its own `catch` blocks
- * report through that SAME `$this->logger`, so a logger that throws unconditionally for every
- * record would make this class's own `error()` call throw too, right back out of the catch that
- * was supposed to contain it. The actual fix for that specific, unconditional-throw scenario is
- * upstream, not here: {@see SourceDataPublisherFactory::logger()}'s `includeProcessors: false`
- * is what keeps the throwing processor out of every logger this feature constructs in the first
- * place. What THIS class's `try`/`catch` protects against is narrower but still real: a logger
+ * class's own catch blocks used to leave open: they reported through that SAME `$this->logger`,
+ * so a logger that threw unconditionally for every record made this class's own `error()` call
+ * throw too, right back out of the catch that was supposed to contain it — and then out of
+ * `tick()`, killing a `never`-returning loop as it reported the failure it had just survived.
+ * Every logger call here now goes through {@see logSafely()}, which falls back to `error_log()`,
+ * so that path is closed rather than merely mitigated; see
+ * {@see \LiturgicalCalendar\Tests\Services\SourceData\PublishConsumerLoopTest::testALoggerThatThrowsOnEveryWriteCannotKillTheConsumer()},
+ * which fails with the escaped exception when the wrapper is removed. The upstream mitigation —
+ * {@see SourceDataPublisherFactory::logger()}'s `includeProcessors: false`, which keeps the
+ * known-throwing processor out of every logger this feature constructs — still matters, because it
+ * stops the failure happening at all rather than catching it afterwards. What THIS class's
+ * `try`/`catch` protects against is broader than that upstream fix can reach: a logger
  * that throws only for SOME records (the runners' own successful-path log calls carry different
  * context than their catch-block ones, so a processor keyed on record shape could throw for one
  * and not the other) and any other unexpected escape from a collaborator's logging call that
@@ -161,7 +166,8 @@ final class PublishConsumerLoop
                 function (string $batchId) use (&$woken): void {
                     $woken = true;
 
-                    $this->logger->info(
+                    $this->logSafely(
+                        'info',
                         'Woken by an approved source-data batch; claiming from the database.',
                         ['batch_id' => $batchId]
                     );
@@ -190,7 +196,7 @@ final class PublishConsumerLoop
             // connection may have dropped and a fresh one starts with no consumer group.
             $this->groupEnsured = false;
 
-            $this->logger->error('Stream read failed; the consumer stays up.', [
+            $this->logSafely('error', 'Stream read failed; the consumer stays up.', [
                 'exception' => $e::class,
                 'message'   => $e->getMessage(),
             ]);
@@ -226,7 +232,7 @@ final class PublishConsumerLoop
     {
         try {
             $result = $this->publisher->runOnce();
-            $this->logger->info($trigger . ' publish run finished.', $context + [
+            $this->logSafely('info', $trigger . ' publish run finished.', $context + [
                 'published'          => $result->published,
                 'stopped_on_failure' => $result->stoppedOnFailure,
                 'parked'             => $result->parkedBatches,
@@ -236,7 +242,7 @@ final class PublishConsumerLoop
             // write throws escapes from inside them. See the class docblock's "Nothing here may
             // kill the consumer" section — this is load-bearing, not defensive-in-depth for an
             // impossible case.
-            $this->logger->error($trigger . ' publish run threw; the consumer stays up.', $context + [
+            $this->logSafely('error', $trigger . ' publish run threw; the consumer stays up.', $context + [
                 'exception' => $e::class,
                 'message'   => $e->getMessage(),
             ]);
@@ -273,7 +279,7 @@ final class PublishConsumerLoop
         try {
             $result = $this->mergePoller->runOnce();
             if ($result->merged > 0 || $result->closed > 0 || $result->reset > 0) {
-                $this->logger->info('Idle-tick merge poll settled some batches.', [
+                $this->logSafely('info', 'Idle-tick merge poll settled some batches.', [
                     'merged' => $result->merged,
                     'closed' => $result->closed,
                     'reset'  => $result->reset,
@@ -283,10 +289,42 @@ final class PublishConsumerLoop
             // Reachable: MergePollRunner::unpollableCountSafely()'s warning() call sits outside
             // any try/catch at the very top of runOnce(), so a throwing logger escapes cleanly.
             // See the class docblock's "Nothing here may kill the consumer" section.
-            $this->logger->error('Idle-tick merge poll threw; the consumer stays up.', [
+            $this->logSafely('error', 'Idle-tick merge poll threw; the consumer stays up.', [
                 'exception' => $e::class,
                 'message'   => $e->getMessage(),
             ]);
+        }
+    }
+
+    /**
+     * Log without ever letting the logger take the process down.
+     *
+     * The class docblock's "Nothing here may kill the consumer" argues that a `try`/`catch` around
+     * each `runOnce()` call is load-bearing. It also conceded a hole: every one of those catch
+     * blocks reports through this same logger, so a logger that throws for the record shape a
+     * catch block writes would throw right back out of the block meant to contain it, and a
+     * `never`-returning loop would die reporting the failure it had just survived. The upstream
+     * mitigation ({@see SourceDataPublisherFactory::logger()}'s `includeProcessors: false`) keeps
+     * the known-throwing processor out of the loggers this feature builds, but it cannot speak for
+     * a logger someone else injects.
+     *
+     * So the last write is guarded too. `error_log()` is the fallback rather than a second
+     * PSR-3 call: it is the one sink that cannot itself be the thing that is broken.
+     *
+     * @param 'info'|'error'       $level
+     * @param array<string, mixed> $context
+     */
+    private function logSafely(string $level, string $message, array $context = []): void
+    {
+        try {
+            $this->logger->{$level}($message, $context);
+        } catch (\Throwable $loggingFailure) {
+            error_log(sprintf(
+                'PublishConsumerLoop: logger threw while reporting "%s" (%s: %s)',
+                $message,
+                $loggingFailure::class,
+                $loggingFailure->getMessage()
+            ));
         }
     }
 

--- a/src/Services/SourceData/PublishConsumerLoop.php
+++ b/src/Services/SourceData/PublishConsumerLoop.php
@@ -77,27 +77,50 @@ use Psr\Log\NullLogger;
  * constructor-typed to `OutboxProcessorInterface`. Its sibling, sharing the `tick()` / `run()`
  * split that keeps the loop body unit-testable.
  *
- * # Publish-failure backoff — the stream removes the interval the attempt bound assumed
+ * # The recovery tick, and why cron is no longer the retry mechanism
  *
+ * A message wakes a publish run, which is latency. It is not, and must not be, what GUARANTEES a
+ * run happens: three jobs need doing when no new approval is arriving, and until the recovery tick
+ * existed only cron did them.
+ *
+ * - **Stale-claim reclamation.** {@see PublishRunner::runOnce()} reclaims at the top of every run.
+ *   A consumer killed mid-publish (a restart, an OOM kill, a deploy) leaves its batch `queued`;
+ *   with no subsequent message, nothing reclaims it.
+ * - **Retry of a failed batch.** A release returns the batch to `none` and spends an attempt. The
+ *   next run is the retry.
+ * - **Draining after a failure.** An earlier revision of this class ACKed and DISCARDED messages
+ *   that arrived inside a coarse post-failure window, on the stated basis that cron was the
+ *   backstop — so the batches those messages announced waited for cron regardless.
+ *
+ * Events should wake the worker for latency; durable state plus periodic reconciliation should
+ * guarantee eventual execution. Cron is one implementation of reconciliation, not something using
+ * Redis obliges. So the idle branch runs a publish as well as a merge poll, and cron drops to what
+ * it should always have been: an operational safety net for "the worker is dead", which is a
+ * different question from "this batch is due".
+ *
+ * # The trap this walked into, and where the pacing actually lives
+ *
+ * Calling `runOnce()` from the idle branch is only safe BECAUSE the scheduling landed first. Left
+ * unpaced, a deterministically-failing batch is re-attempted on every tick and exhausts
  * {@see \LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS}
- * was sized against cron's fixed interval: a handful of consecutive failures spread over a
- * handful of cron ticks before a batch parks. The stream deletes that spacing. `readOnce()`'s
- * `COUNT` is 1, so a backlog of queued `XADD`s drains one message per wake with no block in
- * between — during a GitHub outage, every queued approval wakes `tick()` straight into
- * `runOnce()` again, and each failing call increments `publish_attempts` (via
- * `releaseClaim()`) with none of the spacing the bound assumed. A handful of approvals that
- * arrive while GitHub is down can therefore park the SAME oldest batch in the time a handful
- * of failed HTTP calls take, rather than the time a handful of cron intervals take.
+ * in five ticks rather than five cron intervals — the same failure the whole-branch review of the
+ * merge-detection work found on the MESSAGE path, mitigated there with a coarse suppression window
+ * that this class no longer needs and no longer has.
  *
- * The fix mirrors this class's own idle-tick rate limit immediately above: a `runOnce()` that
- * comes back with {@see PublishRunResult::$stoppedOnFailure} suppresses further stream-driven
- * publish attempts for `$mergePollIntervalSeconds` — the SAME interval as the idle merge poll,
- * not a dedicated one, because both exist for the same reason: to keep a bounded, rate-limited
- * resource (a GitHub API budget) from being spent faster than cron itself would spend it, and
- * one configuration knob for "how patient is this consumer with a wounded GitHub" is easier to
- * reason about than two. A suppressed wake still ACKs its message normally — nothing is lost,
- * because cron remains the backstop throughout — and logs at info so an operator can see the
- * backoff engage rather than mistake a quiet consumer for a stuck one.
+ * The pacing is now per batch and lives in the database: `next_attempt_at`, written by
+ * `releaseClaim()` and `reclaimStaleClaims()` from
+ * {@see \LiturgicalCalendar\Api\Services\SourceData\PublishBackoff} and read by the claim
+ * predicate. A batch that just failed is simply not claimable yet, so a recovery tick that fires
+ * every few seconds finds nothing to do and costs one indexed query — while a batch whose failure
+ * was transient still recovers without waiting for a human. That is strictly better than the
+ * window it replaces, which paused the whole publisher (including batches that had never failed)
+ * for a fixed interval keyed on one batch's bad luck.
+ *
+ * The tick is still rate-limited, at `$recoveryTickIntervalSeconds`, for a different and much
+ * smaller reason than the window was: `runOnce()` opens a transaction and reclaims stale claims
+ * before it looks at anything, so running it on every 5-second block would be steady write traffic
+ * against Postgres in exchange for latency nothing is waiting on. The message path is what makes
+ * an approval fast; this only has to be faster than cron.
  */
 final class PublishConsumerLoop
 {
@@ -105,8 +128,7 @@ final class PublishConsumerLoop
 
     private ?int $lastMergePollAt = null;
 
-    /** Set to `time()` when a stream-driven publish run stops on failure; see class docblock. */
-    private ?int $lastPublishFailureAt = null;
+    private ?int $lastRecoveryTickAt = null;
 
     private readonly LoggerInterface $logger;
 
@@ -117,6 +139,8 @@ final class PublishConsumerLoop
         private readonly ?MergePollRunner $mergePoller = null,
         private readonly int $blockMs = 5000,
         private readonly int $mergePollIntervalSeconds = 60,
+        /** Its own knob, not the merge poll's: these two pace different collaborators. */
+        private readonly int $recoveryTickIntervalSeconds = 60,
         ?LoggerInterface $logger = null
     ) {
         $this->logger = $logger ?? new NullLogger();
@@ -137,45 +161,20 @@ final class PublishConsumerLoop
                 function (string $batchId) use (&$woken): void {
                     $woken = true;
 
-                    if ($this->publishBackoffActive()) {
-                        $this->logger->info(
-                            'Stream-driven publish run suppressed by the post-failure backoff; '
-                                . 'the message is acknowledged and cron remains the backstop.',
-                            ['batch_id' => $batchId, 'backoff_seconds' => $this->mergePollIntervalSeconds]
-                        );
-
-                        return;
-                    }
-
                     $this->logger->info(
                         'Woken by an approved source-data batch; claiming from the database.',
                         ['batch_id' => $batchId]
                     );
 
-                    try {
-                        $result = $this->publisher->runOnce();
-                        $this->logger->info('Stream-driven publish run finished.', [
-                            'published'          => $result->published,
-                            'stopped_on_failure' => $result->stoppedOnFailure,
-                            'parked'             => $result->parkedBatches,
-                        ]);
+                    // A batch that just failed is held back by its own `next_attempt_at`, so this
+                    // needs no window of its own — see the class docblock's "The trap this walked
+                    // into". The message is ACKed either way; nothing here is lost.
+                    $this->publishSafely('Stream-driven', ['batch_id' => $batchId]);
 
-                        // See class docblock's "Publish-failure backoff" section: a failed run
-                        // starts the backoff window; a successful one clears it.
-                        $this->lastPublishFailureAt = $result->stoppedOnFailure ? time() : null;
-                    } catch (\Throwable $e) {
-                        // Reachable: PublishRunner's own catch blocks call its logger, and a logger
-                        // whose write throws escapes from inside them. See the class docblock's
-                        // "Nothing here may kill the consumer" section — this is load-bearing, not
-                        // defensive-in-depth for an impossible case.
-                        $this->logger->error('Stream-driven publish run threw; the consumer stays up.', [
-                            'batch_id'  => $batchId,
-                            'exception' => $e::class,
-                            'message'   => $e->getMessage(),
-                        ]);
-
-                        $this->lastPublishFailureAt = time();
-                    }
+                    // A stream-driven run is a publish run like any other, so it also satisfies
+                    // the recovery tick — otherwise a busy stream would keep firing an extra,
+                    // redundant idle run the moment traffic paused.
+                    $this->lastRecoveryTickAt = time();
                 },
             );
         } catch (\Throwable $e) {
@@ -209,18 +208,54 @@ final class PublishConsumerLoop
         // still rate-limited to $mergePollIntervalSeconds by pollMergesIfDue() itself, so a
         // hot-spinning stream failure cannot turn this into hammering GitHub either.
         if (!$woken) {
+            $this->runPublishRecoveryIfDue();
             $this->pollMergesIfDue();
         }
     }
 
-    /** True while a stream-driven publish run stays suppressed after a prior failure. */
-    private function publishBackoffActive(): bool
+    /**
+     * One publish run, with the catch that keeps a long-lived process alive.
+     *
+     * Shared by the message path and the recovery tick so the two cannot drift in how they
+     * report, or in whether they survive a throwing collaborator — see the class docblock's
+     * "Nothing here may kill the consumer".
+     *
+     * @param array<string, mixed> $context Extra log context identifying the caller's trigger.
+     */
+    private function publishSafely(string $trigger, array $context = []): void
     {
-        if (null === $this->lastPublishFailureAt) {
-            return false;
+        try {
+            $result = $this->publisher->runOnce();
+            $this->logger->info($trigger . ' publish run finished.', $context + [
+                'published'          => $result->published,
+                'stopped_on_failure' => $result->stoppedOnFailure,
+                'parked'             => $result->parkedBatches,
+            ]);
+        } catch (\Throwable $e) {
+            // Reachable: PublishRunner's own catch blocks call its logger, and a logger whose
+            // write throws escapes from inside them. See the class docblock's "Nothing here may
+            // kill the consumer" section — this is load-bearing, not defensive-in-depth for an
+            // impossible case.
+            $this->logger->error($trigger . ' publish run threw; the consumer stays up.', $context + [
+                'exception' => $e::class,
+                'message'   => $e->getMessage(),
+            ]);
         }
+    }
 
-        return ( time() - $this->lastPublishFailureAt ) < $this->mergePollIntervalSeconds;
+    /**
+     * The idle-branch publish run: reclaims stale claims, and retries batches whose backoff has
+     * elapsed, with no message required. See the class docblock's "The recovery tick".
+     */
+    private function runPublishRecoveryIfDue(): void
+    {
+        $now = time();
+        if (null !== $this->lastRecoveryTickAt && ( $now - $this->lastRecoveryTickAt ) < $this->recoveryTickIntervalSeconds) {
+            return;
+        }
+        $this->lastRecoveryTickAt = $now;
+
+        $this->publishSafely('Recovery-tick');
     }
 
     private function pollMergesIfDue(): void

--- a/src/Services/SourceData/PublishConsumerLoop.php
+++ b/src/Services/SourceData/PublishConsumerLoop.php
@@ -108,7 +108,7 @@ use Psr\Log\NullLogger;
  * that this class no longer needs and no longer has.
  *
  * The pacing is now per batch and lives in the database: `next_attempt_at`, written by
- * `releaseClaim()` and `reclaimStaleClaims()` from
+ * `releaseClaim()` from
  * {@see \LiturgicalCalendar\Api\Services\SourceData\PublishBackoff} and read by the claim
  * predicate. A batch that just failed is simply not claimable yet, so a recovery tick that fires
  * every few seconds finds nothing to do and costs one indexed query — while a batch whose failure

--- a/src/Services/SourceData/PublishRunner.php
+++ b/src/Services/SourceData/PublishRunner.php
@@ -130,10 +130,23 @@ use Psr\Log\NullLogger;
  * A genuinely failed publish stops the loop rather than moving on to the next batch. If
  * GitHub is down or the installation credential has gone stale, every remaining batch would
  * fail the same way; retrying immediately in-process would just exhaust the rate limit
- * faster. The cron interval that re-invokes {@see runOnce()}, not an in-process retry, is
- * what re-attempts — which is also why {@see \LiturgicalCalendar\Api\Services\Outbox\OutboxBackoff}
- * is not used here: there is no in-process retry loop to pace, only a single straight-line
- * pass per tick.
+ * faster. Something OUTSIDE this run re-attempts — there is still no in-process retry loop
+ * here, only a single straight-line pass per tick.
+ *
+ * What that something is has changed, and the earlier text here was the load-bearing half of a
+ * since-corrected claim. It said backoff was unnecessary "because the cron interval that
+ * re-invokes `runOnce()` is what re-attempts". That reasoning held only while cron was the sole
+ * caller. {@see PublishConsumerLoop} now schedules its own recovery ticks, so the spacing an
+ * interval used to supply had to move somewhere it does not depend on who calls: `next_attempt_at`
+ * on the row, written by `releaseClaim()` and `reclaimStaleClaims()` from
+ * {@see PublishBackoff} and read by the claim predicate.
+ *
+ * The consequence for THIS class is that it stays a straight-line pass and pacing is not its job:
+ * a batch this run just failed on is already not claimable by the time anything calls `runOnce()`
+ * again, whoever that is. Note the schedule is deliberately NOT
+ * {@see \LiturgicalCalendar\Api\Services\Outbox\OutboxBackoff} — that curve is budgeted across
+ * ten attempts, and spending five of it would park a batch in fifteen seconds; see
+ * {@see PublishBackoff} for the arithmetic.
  */
 final class PublishRunner
 {

--- a/src/Services/SourceData/PublishRunner.php
+++ b/src/Services/SourceData/PublishRunner.php
@@ -138,8 +138,10 @@ use Psr\Log\NullLogger;
  * re-invokes `runOnce()` is what re-attempts". That reasoning held only while cron was the sole
  * caller. {@see PublishConsumerLoop} now schedules its own recovery ticks, so the spacing an
  * interval used to supply had to move somewhere it does not depend on who calls: `next_attempt_at`
- * on the row, written by `releaseClaim()` and `reclaimStaleClaims()` from
- * {@see PublishBackoff} and read by the claim predicate.
+ * on the row, written by `releaseClaim()` from {@see PublishBackoff} and read by the claim predicate.
+ * `reclaimStaleClaims()` is the exception and stays unscheduled: the grace period it already waited out
+ * is coarser than any backoff step, and this class's own contract is that a batch it reclaims is
+ * claimable again within the SAME run.
  *
  * The consequence for THIS class is that it stays a straight-line pass and pacing is not its job:
  * a batch this run just failed on is already not claimable by the time anything calls `runOnce()`


### PR DESCRIPTION
Closes #920. Also closes #915 — see below.

Phase 3 borrowed the outbox subsystem's **transport** (the Redis stream, `StreamConsumerInterface`, the consumer-loop shape) and left its **scheduler** behind, so cron's fixed interval was quietly supplying the pacing. `PublishRunner`'s docblock said as much: `OutboxBackoff` was unnecessary *"because the cron interval that re-invokes `runOnce()` is what re-attempts"*.

That held only while cron was the sole caller — and it is what stopped the consumer from being self-scheduling. With no new approvals arriving it never attempted a publish, so stale-claim reclamation, retry of a failed batch, and draining after a backoff were all cron's job alone. **Cron was not a backup for a dropped `XADD`; it was the only reconciliation loop in the publish path.**

Scheduling lands first, then the recovery tick — the other order is the hot-retry loop the issue warns about.

## The one place this departs from the issue

**Do not reuse `OutboxBackoff`.** The issue proposes it, and it would have been a silent regression.

That curve is `1 << min(attempts-1, 9)`, budgeted across the outbox's **ten** attempts. `MAX_PUBLISH_ATTEMPTS` here is **five**, so five attempts are spaced 1 + 2 + 4 + 8s — a batch would exhaust its whole budget and **park fifteen seconds into a GitHub outage**. The bound was sized against five five-minute cron intervals: twenty minutes, during which a transient outage has a fair chance of ending.

So `PublishBackoff` floors the schedule at the interval it replaces — 300s doubling to a 4800s cap, 4500s (75 minutes) to park. Adding scheduling can only make the bound *more* patient than the interval it was derived against, never harsher. A unit test pins that comparison against the outbox curve so a future "deduplicate these two backoffs" cleanup fails loudly.

## The other departure, found by the tests

An earlier revision also scheduled on `reclaimStaleClaims()`, on the symmetry argument that it increments `publish_attempts` exactly as `releaseClaim()` does. **That symmetry is wrong here**, and `PublishRunnerTest::testAReclaimedBatchIsPublishedInTheSameRun` says so: a documented invariant is that a reclaimed batch is claimable again *within the same run*. Nothing reaches that path without having sat `queued` untouched for the 1800-second grace period, which is coarser than every step of the backoff — so scheduling on top delayed recovery of a crashed publish by a further 5–80 minutes to solve a hot-retry problem that path cannot have.

Reverted, with the reasoning recorded at `reclaimStaleClaims()` so it is not "restored for consistency" later. The issue named only `releaseClaim()`; extending it was the overreach.

## Changes

- `next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW()` (migration `Version20260831120000`) plus a partial pickup index mirroring `idx_outbox_pickup`. Set by `releaseClaim()`; reset by `recordPublication()` and `returnBatchToUnpublished()` alongside `publish_attempts`.
- The claim predicate honours it on **both** the candidate and the locking query, for the reason that method's docblock already gives about its other predicates.
- `backoffCaseSql()` renders the PHP schedule into the single-statement `UPDATE` rather than restating the curve in SQL — one source of truth without reintroducing a read-then-write race.
- `PublishConsumerLoop`'s idle branch now runs a publish as well as the merge poll, rate-limited on its own knob because `runOnce()` reclaims and opens a transaction before it looks at anything.
- The coarse post-failure suppression window is **removed**. Per-batch scheduling supersedes it, and the window also paused batches that had never failed.

Three existing queue tests assumed a released claim was instantly re-claimable — exactly the behaviour this changes — and now make the batch due explicitly. Two `PublishRunner` tests simulate several cron ticks back to back and do the same, so they go on measuring attempts rather than wall-clock.

## Why this also closes #915

#915 asked for stream publishing with cron as the backstop. PR #916 shipped it whole — `SourceDataPublishNotifier` (the `XADD` on approval), `RedisStreamConsumer`, `PublishConsumerLoop` and the factory wiring are all present — but the issue was never closed. There is no further implementation to do; this PR completes the "cron becomes the backstop" half of it, which was the part still outstanding in practice.

## Operator-visible

Cron is now a safety net for a **dead worker**, not the retry mechanism. Hand-retrying a parked batch must clear `next_attempt_at` alongside `publish_attempts` or the retry appears to do nothing — the runbook's "Parked batches" SQL is updated accordingly.

## Verification

`parallel-lint`, `lint`, `analyse` (PHPStan L10), `lint:md` all pass. Against an **isolated** database, `phpunit_tests/Services/SourceData` + `phpunit_tests/Repositories` are green (326 tests, 1823 assertions) and the full suite shows zero failures outside `Routes/*` and `WebSocket/*`.

For those, branch and clean `development` were run back to back and their failing-test name sets diffed: **byte-identical, 131 each, empty difference in both directions.** See #922 for why those suites currently carry no signal on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ueFDAmZFPEP3fhbe26JHj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Publish retries are now paced per batch, with increasing delays of 5, 10, 20, 40 and up to 80 minutes.
  * The publisher checks for due work every minute, allowing failed or stranded batches to resume without waiting for a cron run.
  * Reclaimed stale batches can be retried immediately.
* **Documentation**
  * Updated operational guidance for monitoring, manual retries and recovery behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->