### PR TITLE
fix(tests): keep test runs from damaging jsondata, and name a stale server on the API port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -468,7 +468,7 @@ being tested:
 
 | Layer (path)     | Base class                   | When to use                                                                                                       |
 | ---------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `Routes/*`       | `ApiTestCase`                | Full HTTP-level integration tests. Hits the running API (Guzzle). Skipped when `localhost:8000` is unreachable.   |
+| `Routes/*`       | `ApiTestCase`                | Full HTTP-level integration tests. Hits the running API (Guzzle). Preflighted: see `ApiServerPreflight` below.    |
 | `Handlers/*`     | `AbstractHandlerTestCase`    | In-process handler tests via direct `handle()` invocation. No HTTP server needed. 14+ existing tests follow this. |
 | `Repositories/*` | `RepositoryTestCase`         | PG-only repository tests. Auto-TRUNCATEs project tables; skipped when `DB_*` env unset. 6+ existing tests.        |
 | Pure-logic       | `PHPUnit\Framework\TestCase` | `Methods/`, `Enum/`, `Models/`, `Params/`, etc. — no I/O, extend the framework's `TestCase` directly.             |
@@ -482,6 +482,16 @@ Other notable test infrastructure:
   "service not configured" branches without leaking host `.env.local` values into assertions.
 - `phpunit_tests/Services/OpenFgaClientTest.php`: pattern for `MockHandler`-backed `OpenFgaClient` (Guzzle `MockHandler` injected into
   the HTTP client) — reused by every test that exercises FGA-calling code with mocked responses.
+- `phpunit_tests/Support/ApiServerPreflight.php`: run once per process by `ApiTestCase` (and, via `RequiresLiveApiTrait`, by the `WebSocket/*`
+  classes that fan out to the API). It separates three answers a bare TCP probe conflates — nothing listening (skip / "run `composer start`"),
+  something listening that is NOT this API (hard error naming what answered), and our API (proceed). A foreign responder on the port used to
+  produce ~131 assertion failures that read like a branch regression (#922). It also runs one advisory build-drift comparison per run; that check
+  proves a mismatch, never a match — a stale container whose `jsondata/` agrees with yours still passes it.
+
+**Never mutate `jsondata/` in a test.** Point `Router::$apiFilePath` at a temporary copy instead — every `JsonData::…->path()` resolves against it,
+for the handler AND for the test's own assertions (`Handlers/DecreesHandlerWriteTest` and `Services/Locale/LocaleReadinessCheckerTest` do exactly
+that). Backup-and-restore in `tearDown()` is not equivalent: a run that never reaches `tearDown()` — a fatal, an OOM kill, a `timeout`, a Ctrl-C —
+leaves tracked source data deleted or half-restored, and the next run then fails for reasons unrelated to the change under test (#921).
 
 **Test Groups:**
 

--- a/phpunit_tests/ApiTestCase.php
+++ b/phpunit_tests/ApiTestCase.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
+use LiturgicalCalendar\Tests\Support\ApiServerPreflight;
 use Psr\Http\Message\RequestInterface;
 
 abstract class ApiTestCase extends TestCase
@@ -105,6 +106,35 @@ abstract class ApiTestCase extends TestCase
                 throw new \RuntimeException("Required environment variable {$var} is not set");
             }
         }
+
+        // #922: settle WHAT is on the configured port before a single test runs, and treat the
+        // three possible answers differently.
+        //
+        //  - Foreign responder (a stale container, another project): throw here, once per class,
+        //    carrying the whole diagnostic. Every alternative is worse — a skip hides it, and
+        //    letting the tests proceed produced the 131 phantom failures this guard exists for.
+        //  - Nothing listening: return early with $apiAvailable = false, so setUp() emits the
+        //    documented "maybe run `composer start` first?" message. Returning here also spares
+        //    the caller detectBinding()'s much less informative "Could not detect API binding".
+        //  - Ours: fall through unchanged.
+        //
+        // The probe itself is memoised per process, so this costs one request per run.
+        $preflight = ApiServerPreflight::inspect(
+            (string) $_ENV['API_PROTOCOL'],
+            (string) $_ENV['API_HOST'],
+            (int) $_ENV['API_PORT']
+        );
+        if ($preflight->isForeign()) {
+            $preflight->announceOnce();
+            throw new \RuntimeException($preflight->message());
+        }
+        if (false === $preflight->ok()) {
+            self::$apiAvailable = false;
+            return;
+        }
+        // Advisory, one GET per run: says nothing when it passes, but catches the server that
+        // answers 200 out of a different checkout. See ApiServerPreflight::buildDrift().
+        $preflight->warnOnBuildDriftOnce(dirname(__DIR__));
 
         if (self::isIPAddress($_ENV['API_HOST'])) {
             // Already an IP — detect family directly

--- a/phpunit_tests/Handlers/DecreesHandlerWriteTest.php
+++ b/phpunit_tests/Handlers/DecreesHandlerWriteTest.php
@@ -10,53 +10,195 @@ use LiturgicalCalendar\Api\Http\Exception\ConflictException;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
 use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
+use LiturgicalCalendar\Api\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
 
+/**
+ * Every write in this class lands in a throwaway copy of `jsondata/`, never in the
+ * working tree (#921).
+ *
+ * The class used to back the real `jsondata/sourcedata/rite/roman/decrees/` folder up
+ * to `/tmp` in `setUp()` and restore it in `tearDown()` with `rm -rf <src> && cp -r
+ * <backup> <src>`. Between those two commands the repository held no decrees source
+ * data at all, so a run that never reached `tearDown()` — a fatal, an OOM kill, a
+ * `timeout`, a Ctrl-C — left tracked source data deleted (or, when the `rm -rf` failed
+ * while the `&&` proceeded, nested as `decrees/decrees/`). The next run then failed for
+ * reasons that had nothing to do with the change under test.
+ *
+ * The fix removes the window rather than narrowing it: `setUpBeforeClass()` copies
+ * `jsondata/` into a temporary shadow of the project root and repoints
+ * `Router::$apiFilePath` at it, which is the single seam every `JsonData::…->path()`
+ * resolves against — for the handler under test AND for this class's own assertions.
+ * Nothing outside `sys_get_temp_dir()` is written, chmod'ed or deleted for the whole
+ * lifetime of the class, so an interruption at any instant is harmless: the worst
+ * outcome is an abandoned temp directory.
+ *
+ * The per-test reset (a pristine snapshot re-copied in `setUp()`) lives entirely inside
+ * that temp directory too, and `AbstractHandlerTestCase::tearDownAfterClass()` restores
+ * `Router::$apiFilePath` for the classes that follow.
+ */
 #[CoversClass(DecreesHandler::class)]
 final class DecreesHandlerWriteTest extends AbstractHandlerTestCase
 {
-    /** Empty until setUp() allocates it; tearDown() must tolerate that (#868). */
-    private string $backupDir = '';
+    /**
+     * Temporary shadow of the project root. Empty until setUpBeforeClass() allocates it.
+     *
+     * Contains a real copy of `jsondata/` plus a symlink to the (read-only) `i18n/`
+     * catalogs; `Router::$apiFilePath` points here for the lifetime of the class.
+     */
+    private static string $fixtureRoot = '';
+
+    /** Untouched copy of the shipped decrees folder, re-applied before every test. */
+    private static string $pristineDecrees = '';
+
+    /** The decrees folder inside the fixture — the only tree these tests ever mutate. */
+    private static string $fixtureDecrees = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        // Pins Router::$apiFilePath to the real project root (and skips the whole class
+        // when JWT config is absent, before anything below has allocated state).
+        parent::setUpBeforeClass();
+
+        $realRoot    = Router::$apiFilePath;
+        $realDecrees = dirname(JsonData::DECREES_FILE->path());
+
+        self::assertShippedCorpusIntact($realDecrees);
+
+        // Pin the audit logger to the REAL logs/ folder while the root still points there.
+        // LoggerFactory memoises both the resolved logs folder and the 'audit' channel for
+        // the whole process; letting the handler resolve it later — under the fixture root —
+        // would leave every subsequent test class in this process logging into a directory
+        // this class deletes in tearDownAfterClass().
+        $realLogs = $realRoot . 'logs';
+        if (!is_dir($realLogs)) {
+            mkdir($realLogs, 0755, true);
+        }
+        LoggerFactory::create('audit', $realLogs, 90, false, true, false);
+
+        self::$fixtureRoot = sys_get_temp_dir() . '/litcal-decrees-fixture-' . bin2hex(random_bytes(6));
+        self::copyTree($realRoot . 'jsondata', self::$fixtureRoot . '/jsondata');
+        // Gettext catalogs are only ever read, so a symlink is enough and keeps the copy small.
+        if (is_dir($realRoot . 'i18n')) {
+            symlink($realRoot . 'i18n', self::$fixtureRoot . '/i18n');
+        }
+
+        // Snapshot taken from the untouched working tree, kept inside the fixture so the
+        // per-test reset never reads the repository again.
+        self::$pristineDecrees = self::$fixtureRoot . '/pristine/decrees';
+        self::copyTree($realDecrees, self::$pristineDecrees);
+
+        // From here on every JsonData path — handler and assertions alike — resolves
+        // inside the fixture.
+        Router::$apiFilePath  = self::$fixtureRoot . DIRECTORY_SEPARATOR;
+        self::$fixtureDecrees = JsonData::DECREES_FOLDER->path();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if ('' !== self::$fixtureRoot) {
+            self::removeTree(self::$fixtureRoot);
+            self::$fixtureRoot     = '';
+            self::$pristineDecrees = '';
+            self::$fixtureDecrees  = '';
+        }
+        // Restores Router::$apiFilePath to whatever it was before this class ran.
+        parent::tearDownAfterClass();
+    }
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->backupDir = sys_get_temp_dir() . '/decrees-backup-' . uniqid();
-        mkdir($this->backupDir, 0755, true);
-        $src      = dirname(JsonData::DECREES_FILE->path());
-        $exitCode = 1;
-        exec(sprintf('cp -r %s %s', escapeshellarg($src), escapeshellarg($this->backupDir)), result_code: $exitCode);
-        if ($exitCode !== 0 || !is_dir($this->backupDir . '/decrees')) {
-            self::fail('Failed to back up the decrees source data directory; aborting before any test can mutate it.');
+        // Reset the mutable corpus between tests. Source and destination both live under
+        // sys_get_temp_dir(), so this delete-then-copy — unlike the one it replaces — can
+        // only ever destroy a copy.
+        self::removeTree(self::$fixtureDecrees);
+        self::copyTree(self::$pristineDecrees, self::$fixtureDecrees);
+    }
+
+    /**
+     * Refuse to run against a working tree that a previous (pre-#921) interrupted run
+     * already damaged, rather than compounding the damage and reporting it as a code failure.
+     */
+    private static function assertShippedCorpusIntact(string $realDecrees): void
+    {
+        if (!is_dir($realDecrees) || !is_file($realDecrees . '/decrees.json')) {
+            throw new \RuntimeException(sprintf(
+                'The decrees source data is missing from the working tree (%s). '
+                . 'An interrupted run of an earlier version of this test may have deleted it; '
+                . 'recover with `git checkout -- jsondata/` (a backup may also survive as /tmp/decrees-backup-*).',
+                $realDecrees
+            ));
+        }
+
+        if (is_dir($realDecrees . '/decrees')) {
+            throw new \RuntimeException(sprintf(
+                'The decrees source data folder contains a nested copy of itself (%s/decrees). '
+                . 'That is the signature of an interrupted restore in an earlier version of this test; '
+                . 'recover with `rm -rf %s/decrees && git checkout -- jsondata/`.',
+                $realDecrees,
+                $realDecrees
+            ));
         }
     }
 
-    protected function tearDown(): void
+    /** Recursive copy of a directory tree; files only, no symlinks are followed into. */
+    private static function copyTree(string $from, string $to): void
     {
-        // setUp() allocates the backup after parent::setUp(); if the class never got
-        // that far there is nothing to restore, and nothing was written either.
-        if ('' === $this->backupDir) {
-            parent::tearDown();
-            return;
+        if (!is_dir($to) && !mkdir($to, 0755, true) && !is_dir($to)) {
+            throw new \RuntimeException('Could not create fixture directory ' . $to);
         }
 
-        $src       = dirname(JsonData::DECREES_FILE->path());
-        $backupSrc = $this->backupDir . '/decrees';
-        // Only wipe the live directory when a non-empty backup exists to restore from;
-        // otherwise we would destroy the real decrees data with nothing to put back.
-        if (is_dir($backupSrc) && count(glob($backupSrc . '/*') ?: []) > 0) {
-            $exitCode = 1;
-            exec(sprintf('rm -rf %s && cp -r %s %s', escapeshellarg($src), escapeshellarg($backupSrc), escapeshellarg($src)), result_code: $exitCode);
-            if ($exitCode !== 0) {
-                // Keep the backup dir around for manual recovery and fail loudly.
-                parent::tearDown();
-                self::fail(sprintf('Failed to restore the decrees source data directory from backup %s; backup left in place for manual recovery.', $backupSrc));
+        foreach (scandir($from) ?: [] as $entry) {
+            if ('.' === $entry || '..' === $entry) {
+                continue;
             }
-            exec(sprintf('rm -rf %s', escapeshellarg($this->backupDir)));
-        } else {
-            trigger_error('DecreesHandlerWriteTest::tearDown: backup directory missing or empty, skipping restore.', E_USER_WARNING);
+            $source = $from . DIRECTORY_SEPARATOR . $entry;
+            $target = $to . DIRECTORY_SEPARATOR . $entry;
+            if (is_link($source)) {
+                continue;
+            }
+            if (is_dir($source)) {
+                self::copyTree($source, $target);
+                continue;
+            }
+            if (!copy($source, $target)) {
+                throw new \RuntimeException('Could not copy ' . $source . ' to ' . $target);
+            }
         }
-        parent::tearDown();
+    }
+
+    /**
+     * Recursive delete, hard-fenced to sys_get_temp_dir().
+     *
+     * Symlinks are unlinked, never descended into: the fixture root holds a symlink to
+     * the repository's `i18n/` folder, and following it would be the very class of
+     * accident this rewrite exists to remove.
+     */
+    private static function removeTree(string $dir): void
+    {
+        $tempDir = realpath(sys_get_temp_dir());
+        $target  = realpath($dir);
+        if (false === $tempDir || false === $target) {
+            return;
+        }
+        if (!str_starts_with($target . DIRECTORY_SEPARATOR, $tempDir . DIRECTORY_SEPARATOR)) {
+            throw new \RuntimeException(sprintf('Refusing to delete %s: it is outside %s.', $target, $tempDir));
+        }
+
+        foreach (scandir($target) ?: [] as $entry) {
+            if ('.' === $entry || '..' === $entry) {
+                continue;
+            }
+            $path = $target . DIRECTORY_SEPARATOR . $entry;
+            if (is_link($path) || !is_dir($path)) {
+                unlink($path);
+                continue;
+            }
+            self::removeTree($path);
+        }
+        rmdir($target);
     }
 
     /** @return array<string,mixed> */

--- a/phpunit_tests/Support/ApiServerPreflight.php
+++ b/phpunit_tests/Support/ApiServerPreflight.php
@@ -70,7 +70,8 @@ final class ApiServerPreflight
         public readonly int $httpStatus,
         public readonly string $poweredBy,
         public readonly string $contentType,
-        public readonly string $bodyExcerpt
+        public readonly string $bodyExcerpt,
+        public readonly string $location = ''
     ) {
     }
 
@@ -131,6 +132,9 @@ final class ApiServerPreflight
                 $this->poweredBy,
                 PHP_VERSION
             );
+        }
+        if ('' !== $this->location) {
+            $lines[] = sprintf('  redirect to: %s — not followed, so the fields above describe this port', $this->location);
         }
         if ('' !== $this->bodyExcerpt) {
             $lines[] = sprintf('  body:        %s', $this->bodyExcerpt);
@@ -253,6 +257,12 @@ final class ApiServerPreflight
         $poweredBy   = $normalizedHeaders['x-powered-by'] ?? ( $normalizedHeaders['server'] ?? '' );
         $contentType = $normalizedHeaders['content-type'] ?? '';
 
+        $location = $normalizedHeaders['location'] ?? '';
+
+        // A redirect is FOREIGN by construction: `$isOurs` requires 200, and this API answers
+        // /calendars directly. Reported with its target, because the realistic cause is a
+        // misconfigured base URI (API_PROTOCOL/API_HOST/API_PORT) rather than a stale container,
+        // and those two need different fixes.
         $decoded = json_decode($body, true);
         $isOurs  = 200 === $httpStatus && is_array($decoded) && array_key_exists(self::IDENTITY_KEY, $decoded);
 
@@ -262,7 +272,8 @@ final class ApiServerPreflight
             $httpStatus,
             $poweredBy,
             $contentType,
-            $isOurs ? '' : self::excerpt($body)
+            $isOurs ? '' : self::excerpt($body),
+            $isOurs ? '' : $location
         );
     }
 
@@ -303,6 +314,11 @@ final class ApiServerPreflight
                 'timeout'         => 10,
                 'connect_timeout' => 2,
                 'http_errors'     => false,
+                // Guzzle follows up to 5 redirects by default. Following one here would make
+                // every field below describe the redirect TARGET while the message still names
+                // this base URI — the probe would report on a server the tests never talk to,
+                // and a 3xx that happened to land on a healthy API would be reported as OK.
+                'allow_redirects' => false,
             ]);
             $response = $client->get($path, ['headers' => ['Accept' => 'application/json']]);
             $headers  = [];

--- a/phpunit_tests/Support/ApiServerPreflight.php
+++ b/phpunit_tests/Support/ApiServerPreflight.php
@@ -1,0 +1,319 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Support;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\TransferException;
+
+/**
+ * Answers one question for every suite that talks to a live API server: is the thing on
+ * the configured port OUR API, something else, or nothing at all? (#922)
+ *
+ * The `Routes/*` and `WebSocket/*` suites used to ask only whether the port accepted a
+ * connection. When a stale container held `127.0.0.1:8000` and 404'd every path, that
+ * produced 131 failures spread across dozens of classes, all of which read like a
+ * regression in whatever branch happened to be checked out. Establishing that they were
+ * environmental took running the same suites against a clean checkout and diffing the
+ * failing test names.
+ *
+ * The three outcomes are deliberately NOT treated alike:
+ *
+ *  - NOT_LISTENING — nothing has the port. This is the ordinary "I haven't started the
+ *    server" case and stays exactly as loud as it was: the caller skips (WebSocket) or
+ *    fails with the documented "maybe run `composer start` first?" message (ApiTestCase).
+ *  - FOREIGN — something answers, but it is not this API. This must never look like
+ *    either of the other two: not a skip (the developer would never see it) and not a
+ *    burst of assertion failures (the developer would misread it). Callers fail fast with
+ *    {@see message()}, which names what answered and what was expected.
+ *  - OK — `/calendars` returned 200 with a `litcal_metadata` body.
+ *
+ * How strong is "OK"? It proves the responder is a Liturgical Calendar API serving
+ * source data. It does NOT prove the responder is running the working tree's PHP code:
+ * a stale container of THIS project, a few commits behind, answers exactly the same way.
+ * {@see buildDrift()} is the partial answer to that — a byte comparison of one file the
+ * API serves verbatim — and its limits are documented there.
+ */
+final class ApiServerPreflight
+{
+    public const OK            = 'ok';
+    public const NOT_LISTENING = 'not-listening';
+    public const FOREIGN       = 'foreign';
+
+    /** The endpoint probed for identity: cheap, unauthenticated, and always 200 on a healthy API. */
+    private const IDENTITY_PATH = '/calendars';
+
+    /** The key every `/calendars` response carries, and no generic JSON 404 page does. */
+    private const IDENTITY_KEY = 'litcal_metadata';
+
+    /** A file the API serves verbatim from `jsondata/schemas/`, used by the advisory build check. */
+    private const BUILD_PROBE_PATH = '/schemas/LitCal.json';
+
+    /**
+     * One probe per base URI per process: the suites ask on every class, and the answer
+     * cannot change mid-run in any way a test could act on.
+     *
+     * @var array<string, self>
+     */
+    private static array $memo = [];
+
+    /** True once the FOREIGN banner has been written to STDERR, so it is printed once per run. */
+    private static bool $bannerPrinted = false;
+
+    /** True once the advisory build-drift comparison has run, so it costs one GET per run. */
+    private static bool $driftChecked = false;
+
+    private function __construct(
+        public readonly string $status,
+        public readonly string $baseUri,
+        public readonly int $httpStatus,
+        public readonly string $poweredBy,
+        public readonly string $contentType,
+        public readonly string $bodyExcerpt
+    ) {
+    }
+
+    /**
+     * Probe the configured server, memoised per base URI.
+     *
+     * @param null|callable(string, string): (array{int, array<string, string>, string}|null) $transport
+     *        Test seam. Receives the base URI and the path, and returns [status, headers, body],
+     *        or null when nothing is listening. When supplied, the memo is bypassed.
+     */
+    public static function inspect(string $protocol, string $host, int $port, ?callable $transport = null): self
+    {
+        $baseUri = sprintf('%s://%s:%d', $protocol, $host, $port);
+
+        // An injected transport belongs to a single test: never read or write the memo for it.
+        if (null !== $transport) {
+            return self::evaluate($baseUri, $transport);
+        }
+
+        return self::$memo[$baseUri] ??= self::evaluate($baseUri, self::realTransport(...));
+    }
+
+    public function ok(): bool
+    {
+        return self::OK === $this->status;
+    }
+
+    public function isForeign(): bool
+    {
+        return self::FOREIGN === $this->status;
+    }
+
+    /**
+     * Full diagnostic for the FOREIGN case: what answered, what was expected, and the
+     * two things that realistically cause it. Written to be readable in a PHPUnit
+     * failure message, where it is the only thing the developer will see.
+     */
+    public function message(): string
+    {
+        if (!$this->isForeign()) {
+            return sprintf('API preflight on %s: %s.', $this->baseUri, $this->status);
+        }
+
+        $lines = [
+            sprintf('Something is listening on %s, but it is not this API (#922).', $this->baseUri),
+            '',
+            sprintf('  probed:      GET %s%s', $this->baseUri, self::IDENTITY_PATH),
+            sprintf(
+                '  responded:   %s%s',
+                0 === $this->httpStatus ? 'no HTTP response' : 'HTTP ' . $this->httpStatus,
+                '' === $this->contentType ? '' : ' (' . $this->contentType . ')'
+            ),
+        ];
+
+        if ('' !== $this->poweredBy) {
+            $lines[] = sprintf(
+                '  served by:   %s — this test process runs PHP %s',
+                $this->poweredBy,
+                PHP_VERSION
+            );
+        }
+        if ('' !== $this->bodyExcerpt) {
+            $lines[] = sprintf('  body:        %s', $this->bodyExcerpt);
+        }
+
+        $lines[] = sprintf('  expected:    HTTP 200 with a JSON body containing "%s"', self::IDENTITY_KEY);
+        $lines[] = '';
+        $lines[] = 'A stale container (or another project) is holding the port. Recreate it, or move these tests:';
+        $lines[] = '  docker compose up -d --force-recreate litcal-api';
+        $lines[] = '  ./stop-server.sh && composer start';
+        $lines[] = '  API_PORT=<free port> in .env.local';
+        $lines[] = '';
+        $lines[] = 'This is deliberately an error and not a skip: a foreign server on the port otherwise';
+        $lines[] = 'produces a suite-wide burst of failures that reads like a regression in your branch.';
+
+        return implode(PHP_EOL, $lines);
+    }
+
+    /**
+     * Advisory only, and only a partial answer to "is this the code under test?".
+     *
+     * Compares one file the API serves verbatim out of `jsondata/schemas/` with the same
+     * file in the working tree. A mismatch proves the server is serving a different
+     * checkout. A match proves only that this one file agrees: a stale container whose
+     * schemas are unchanged — the common case for a code-only change — matches happily.
+     * That is why this never fails a test; it only prints a warning worth checking when
+     * results look impossible.
+     *
+     * @param null|callable(string, string): (array{int, array<string, string>, string}|null) $transport
+     * @return string|null A human-readable warning, or null when nothing looks wrong (or
+     *                     when the comparison could not be made at all).
+     */
+    public function buildDrift(string $projectRoot, ?callable $transport = null): ?string
+    {
+        if (!$this->ok()) {
+            return null;
+        }
+
+        $localFile = rtrim($projectRoot, DIRECTORY_SEPARATOR) . '/jsondata/schemas/LitCal.json';
+        if (!is_file($localFile)) {
+            return null;
+        }
+
+        $transport ??= self::realTransport(...);
+        $response    = $transport($this->baseUri, self::BUILD_PROBE_PATH);
+        if (null === $response || 200 !== $response[0]) {
+            return null;
+        }
+
+        $servedHash = hash('sha256', $response[2]);
+        $localHash  = hash('sha256', (string) file_get_contents($localFile));
+        if ($servedHash === $localHash) {
+            return null;
+        }
+
+        return sprintf(
+            'API build drift: %s%s does not match this working tree\'s jsondata/schemas/LitCal.json '
+            . '(served sha256 %s, local %s). The server on %s is serving a different checkout — '
+            . 'results from Routes/ and WebSocket/ describe THAT build, not yours.',
+            $this->baseUri,
+            self::BUILD_PROBE_PATH,
+            substr($servedHash, 0, 12),
+            substr($localHash, 0, 12),
+            $this->baseUri
+        );
+    }
+
+    /** Print the FOREIGN diagnostic to STDERR once per process, ahead of the per-class errors. */
+    public function announceOnce(): void
+    {
+        if (self::$bannerPrinted || !$this->isForeign()) {
+            return;
+        }
+        self::$bannerPrinted = true;
+        fwrite(STDERR, PHP_EOL . $this->message() . PHP_EOL . PHP_EOL);
+    }
+
+    /**
+     * Run the advisory build comparison once per process and print any warning to STDERR.
+     * Never fails anything: see buildDrift() for what a clean result does and does not prove.
+     */
+    public function warnOnBuildDriftOnce(string $projectRoot): void
+    {
+        if (self::$driftChecked) {
+            return;
+        }
+        self::$driftChecked = true;
+
+        $drift = $this->buildDrift($projectRoot);
+        if (null !== $drift) {
+            fwrite(STDERR, PHP_EOL . 'WARNING: ' . $drift . PHP_EOL . PHP_EOL);
+        }
+    }
+
+    /** Drop the memo and the once-per-run latches. For tests of this class only. */
+    public static function reset(): void
+    {
+        self::$memo          = [];
+        self::$bannerPrinted = false;
+        self::$driftChecked  = false;
+    }
+
+    /**
+     * @param callable(string, string): (array{int, array<string, string>, string}|null) $transport
+     */
+    private static function evaluate(string $baseUri, callable $transport): self
+    {
+        $response = $transport($baseUri, self::IDENTITY_PATH);
+
+        if (null === $response) {
+            return new self(self::NOT_LISTENING, $baseUri, 0, '', '', '');
+        }
+
+        [$httpStatus, $headers, $body] = $response;
+
+        $normalizedHeaders = [];
+        foreach ($headers as $name => $value) {
+            $normalizedHeaders[strtolower($name)] = $value;
+        }
+        $poweredBy   = $normalizedHeaders['x-powered-by'] ?? ( $normalizedHeaders['server'] ?? '' );
+        $contentType = $normalizedHeaders['content-type'] ?? '';
+
+        $decoded = json_decode($body, true);
+        $isOurs  = 200 === $httpStatus && is_array($decoded) && array_key_exists(self::IDENTITY_KEY, $decoded);
+
+        return new self(
+            $isOurs ? self::OK : self::FOREIGN,
+            $baseUri,
+            $httpStatus,
+            $poweredBy,
+            $contentType,
+            $isOurs ? '' : self::excerpt($body)
+        );
+    }
+
+    /** Single-line, bounded excerpt of a response body, for the diagnostic. */
+    private static function excerpt(string $body): string
+    {
+        $collapsed = trim((string) preg_replace('/\s+/', ' ', $body));
+        if ('' === $collapsed) {
+            return '(empty)';
+        }
+        return strlen($collapsed) > 160 ? substr($collapsed, 0, 157) . '...' : $collapsed;
+    }
+
+    /**
+     * The real probe: a TCP connect (so "nothing listening" is answered without waiting on
+     * an HTTP timeout) followed by one GET.
+     *
+     * @return array{int, array<string, string>, string}|null
+     */
+    private static function realTransport(string $baseUri, string $path): ?array
+    {
+        $parts = parse_url($baseUri);
+        $host  = is_array($parts) && isset($parts['host']) ? (string) $parts['host'] : '';
+        $port  = is_array($parts) && isset($parts['port']) ? (int) $parts['port'] : 80;
+        if ('' === $host) {
+            return null;
+        }
+
+        $socket = @stream_socket_client(sprintf('tcp://%s:%d', $host, $port), $errno, $errstr, 2.0);
+        if (false === $socket) {
+            return null;
+        }
+        fclose($socket);
+
+        try {
+            $client   = new Client([
+                'base_uri'        => $baseUri,
+                'timeout'         => 10,
+                'connect_timeout' => 2,
+                'http_errors'     => false,
+            ]);
+            $response = $client->get($path, ['headers' => ['Accept' => 'application/json']]);
+            $headers  = [];
+            foreach ($response->getHeaders() as $name => $values) {
+                $headers[$name] = implode(', ', $values);
+            }
+            return [$response->getStatusCode(), $headers, (string) $response->getBody()];
+        } catch (TransferException $e) {
+            // The port accepted a connection but no HTTP response came back: still "something
+            // is there that isn't us", which is exactly the FOREIGN case.
+            return [0, [], 'transport error: ' . $e->getMessage()];
+        }
+    }
+}

--- a/phpunit_tests/Support/ApiServerPreflightTest.php
+++ b/phpunit_tests/Support/ApiServerPreflightTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Support;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The preflight's whole value is that it separates three outcomes a bare TCP probe
+ * conflates, so each of the three is asserted here through the injected transport seam
+ * rather than against a live port (#922).
+ */
+#[CoversClass(ApiServerPreflight::class)]
+final class ApiServerPreflightTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        ApiServerPreflight::reset();
+    }
+
+    /**
+     * @param array{int, array<string, string>, string}|null $response
+     * @return callable(string, string): (array{int, array<string, string>, string}|null)
+     */
+    private static function transportReturning(?array $response): callable
+    {
+        return static fn (string $baseUri, string $path): ?array => $response;
+    }
+
+    public function testNothingListeningIsNeitherOkNorForeign(): void
+    {
+        $preflight = ApiServerPreflight::inspect('http', 'localhost', 8000, self::transportReturning(null));
+
+        self::assertSame(ApiServerPreflight::NOT_LISTENING, $preflight->status);
+        self::assertFalse($preflight->ok());
+        // The caller must be free to skip: an absent server is the ordinary
+        // "I haven't run `composer start`" case, not a broken environment.
+        self::assertFalse($preflight->isForeign());
+    }
+
+    public function testA404FromAForeignServerIsReportedWithItsSignature(): void
+    {
+        // The exact shape observed in #922: a containerised PHP holding the port and
+        // 404ing every path, with a patch version different from the local CLI's.
+        $preflight = ApiServerPreflight::inspect('http', 'localhost', 8000, self::transportReturning([
+            404,
+            ['X-Powered-By' => 'PHP/8.4.20', 'Content-Type' => 'text/html; charset=UTF-8'],
+            '<!doctype html><html><head><title>404 Not Found</title></head><body><h1>Not Found</h1></body></html>',
+        ]));
+
+        self::assertTrue($preflight->isForeign());
+        self::assertFalse($preflight->ok());
+
+        $message = $preflight->message();
+        self::assertStringContainsString('is not this API', $message);
+        self::assertStringContainsString('http://localhost:8000/calendars', $message);
+        self::assertStringContainsString('HTTP 404', $message);
+        self::assertStringContainsString('PHP/8.4.20', $message);
+        self::assertStringContainsString('litcal_metadata', $message);
+        self::assertStringContainsString('404 Not Found', $message, 'the body excerpt is the evidence of what answered');
+        self::assertStringContainsString('force-recreate', $message, 'the diagnostic must name a remedy');
+    }
+
+    public function testA200ThatIsNotOurPayloadIsForeign(): void
+    {
+        // The dangerous variant: a healthy-looking JSON 200 from something else entirely.
+        $preflight = ApiServerPreflight::inspect('http', 'localhost', 8000, self::transportReturning([
+            200,
+            ['Content-Type' => 'application/json'],
+            '{"status":"ok"}',
+        ]));
+
+        self::assertTrue($preflight->isForeign());
+    }
+
+    public function testOurApiIsRecognised(): void
+    {
+        $preflight = ApiServerPreflight::inspect('http', 'localhost', 8000, self::transportReturning([
+            200,
+            ['Content-Type' => 'application/json'],
+            '{"litcal_metadata":{"national_calendars_keys":["VA"]}}',
+        ]));
+
+        self::assertTrue($preflight->ok());
+        self::assertFalse($preflight->isForeign());
+        self::assertStringNotContainsString('is not this API', $preflight->message());
+    }
+
+    public function testAnInjectedTransportNeverPoisonsTheProcessMemo(): void
+    {
+        $foreign = ApiServerPreflight::inspect('http', 'localhost', 8000, self::transportReturning([404, [], 'nope']));
+        self::assertTrue($foreign->isForeign());
+
+        $ours = ApiServerPreflight::inspect('http', 'localhost', 8000, self::transportReturning([
+            200,
+            ['Content-Type' => 'application/json'],
+            '{"litcal_metadata":{}}',
+        ]));
+        self::assertTrue($ours->ok(), 'a memoised injected result would have returned the foreign verdict here');
+    }
+
+    public function testBuildDriftIsSilentWhenTheServedFileMatchesTheWorkingTree(): void
+    {
+        $root  = dirname(__DIR__, 2);
+        $local = (string) file_get_contents($root . '/jsondata/schemas/LitCal.json');
+
+        $preflight = ApiServerPreflight::inspect('http', 'localhost', 8000, self::transportReturning([
+            200,
+            ['Content-Type' => 'application/json'],
+            '{"litcal_metadata":{}}',
+        ]));
+
+        self::assertNull($preflight->buildDrift($root, self::transportReturning([200, [], $local])));
+    }
+
+    public function testBuildDriftReportsAServerServingADifferentCheckout(): void
+    {
+        $root = dirname(__DIR__, 2);
+
+        $preflight = ApiServerPreflight::inspect('http', 'localhost', 8000, self::transportReturning([
+            200,
+            ['Content-Type' => 'application/json'],
+            '{"litcal_metadata":{}}',
+        ]));
+
+        $drift = $preflight->buildDrift($root, self::transportReturning([200, [], '{"title":"a different build"}']));
+
+        self::assertIsString($drift);
+        self::assertStringContainsString('build drift', $drift);
+        self::assertStringContainsString('different checkout', $drift);
+    }
+
+    public function testBuildDriftSaysNothingWhenTheServerIsNotEvenOurs(): void
+    {
+        $preflight = ApiServerPreflight::inspect('http', 'localhost', 8000, self::transportReturning([404, [], 'nope']));
+
+        // A foreign server is already reported as an error; a second, weaker complaint
+        // about its files would only add noise.
+        self::assertNull($preflight->buildDrift(dirname(__DIR__, 2), self::transportReturning([200, [], 'anything'])));
+    }
+}

--- a/phpunit_tests/Support/ApiServerPreflightTest.php
+++ b/phpunit_tests/Support/ApiServerPreflightTest.php
@@ -4,15 +4,19 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Support;
 
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 /**
  * The preflight's whole value is that it separates three outcomes a bare TCP probe
  * conflates, so each of the three is asserted here through the injected transport seam
  * rather than against a live port (#922).
+ *
+ * No #[CoversClass]: ApiServerPreflight is test-support code under phpunit_tests/, which is
+ * outside the coverage whitelist (src/ only). Naming it as a coverage target makes the
+ * coverage run emit "is not a valid target for code coverage" — eight warnings that fail
+ * `composer test:coverage` in CI while `composer test:quick`, which collects no coverage,
+ * stays green.
  */
-#[CoversClass(ApiServerPreflight::class)]
 final class ApiServerPreflightTest extends TestCase
 {
     protected function tearDown(): void

--- a/phpunit_tests/Support/ApiServerPreflightTest.php
+++ b/phpunit_tests/Support/ApiServerPreflightTest.php
@@ -105,6 +105,42 @@ final class ApiServerPreflightTest extends TestCase
         self::assertTrue($ours->ok(), 'a memoised injected result would have returned the foreign verdict here');
     }
 
+    /**
+     * A 3xx is FOREIGN, and is reported with its target rather than followed.
+     *
+     * Guzzle follows redirects by default, which would make every reported field describe the
+     * redirect target while the message still named this base URI — and a redirect that happened
+     * to land on a healthy API would be classified OK, certifying a server the tests never talk to.
+     */
+    public function testARedirectIsForeignAndNamesItsTargetWithoutBeingFollowed(): void
+    {
+        $preflight = ApiServerPreflight::inspect('http', 'localhost', 8000, self::transportReturning([
+            302,
+            ['Location' => 'https://api.example.test/calendars', 'Content-Type' => 'text/html'],
+            '<html><body>Moved</body></html>',
+        ]));
+
+        self::assertTrue($preflight->isForeign(), 'a 3xx is not this API answering /calendars');
+        self::assertFalse($preflight->ok());
+        self::assertSame(302, $preflight->httpStatus, 'the 3xx itself must survive to evaluate()');
+        self::assertSame('https://api.example.test/calendars', $preflight->location);
+        self::assertStringContainsString('https://api.example.test/calendars', $preflight->message());
+        self::assertStringContainsString('not followed', $preflight->message());
+    }
+
+    /** A Location on an otherwise-OK response is not reported: there is nothing to explain. */
+    public function testLocationIsNotReportedWhenTheServerIsOurs(): void
+    {
+        $preflight = ApiServerPreflight::inspect('http', 'localhost', 8000, self::transportReturning([
+            200,
+            ['Location' => 'https://api.example.test/elsewhere', 'Content-Type' => 'application/json'],
+            '{"litcal_metadata":{}}',
+        ]));
+
+        self::assertTrue($preflight->ok());
+        self::assertSame('', $preflight->location);
+    }
+
     public function testBuildDriftIsSilentWhenTheServedFileMatchesTheWorkingTree(): void
     {
         $root  = dirname(__DIR__, 2);

--- a/phpunit_tests/Support/RequiresLiveApiTrait.php
+++ b/phpunit_tests/Support/RequiresLiveApiTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Support;
+
+/**
+ * The WebSocket suites' half of the #922 guard.
+ *
+ * Three of the four `WebSocket/*` classes drive actions that fan out from the Ratchet
+ * handler to the HTTP API, so they probed `API_HOST:API_PORT` with a bare TCP connect and
+ * skipped when it was refused. That answers "is anything there?", never "is it ours?" —
+ * so a stale container holding the port turned every one of those tests into a failure
+ * about liturgical data.
+ *
+ * `ApiTestCase` carries the same logic for `Routes/*`; these classes extend PHPUnit's
+ * `TestCase` directly (they are not HTTP-client tests), which is why the shared part lives
+ * in {@see ApiServerPreflight} and only the skip-versus-fail decision lives here.
+ */
+trait RequiresLiveApiTrait
+{
+    /**
+     * Skip when the API server is absent; fail loudly when something that is not the API
+     * holds its port.
+     *
+     * @param string $why Appended to the skip message: what this class needs the API for.
+     */
+    protected function requireLiveApi(string $host, int $port, string $why = ''): void
+    {
+        $preflight = ApiServerPreflight::inspect(
+            (string) ( $_ENV['API_PROTOCOL'] ?? 'http' ),
+            $host,
+            $port
+        );
+
+        if ($preflight->isForeign()) {
+            $preflight->announceOnce();
+            self::fail($preflight->message());
+        }
+
+        if (false === $preflight->ok()) {
+            $this->markTestSkipped(trim(sprintf(
+                'HTTP API not reachable on %s:%d — start it with `composer start`. %s',
+                $host,
+                $port,
+                $why
+            )));
+        }
+    }
+}

--- a/phpunit_tests/WebSocket/ExecuteUnitTestTest.php
+++ b/phpunit_tests/WebSocket/ExecuteUnitTestTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\WebSocket;
 
+use LiturgicalCalendar\Tests\Support\RequiresLiveApiTrait;
 use LiturgicalCalendar\Tests\Support\WsAuthTrait;
 use PHPUnit\Framework\TestCase;
 
@@ -31,6 +32,7 @@ final class ExecuteUnitTestTest extends TestCase
     // Since #894 a run-starting action needs a credential on the handshake. See the trait for why
     // the absence of JWT_SECRET must skip rather than pass.
     use WsAuthTrait;
+    use RequiresLiveApiTrait;
 
     private string $wsHost;
     private int $wsPort;
@@ -57,23 +59,13 @@ final class ExecuteUnitTestTest extends TestCase
         }
         fclose($wsProbe);
 
-        $apiProbe = @stream_socket_client(
-            sprintf('tcp://%s:%d', $this->apiHost, $this->apiPort),
-            $_e,
-            $_m,
-            1.0
+        // Skips when the API is absent, fails with a diagnostic when something that is not
+        // the API holds its port (#922).
+        $this->requireLiveApi(
+            $this->apiHost,
+            $this->apiPort,
+            'executeUnitTest needs both the WS server AND the HTTP API.'
         );
-        if ($apiProbe === false) {
-            $this->markTestSkipped(
-                sprintf(
-                    'HTTP API not reachable on %s:%d — start it with `composer start`. '
-                    . 'executeUnitTest needs both the WS server AND the HTTP API.',
-                    $this->apiHost,
-                    $this->apiPort
-                )
-            );
-        }
-        fclose($apiProbe);
     }
 
     /**

--- a/phpunit_tests/WebSocket/ExecuteValidationTest.php
+++ b/phpunit_tests/WebSocket/ExecuteValidationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests\WebSocket;
 
 use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
+use LiturgicalCalendar\Tests\Support\RequiresLiveApiTrait;
 use LiturgicalCalendar\Tests\Support\WsAuthTrait;
 use PHPUnit\Framework\TestCase;
 
@@ -38,6 +39,7 @@ final class ExecuteValidationTest extends TestCase
     // Since #894 a run-starting action needs a credential on the handshake. See the trait for why
     // the absence of JWT_SECRET must skip rather than pass.
     use WsAuthTrait;
+    use RequiresLiveApiTrait;
 
     private string $wsHost;
     private int $wsPort;
@@ -59,13 +61,9 @@ final class ExecuteValidationTest extends TestCase
         }
         fclose($wsProbe);
 
-        $apiProbe = @stream_socket_client(sprintf('tcp://%s:%d', $this->apiHost, $this->apiPort), $_e, $_m, 1.0);
-        if ($apiProbe === false) {
-            $this->markTestSkipped(
-                sprintf('HTTP API not reachable on %s:%d — start it with `composer start`.', $this->apiHost, $this->apiPort)
-            );
-        }
-        fclose($apiProbe);
+        // Skips when the API is absent, fails with a diagnostic when something that is not
+        // the API holds its port (#922).
+        $this->requireLiveApi($this->apiHost, $this->apiPort);
     }
 
     /**

--- a/phpunit_tests/WebSocket/ValidateCalendarTest.php
+++ b/phpunit_tests/WebSocket/ValidateCalendarTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\WebSocket;
 
+use LiturgicalCalendar\Tests\Support\RequiresLiveApiTrait;
 use LiturgicalCalendar\Tests\Support\WsAuthTrait;
 use PHPUnit\Framework\TestCase;
 
@@ -38,6 +39,7 @@ final class ValidateCalendarTest extends TestCase
     // Since #894 a run-starting action needs a credential on the handshake. See the trait for why
     // the absence of JWT_SECRET must skip rather than pass.
     use WsAuthTrait;
+    use RequiresLiveApiTrait;
 
     private string $wsHost;
     private int $wsPort;
@@ -59,13 +61,9 @@ final class ValidateCalendarTest extends TestCase
         }
         fclose($wsProbe);
 
-        $apiProbe = @stream_socket_client(sprintf('tcp://%s:%d', $this->apiHost, $this->apiPort), $_e, $_m, 1.0);
-        if ($apiProbe === false) {
-            $this->markTestSkipped(
-                sprintf('HTTP API not reachable on %s:%d — start it with `composer start`. validateCalendar needs both.', $this->apiHost, $this->apiPort)
-            );
-        }
-        fclose($apiProbe);
+        // Skips when the API is absent, fails with a diagnostic when something that is not
+        // the API holds its port (#922).
+        $this->requireLiveApi($this->apiHost, $this->apiPort, 'validateCalendar needs both.');
     }
 
     /**


### PR DESCRIPTION
Two test-infrastructure safety fixes. No production code changes.

## #921 — `DecreesHandlerWriteTest` could delete the real decrees corpus

The class backed the live `jsondata/sourcedata/rite/roman/decrees/` folder up to `/tmp` in `setUp()` and restored it in `tearDown()` with
`rm -rf <src> && cp -r <backup> <src>` in one shell command. Between those two commands the repository held **no decrees source data at all**,
so any run that never reached `tearDown()` — a fatal, an OOM kill, a `timeout`, a Ctrl-C — left tracked source data deleted (or nested as
`decrees/decrees/` when the `rm -rf` failed while the `&&` proceeded).

**Fix:** remove the window rather than narrow it. `setUpBeforeClass()` copies `jsondata/` into a temporary shadow of the project root and
repoints `Router::$apiFilePath` at it — the single seam every `JsonData::…->path()` resolves against, so the handler under test and the test's
own assertions move together. Nothing outside `sys_get_temp_dir()` is written, chmod'ed or deleted for the lifetime of the class. A preflight
also refuses to run against a tree an earlier version already damaged, naming the recovery command instead of compounding the damage.

Reproduction and proof (`timeout -s KILL <d> vendor/bin/phpunit …DecreesHandlerWriteTest.php`, then `git status`):

| SIGKILL after | before (HEAD)                                        | after (this branch)                     |
| ------------- | ---------------------------------------------------- | --------------------------------------- |
| 0.10 s        | 23 files, clean                                      | 23 files, clean                         |
| 0.15 s        | 23 files, clean                                      | 23 files, clean                         |
| 0.20 s        | 23 files, clean                                      | 23 files, clean                         |
| 0.25 s        | **0 files**, `D decrees.json`, `D i18n/*.json`, …    | 23 files, clean                         |
| 0.28 / 0.30 s | (not sampled)                                        | 23 files, clean                         |

`OK (22 tests, 53 assertions)` on a normal run, with `git status --porcelain` empty afterwards.

## #922 — 131 phantom failures from a stale container on port 8000

`Routes/*` and `WebSocket/*` asked only whether the port accepted a TCP connection. `phpunit_tests/Support/ApiServerPreflight.php` now probes
`GET /calendars` once per process and separates three answers:

- **nothing listening** — unchanged: `ApiTestCase` fails with the documented "maybe run `composer start` first?" message (and no longer hits
  `detectBinding()`'s far less informative `Could not detect API binding`); the WebSocket classes still skip.
- **listening, not ours** — a hard error, once per class, carrying the diagnostic: probed URL, status + content type, the responder's
  `X-Powered-By` against this process's PHP version, a body excerpt, what was expected, and the commands that fix it.
- **ours** — proceed, unchanged.

Verified against the real fault, which is live on the reporter's machine (a container holding `:8000` and 404ing everything):

```text
before: Tests: 11, Assertions: 13, Failures: 7   ("Failed asserting that 404 is identical to 200", ×7, cause unstated)
after:  Tests: 3,  Assertions: 0,  Errors: 3     (one per class, each carrying:)

  Something is listening on http://localhost:8000, but it is not this API (#922).
    probed:      GET http://localhost:8000/calendars
    responded:   HTTP 404 (text/html; charset=UTF-8)
    served by:   PHP/8.4.20 — this test process runs PHP 8.4.23
    body:        <!doctype html><html><head><title>404 Not Found</title>...
    expected:    HTTP 200 with a JSON body containing "litcal_metadata"
```

Against a healthy server started from this branch, `Routes/Readonly` is `OK (89 tests, 147679 assertions)` — no false positives.

**How strong is the identification?** A 200 with `litcal_metadata` proves the responder is a Liturgical Calendar API. It does **not** prove it
runs this working tree's code: a stale container of this same project answers identically, which is the realistic case. `buildDrift()` is the
partial answer — one advisory comparison per run of a file the API serves verbatim from `jsondata/schemas/` against the local copy. It proves a
mismatch, never a match (a code-only difference with identical `jsondata/` passes it), so it warns on STDERR and never fails a test. Demonstrated
firing against a server serving different bytes, and correctly silent against this branch's own server.

## Sibling audit

`phpunit_tests/Handlers/RegionalDataHandlerTest` does the same *kind* of thing to another part of `jsondata/sourcedata`: it holds HR's national
calendar and i18n file contents **in memory only** while the handler under test deletes them from the working tree, restoring them in
`tearDown()` (and creating/removing MT files). A run that dies between the DELETE and `tearDown()` leaves those tracked files deleted — same
misdiagnosis trap, same recovery (`git checkout -- jsondata/`), narrower blast radius. Not changed here; the same `Router::$apiFilePath`
redirect would fix it and is worth a follow-up. Everything else that writes under `jsondata/` in the suite either works on a temp copy already
(`Services/Locale/LocaleReadinessCheckerTest`) or only adds a file it then removes (`Support/BrokenInventoryTrait`,
`HealthSourceFileFailureArmsTest`).

## Verification

- `composer lint` — clean (exit 0)
- `composer analyse` — `[OK] No errors` (PHPStan level 10)
- `composer test:quick` — `Tests: 4154`. The 20 WebSocket errors are identical with and without this branch's changes (the WS server on :8082 is
  a container that cannot reach a worktree API); every other failure churns run to run — three full runs (branch, HEAD content, branch again)
  share exactly that 20-test core and no other failing test appears in more than one run, which is the shared-Postgres nondeterminism #922
  itself describes.

Closes #921
Closes #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuyQTWwdmkzsxxjBEJcBG3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test handling when the API is unavailable or when another service is using the expected endpoint.
  - Added clearer diagnostics for incorrect API responses and potential build mismatches.

- **Tests**
  - Standardised live API availability checks across integration and WebSocket tests.
  - Tests now use isolated temporary data, protecting shipped content from accidental modification.

- **Documentation**
  - Updated testing guidance with API preflight checks and safe data-handling rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->