### PR TITLE
feat(notifications): notify the submitter on the review decision, and document /data's `data` key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,31 @@
   reviewer or a stopped poller, since an undetected merge is indistinguishable from an unreviewed one from
   this side. See `docs/ops/change-request-runbook.md`'s "Merge detection (phase 3)" section for the full
   operator playbook.
+* **notify a change request's submitter on the review decision, not only on publication**, see issue
+  [#925](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/925). Phase 3 announced a batch
+  only once it settled on GitHub, so an approval arrived late and a **rejection arrived never**: a rejected
+  batch is never published, so no notification was generated at all, and the only way an editor learned their
+  work was refused was to notice a status change on `GET /auth/change-requests`. `GET /auth/notifications`
+  now carries a third item shape, `change_request_reviewed`, whose `review_status` (`approved`/`rejected`)
+  and `rejected_reason` let a client tell the two outcomes apart without a second request. It is additive:
+  the `items` list was already a discriminated union and clients were already required to switch on `type`.
+  One item per batch, keyed on a new `sourcedata_change_requests.review_decision` column that records the
+  outcome AS DECIDED — deliberately not `review_status`, which merge detection rewrites to `rejected` when a
+  published batch's pull request closes unmerged, on a batch a human approved. A decision an editor made on
+  their own batch (the auto-approval a resource admin's own write receives inline) produces no notification:
+  the write response already answered `disposition: "approved"`. Historical decisions are backfilled, so they
+  become visible the first time a user opens their inbox.
+* **document the `data` key the `/data/*` write responses have always emitted**, see issue
+  [#933](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/933). All fourteen `PUT`/`PATCH`
+  response schemas were `additionalProperties: false` and declared only `success`, `disposition` and
+  `change_request`, while `RegionalDataHandler` also sets `data` — so a strict response validator rejected a
+  response the API is designed to return, and a client generated from the spec did not know the key existed.
+  No behaviour changes: `data` is documented rather than removed, because removing it is a contract change
+  the frontend must land first. The documentation states the trap explicitly — `data` is set from the raw
+  payload **unconditionally**, in both write modes, so under a `submitted` or `approved` disposition nothing
+  was written and it is the *proposed* payload rather than a stored resource. Clients must branch on
+  `disposition` before trusting it. A new test drives the real handler and validates its response against the
+  documented schema, so the two cannot drift again.
 * **`PATCH` on the seven `/data/*` calendar routes now answers `200 OK` instead of `201 Created`**, see
   issue [#913](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/913). The affected
   routes are `/data/nation/{key}`, `/data/roman/nation/{key}`, `/data/diocese/{key}`,

--- a/docs/superpowers/specs/2026-08-30-sourcedata-merge-detection-design.md
+++ b/docs/superpowers/specs/2026-08-30-sourcedata-merge-detection-design.md
@@ -243,6 +243,15 @@ produces. Review decisions (approve, reject at the gate) are equally notificatio
 unnotified today, but that is a phase-1 gap and belongs to its own issue rather than being smuggled
 in here.
 
+> **Amended, #925.** That issue was filed and closed the gap: a third item type,
+> `change_request_reviewed`, reports the decision itself. A batch can now produce one item of each
+> kind at different times, and a REJECTED batch — which never publishes, and so produced nothing at
+> all under phase 3 alone — produces the review item. Its cursor is `approved_at`, which
+> `decideBatch()` stamps for both outcomes under its single-shot `review_status = 'submitted'`
+> guard; the outcome itself is a new `review_decision` column, because `review_status` is the
+> batch's current position and `markBatchClosedUnmerged()` rewrites it to `rejected` on a batch a
+> human approved. Decisions an editor made on their own batch are suppressed.
+
 ### Merged in PHP, not in SQL
 
 `fetchInbox()` queries each source separately, merges the two lists in PHP, sorts by timestamp

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -6467,6 +6467,11 @@
                         "National calendar created for nation {NATION}"
                       ]
                     },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The payload the request proposed, echoed back with its `i18n` member removed — those translations are written as separate per-locale files, and the handler strips the member before echoing.\n\n**Not necessarily a stored resource. Branch on `disposition` before trusting it.** The handler sets this key UNCONDITIONALLY, in both write modes. Only `disposition: \"applied\"` means the bytes were written to the source-data tree and this describes what is now stored. Under `submitted` or `approved` the write was recorded as a change request and NOTHING was written: this is the PROPOSED content, and reading it as a stored resource — registering the `metadata.diocese_id` it names as an existing calendar, say — reports a queued write as a completed one.\n\nDocumented rather than required: it is emitted on every write response today, and is declared here so a strict response validator stops rejecting a response the API is designed to return (#933). It is deliberately absent from `required` because the better long-term shape is to stop emitting it when the disposition is not `applied`, and clients must not be built to depend on its presence."
+                    },
                     "disposition": {
                       "$ref": "#/components/schemas/ChangeRequestDisposition"
                     },
@@ -6625,6 +6630,11 @@
                     "success": {
                       "type": "string",
                       "example": "National calendar updated for nation {NATION}"
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The payload the request proposed, echoed back with its `i18n` member removed — those translations are written as separate per-locale files, and the handler strips the member before echoing.\n\n**Not necessarily a stored resource. Branch on `disposition` before trusting it.** The handler sets this key UNCONDITIONALLY, in both write modes. Only `disposition: \"applied\"` means the bytes were written to the source-data tree and this describes what is now stored. Under `submitted` or `approved` the write was recorded as a change request and NOTHING was written: this is the PROPOSED content, and reading it as a stored resource — registering the `metadata.diocese_id` it names as an existing calendar, say — reports a queued write as a completed one.\n\nDocumented rather than required: it is emitted on every write response today, and is declared here so a strict response validator stops rejecting a response the API is designed to return (#933). It is deliberately absent from `required` because the better long-term shape is to stop emitting it when the disposition is not `applied`, and clients must not be built to depend on its presence."
                     },
                     "disposition": {
                       "$ref": "#/components/schemas/ChangeRequestDisposition"
@@ -6808,6 +6818,11 @@
                         "National calendar created for nation {NATION}"
                       ]
                     },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The payload the request proposed, echoed back with its `i18n` member removed — those translations are written as separate per-locale files, and the handler strips the member before echoing.\n\n**Not necessarily a stored resource. Branch on `disposition` before trusting it.** The handler sets this key UNCONDITIONALLY, in both write modes. Only `disposition: \"applied\"` means the bytes were written to the source-data tree and this describes what is now stored. Under `submitted` or `approved` the write was recorded as a change request and NOTHING was written: this is the PROPOSED content, and reading it as a stored resource — registering the `metadata.diocese_id` it names as an existing calendar, say — reports a queued write as a completed one.\n\nDocumented rather than required: it is emitted on every write response today, and is declared here so a strict response validator stops rejecting a response the API is designed to return (#933). It is deliberately absent from `required` because the better long-term shape is to stop emitting it when the disposition is not `applied`, and clients must not be built to depend on its presence."
+                    },
                     "disposition": {
                       "$ref": "#/components/schemas/ChangeRequestDisposition"
                     },
@@ -6958,6 +6973,11 @@
                     "success": {
                       "type": "string",
                       "example": "National calendar updated for nation {NATION}"
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The payload the request proposed, echoed back with its `i18n` member removed — those translations are written as separate per-locale files, and the handler strips the member before echoing.\n\n**Not necessarily a stored resource. Branch on `disposition` before trusting it.** The handler sets this key UNCONDITIONALLY, in both write modes. Only `disposition: \"applied\"` means the bytes were written to the source-data tree and this describes what is now stored. Under `submitted` or `approved` the write was recorded as a change request and NOTHING was written: this is the PROPOSED content, and reading it as a stored resource — registering the `metadata.diocese_id` it names as an existing calendar, say — reports a queued write as a completed one.\n\nDocumented rather than required: it is emitted on every write response today, and is declared here so a strict response validator stops rejecting a response the API is designed to return (#933). It is deliberately absent from `required` because the better long-term shape is to stop emitting it when the disposition is not `applied`, and clients must not be built to depend on its presence."
                     },
                     "disposition": {
                       "$ref": "#/components/schemas/ChangeRequestDisposition"
@@ -7147,6 +7167,11 @@
                         "Diocesan calendar created for diocese {DIOCESE}"
                       ]
                     },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The payload the request proposed, echoed back with its `i18n` member removed — those translations are written as separate per-locale files, and the handler strips the member before echoing.\n\n**Not necessarily a stored resource. Branch on `disposition` before trusting it.** The handler sets this key UNCONDITIONALLY, in both write modes. Only `disposition: \"applied\"` means the bytes were written to the source-data tree and this describes what is now stored. Under `submitted` or `approved` the write was recorded as a change request and NOTHING was written: this is the PROPOSED content, and reading it as a stored resource — registering the `metadata.diocese_id` it names as an existing calendar, say — reports a queued write as a completed one.\n\nDocumented rather than required: it is emitted on every write response today, and is declared here so a strict response validator stops rejecting a response the API is designed to return (#933). It is deliberately absent from `required` because the better long-term shape is to stop emitting it when the disposition is not `applied`, and clients must not be built to depend on its presence."
+                    },
                     "disposition": {
                       "$ref": "#/components/schemas/ChangeRequestDisposition"
                     },
@@ -7304,6 +7329,11 @@
                     "success": {
                       "type": "string",
                       "example": "Diocesan calendar updated for diocese {DIOCESE}"
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The payload the request proposed, echoed back with its `i18n` member removed — those translations are written as separate per-locale files, and the handler strips the member before echoing.\n\n**Not necessarily a stored resource. Branch on `disposition` before trusting it.** The handler sets this key UNCONDITIONALLY, in both write modes. Only `disposition: \"applied\"` means the bytes were written to the source-data tree and this describes what is now stored. Under `submitted` or `approved` the write was recorded as a change request and NOTHING was written: this is the PROPOSED content, and reading it as a stored resource — registering the `metadata.diocese_id` it names as an existing calendar, say — reports a queued write as a completed one.\n\nDocumented rather than required: it is emitted on every write response today, and is declared here so a strict response validator stops rejecting a response the API is designed to return (#933). It is deliberately absent from `required` because the better long-term shape is to stop emitting it when the disposition is not `applied`, and clients must not be built to depend on its presence."
                     },
                     "disposition": {
                       "$ref": "#/components/schemas/ChangeRequestDisposition"
@@ -7489,6 +7519,11 @@
                         "Diocesan calendar created for diocese {DIOCESE}"
                       ]
                     },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The payload the request proposed, echoed back with its `i18n` member removed — those translations are written as separate per-locale files, and the handler strips the member before echoing.\n\n**Not necessarily a stored resource. Branch on `disposition` before trusting it.** The handler sets this key UNCONDITIONALLY, in both write modes. Only `disposition: \"applied\"` means the bytes were written to the source-data tree and this describes what is now stored. Under `submitted` or `approved` the write was recorded as a change request and NOTHING was written: this is the PROPOSED content, and reading it as a stored resource — registering the `metadata.diocese_id` it names as an existing calendar, say — reports a queued write as a completed one.\n\nDocumented rather than required: it is emitted on every write response today, and is declared here so a strict response validator stops rejecting a response the API is designed to return (#933). It is deliberately absent from `required` because the better long-term shape is to stop emitting it when the disposition is not `applied`, and clients must not be built to depend on its presence."
+                    },
                     "disposition": {
                       "$ref": "#/components/schemas/ChangeRequestDisposition"
                     },
@@ -7639,6 +7674,11 @@
                     "success": {
                       "type": "string",
                       "example": "Diocesan calendar updated for diocese {DIOCESE}"
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The payload the request proposed, echoed back with its `i18n` member removed — those translations are written as separate per-locale files, and the handler strips the member before echoing.\n\n**Not necessarily a stored resource. Branch on `disposition` before trusting it.** The handler sets this key UNCONDITIONALLY, in both write modes. Only `disposition: \"applied\"` means the bytes were written to the source-data tree and this describes what is now stored. Under `submitted` or `approved` the write was recorded as a change request and NOTHING was written: this is the PROPOSED content, and reading it as a stored resource — registering the `metadata.diocese_id` it names as an existing calendar, say — reports a queued write as a completed one.\n\nDocumented rather than required: it is emitted on every write response today, and is declared here so a strict response validator stops rejecting a response the API is designed to return (#933). It is deliberately absent from `required` because the better long-term shape is to stop emitting it when the disposition is not `applied`, and clients must not be built to depend on its presence."
                     },
                     "disposition": {
                       "$ref": "#/components/schemas/ChangeRequestDisposition"
@@ -7830,6 +7870,11 @@
                         "Wider region calendar created for region {REGION}"
                       ]
                     },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The payload the request proposed, echoed back with its `i18n` member removed — those translations are written as separate per-locale files, and the handler strips the member before echoing.\n\n**Not necessarily a stored resource. Branch on `disposition` before trusting it.** The handler sets this key UNCONDITIONALLY, in both write modes. Only `disposition: \"applied\"` means the bytes were written to the source-data tree and this describes what is now stored. Under `submitted` or `approved` the write was recorded as a change request and NOTHING was written: this is the PROPOSED content, and reading it as a stored resource — registering the `metadata.diocese_id` it names as an existing calendar, say — reports a queued write as a completed one.\n\nDocumented rather than required: it is emitted on every write response today, and is declared here so a strict response validator stops rejecting a response the API is designed to return (#933). It is deliberately absent from `required` because the better long-term shape is to stop emitting it when the disposition is not `applied`, and clients must not be built to depend on its presence."
+                    },
                     "disposition": {
                       "$ref": "#/components/schemas/ChangeRequestDisposition"
                     },
@@ -7987,6 +8032,11 @@
                     "success": {
                       "type": "string",
                       "example": "Wider region calendar updated for region {REGION}"
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The payload the request proposed, echoed back with its `i18n` member removed — those translations are written as separate per-locale files, and the handler strips the member before echoing.\n\n**Not necessarily a stored resource. Branch on `disposition` before trusting it.** The handler sets this key UNCONDITIONALLY, in both write modes. Only `disposition: \"applied\"` means the bytes were written to the source-data tree and this describes what is now stored. Under `submitted` or `approved` the write was recorded as a change request and NOTHING was written: this is the PROPOSED content, and reading it as a stored resource — registering the `metadata.diocese_id` it names as an existing calendar, say — reports a queued write as a completed one.\n\nDocumented rather than required: it is emitted on every write response today, and is declared here so a strict response validator stops rejecting a response the API is designed to return (#933). It is deliberately absent from `required` because the better long-term shape is to stop emitting it when the disposition is not `applied`, and clients must not be built to depend on its presence."
                     },
                     "disposition": {
                       "$ref": "#/components/schemas/ChangeRequestDisposition"
@@ -8169,6 +8219,11 @@
                         "Wider region calendar created for region {REGION}"
                       ]
                     },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The payload the request proposed, echoed back with its `i18n` member removed — those translations are written as separate per-locale files, and the handler strips the member before echoing.\n\n**Not necessarily a stored resource. Branch on `disposition` before trusting it.** The handler sets this key UNCONDITIONALLY, in both write modes. Only `disposition: \"applied\"` means the bytes were written to the source-data tree and this describes what is now stored. Under `submitted` or `approved` the write was recorded as a change request and NOTHING was written: this is the PROPOSED content, and reading it as a stored resource — registering the `metadata.diocese_id` it names as an existing calendar, say — reports a queued write as a completed one.\n\nDocumented rather than required: it is emitted on every write response today, and is declared here so a strict response validator stops rejecting a response the API is designed to return (#933). It is deliberately absent from `required` because the better long-term shape is to stop emitting it when the disposition is not `applied`, and clients must not be built to depend on its presence."
+                    },
                     "disposition": {
                       "$ref": "#/components/schemas/ChangeRequestDisposition"
                     },
@@ -8318,6 +8373,11 @@
                     "success": {
                       "type": "string",
                       "example": "Wider region calendar updated for region {REGION}"
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The payload the request proposed, echoed back with its `i18n` member removed — those translations are written as separate per-locale files, and the handler strips the member before echoing.\n\n**Not necessarily a stored resource. Branch on `disposition` before trusting it.** The handler sets this key UNCONDITIONALLY, in both write modes. Only `disposition: \"applied\"` means the bytes were written to the source-data tree and this describes what is now stored. Under `submitted` or `approved` the write was recorded as a change request and NOTHING was written: this is the PROPOSED content, and reading it as a stored resource — registering the `metadata.diocese_id` it names as an existing calendar, say — reports a queued write as a completed one.\n\nDocumented rather than required: it is emitted on every write response today, and is declared here so a strict response validator stops rejecting a response the API is designed to return (#933). It is deliberately absent from `required` because the better long-term shape is to stop emitting it when the disposition is not `applied`, and clients must not be built to depend on its presence."
                     },
                     "disposition": {
                       "$ref": "#/components/schemas/ChangeRequestDisposition"
@@ -8496,6 +8556,11 @@
                         "Diocesan calendar created for diocese {DIOCESE}"
                       ]
                     },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The payload the request proposed, echoed back with its `i18n` member removed — those translations are written as separate per-locale files, and the handler strips the member before echoing.\n\n**Not necessarily a stored resource. Branch on `disposition` before trusting it.** The handler sets this key UNCONDITIONALLY, in both write modes. Only `disposition: \"applied\"` means the bytes were written to the source-data tree and this describes what is now stored. Under `submitted` or `approved` the write was recorded as a change request and NOTHING was written: this is the PROPOSED content, and reading it as a stored resource — registering the `metadata.diocese_id` it names as an existing calendar, say — reports a queued write as a completed one.\n\nDocumented rather than required: it is emitted on every write response today, and is declared here so a strict response validator stops rejecting a response the API is designed to return (#933). It is deliberately absent from `required` because the better long-term shape is to stop emitting it when the disposition is not `applied`, and clients must not be built to depend on its presence."
+                    },
                     "disposition": {
                       "$ref": "#/components/schemas/ChangeRequestDisposition"
                     },
@@ -8643,6 +8708,11 @@
                     "success": {
                       "type": "string",
                       "example": "Diocesan calendar updated for diocese {DIOCESE}"
+                    },
+                    "data": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "The payload the request proposed, echoed back with its `i18n` member removed — those translations are written as separate per-locale files, and the handler strips the member before echoing.\n\n**Not necessarily a stored resource. Branch on `disposition` before trusting it.** The handler sets this key UNCONDITIONALLY, in both write modes. Only `disposition: \"applied\"` means the bytes were written to the source-data tree and this describes what is now stored. Under `submitted` or `approved` the write was recorded as a change request and NOTHING was written: this is the PROPOSED content, and reading it as a stored resource — registering the `metadata.diocese_id` it names as an existing calendar, say — reports a queued write as a completed one.\n\nDocumented rather than required: it is emitted on every write response today, and is declared here so a strict response validator stops rejecting a response the API is designed to return (#933). It is deliberately absent from `required` because the better long-term shape is to stop emitting it when the disposition is not `applied`, and clients must not be built to depend on its presence."
                     },
                     "disposition": {
                       "$ref": "#/components/schemas/ChangeRequestDisposition"
@@ -14139,9 +14209,79 @@
         ],
         "additionalProperties": false
       },
+      "ChangeRequestReviewedNotification": {
+        "type": "object",
+        "description": "A single review-decision notification item in the authenticated user's inbox: a reviewer approved or REJECTED one of the caller's own submitted source-data change-request batches. One item per batch, not per file.\n\nThis is a different event from ChangeRequestNotification, at a different time, and a batch can produce one of each: the decision is when a human judged the proposal, the publication is when GitHub settled it. A rejected batch never publishes at all, so before this type existed a refusal produced no notification of any kind.\n\nDecisions the caller made on their own batch never appear here — the auto-approval a resource admin's own write receives inline is not news, and the write response already answered `disposition: \"approved\"` synchronously.\n\nOne of the shapes UserNotificationsResponse.items may contain. Discriminated on `type`; the shapes share only `type` and `unread`.",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "change_request_reviewed"
+            ],
+            "description": "Discriminator for the notification kind."
+          },
+          "batch_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "UUID shared by every sourcedata_change_requests row submitted together in this batch."
+          },
+          "resource_type": {
+            "type": "string",
+            "enum": [
+              "national_calendar",
+              "diocesan_calendar",
+              "wider_region",
+              "national_calendar_test",
+              "diocesan_calendar_test",
+              "general_roman_calendar_test",
+              "rite_calendar_test",
+              "general_roman_calendar"
+            ]
+          },
+          "resource_id": {
+            "type": "string",
+            "description": "Rite-qualified as `<rite>/<calendarId>` for calendar-naming types (e.g. `roman/US`), and for the `national_calendar_test` and `diocesan_calendar_test` scopes. Bare for `general_roman_calendar` ids such as `decrees`, and for `general_roman_calendar_test` and `rite_calendar_test`."
+          },
+          "review_status": {
+            "type": "string",
+            "enum": [
+              "approved",
+              "rejected"
+            ],
+            "description": "The decision, AS DECIDED. This is the batch's `review_decision`, frozen at the review and never rewritten — deliberately not its current `review_status`, which a later publication failure can move: a published batch whose pull request is closed unmerged is set to `rejected` even though a human approved it. That batch's close is reported separately, as a ChangeRequestNotification with `publication_status: \"closed\"`.\n\n`approved` does not mean published. An approved batch is queued for publication and settles later; watch for the ChangeRequestNotification carrying the same `batch_id`."
+          },
+          "rejected_reason": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Free-text reason the reviewer gave, when the decision was `rejected` and they supplied one. Null on an approval, and null on a rejection given without a reason. The same value the batch itself reports, so a client may show it inline here rather than fetching the batch."
+          },
+          "reviewed_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "RFC 3339 UTC timestamp of when the batch was decided. Written once, by the decision itself, and it is the cursor this item is ordered and unread-flagged by — the review-decision counterpart of ChangeRequestNotification.settled_at."
+          },
+          "unread": {
+            "type": "boolean",
+            "description": "True if reviewed_at is more recent than the user's last_seen_at bookmark."
+          }
+        },
+        "required": [
+          "type",
+          "batch_id",
+          "resource_type",
+          "resource_id",
+          "review_status",
+          "rejected_reason",
+          "reviewed_at",
+          "unread"
+        ],
+        "additionalProperties": false
+      },
       "UserNotificationsResponse": {
         "type": "object",
-        "description": "Response from GET /auth/notifications — the inbox with unread badge metadata. `items` is a discriminated union: clients MUST switch on each item's `type` (`access_request_reviewed` or `change_request_published`) before reading any other key — the two shapes share only `type` and `unread`.",
+        "description": "Response from GET /auth/notifications — the inbox with unread badge metadata. `items` is a discriminated union: clients MUST switch on each item's `type` (`access_request_reviewed`, `change_request_reviewed` or `change_request_published`) before reading any other key — the shapes share only `type` and `unread`. A change-request batch can produce both a `change_request_reviewed` item (when a human decided it) and a `change_request_published` item (when GitHub settled it), carrying the same `batch_id` at different times; a REJECTED batch never publishes and so produces only the former.",
         "properties": {
           "items": {
             "type": "array",
@@ -14152,6 +14292,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/ChangeRequestNotification"
+                },
+                {
+                  "$ref": "#/components/schemas/ChangeRequestReviewedNotification"
                 }
               ]
             }

--- a/phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php
+++ b/phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Handlers\Auth;
 
+use LiturgicalCalendar\Api\Enum\ChangeOperation;
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Handlers\Auth\NotificationsHandler;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\ChangeResource;
 use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+use Swaggest\JsonSchema\Schema;
 
 final class NotificationsHandlerTest extends AbstractHandlerTestCase
 {
@@ -254,6 +259,98 @@ final class NotificationsHandlerTest extends AbstractHandlerTestCase
                 $_SERVER['API_BASE_PATH'] = $originalServer;
             }
         }
+    }
+
+    /**
+     * A REJECTED change request reaches the inbox over the wire (#925). `AbstractHandlerTestCase`
+     * does not truncate `sourcedata_change_requests`, so this does it explicitly.
+     *
+     * @return array<string, mixed> The decoded GET /auth/notifications body.
+     */
+    private function inboxAfterRejectingABatchFor(string $sub): array
+    {
+        self::$pdo?->exec('TRUNCATE TABLE sourcedata_change_requests RESTART IDENTITY CASCADE');
+
+        $repo    = new SourceDataChangeRequestRepository(self::$pdo);
+        $batchId = $repo->submitBatch(
+            ChangeResource::nationalCalendar(Rite::ROMAN, 'US'),
+            [
+                [
+                    'path'      => 'jsondata/sourcedata/rite/roman/calendars/nations/US/US.json',
+                    'operation' => ChangeOperation::CREATE,
+                    'content'   => '{"litcal":[]}',
+                ]
+            ],
+            $sub,
+            'Submitter',
+            'submitter@example.test',
+            true
+        )['batch_id'];
+        $repo->rejectBatch($batchId, 'reviewer-1', 'Not a universal feast');
+
+        $response = ( new NotificationsHandler() )->handle(
+            $this->withOidcUser($this->requestFor('GET', '/auth/notifications'), $sub)
+        );
+        self::assertSame(200, $response->getStatusCode());
+
+        return $this->decodeJsonBody($response);
+    }
+
+    public function testGetInboxCarriesARejectedChangeRequestWithItsReason(): void
+    {
+        $body = $this->inboxAfterRejectingABatchFor('zitadel-user-rejected-1');
+
+        self::assertCount(1, $body['items']);
+        $item = $body['items'][0];
+        self::assertSame('change_request_reviewed', $item['type']);
+        self::assertSame('rejected', $item['review_status']);
+        self::assertSame('Not a universal feast', $item['rejected_reason']);
+        self::assertSame('national_calendar', $item['resource_type']);
+        self::assertSame('roman/US', $item['resource_id']);
+        self::assertTrue($item['unread']);
+        self::assertSame(1, $body['unread_count']);
+    }
+
+    /**
+     * The wire contract: the response validates against `UserNotificationsResponse` in
+     * `openapi.json`, whose `items` is a discriminated `oneOf`. Because every member is
+     * `additionalProperties: false`, a new item shape that the union does not list makes `oneOf`
+     * match zero branches and fails here — which is what stops the handler and the document
+     * drifting apart the way the `/data` write responses did (#933).
+     *
+     * Both a reviewed access request and a reviewed change request are in the inbox, so the
+     * assertion covers more than one branch of the union in a single validation.
+     */
+    public function testTheInboxValidatesAgainstTheDocumentedUnion(): void
+    {
+        $sub = 'zitadel-user-union-1';
+
+        $accessRepo = new AccessRequestRepository(self::$pdo);
+        $accessRepo->approve(
+            $accessRepo->create(
+                $sub,
+                'union@example.test',
+                'Union',
+                'calendar_editor',
+                [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+            ),
+            'admin-x',
+            'welcome'
+        );
+
+        $body = $this->inboxAfterRejectingABatchFor($sub);
+
+        self::assertSame(2, $body['total']);
+        self::assertEqualsCanonicalizing(
+            ['access_request_reviewed', 'change_request_reviewed'],
+            array_column($body['items'], 'type')
+        );
+
+        $decoded = json_decode(json_encode($body, JSON_THROW_ON_ERROR), flags: JSON_THROW_ON_ERROR);
+        Schema::import(
+            dirname(__DIR__, 3) . '/jsondata/schemas/openapi.json#/components/schemas/UserNotificationsResponse'
+        )->in($decoded);
+        $this->addToAssertionCount(1);
     }
 
     public function testGetThenSeenThenGetFlipsUnreadFlag(): void

--- a/phpunit_tests/Handlers/RegionalDataWriteResponseSchemaTest.php
+++ b/phpunit_tests/Handlers/RegionalDataWriteResponseSchemaTest.php
@@ -89,15 +89,65 @@ final class RegionalDataWriteResponseSchemaTest extends AbstractHandlerTestCase
     }
 
     /**
-     * The fourteen `/data/*` operations the issue enumerates, as (path, method, status) triples
-     * read out of the document rather than restated here — a new rite spelling picks itself up.
+     * The fourteen `/data/*` write responses this contract covers, enumerated independently of
+     * the document being checked.
      *
+     * Discovery alone cannot guard a contract it reads from its own subject: if a path were
+     * dropped from `openapi.json`, or a response lost `disposition`, a purely discovered provider
+     * would yield fewer cases and every remaining one would still pass — the suite would go green
+     * on a shrinking contract. So the set lives here, and {@see testTheDocumentedWriteSurfaceIsExactlyTheKnownFourteen}
+     * asserts the document still matches it in both directions.
+     *
+     * Adding a rite therefore reds this list on purpose. That is the point: a new rite's write
+     * routes inherit the `data` trap documented below, and someone should say so deliberately
+     * rather than have it picked up silently.
+     *
+     * @return list<array{0:string, 1:string, 2:string}>
+     */
+    private static function expectedWriteOperations(): array
+    {
+        $targets = [];
+        foreach (
+            [
+                '/data/nation/{key}',
+                '/data/roman/nation/{key}',
+                '/data/diocese/{key}',
+                '/data/roman/diocese/{key}',
+                '/data/widerregion/{key}',
+                '/data/roman/widerregion/{key}',
+                '/data/ambrosian/diocese/{key}',
+            ] as $path
+        ) {
+            // PUT creates (201), PATCH updates (200); both assemble the body the same way.
+            $targets[] = [$path, 'put', '201'];
+            $targets[] = [$path, 'patch', '200'];
+        }
+
+        return $targets;
+    }
+
+    /**
      * @return array<string, array{0:string, 1:string, 2:string}>
      */
     public static function documentedWriteOperations(): array
     {
         $operations = [];
+        foreach (self::expectedWriteOperations() as [$path, $method, $status]) {
+            $operations[strtoupper($method) . ' ' . $path . ' ' . $status] = [$path, $method, $status];
+        }
 
+        return $operations;
+    }
+
+    /**
+     * The enumerated set and the document agree, in both directions.
+     *
+     * Checked as a set rather than a count: a count catches a deletion but not a swap, and the
+     * failure message for a mismatched count tells a reader nothing about which operation moved.
+     */
+    public function testTheDocumentedWriteSurfaceIsExactlyTheKnownFourteen(): void
+    {
+        $discovered = [];
         foreach (self::openapiPaths() as $path => $pathItem) {
             if (!str_starts_with($path, '/data/')) {
                 continue;
@@ -107,16 +157,46 @@ final class RegionalDataWriteResponseSchemaTest extends AbstractHandlerTestCase
                 /** @var array<string, array<string, mixed>> $responses */
                 $responses = $pathItem[$method]['responses'];
                 foreach ($responses as $status => $response) {
-                    $schema = self::jsonSchemaOf($response);
-                    if ($schema === null || !isset($schema['properties']['disposition'])) {
+                    if (null === self::jsonSchemaOf($response)) {
                         continue;
                     }
-                    $operations[strtoupper($method) . ' ' . $path . ' ' . $status] = [$path, $method, (string) $status];
+                    $discovered[] = strtoupper($method) . ' ' . $path . ' ' . $status;
                 }
             }
         }
 
-        return $operations;
+        $expected = array_keys(self::documentedWriteOperations());
+        sort($discovered);
+        sort($expected);
+
+        self::assertSame(
+            $expected,
+            $discovered,
+            'The set of /data/* write responses in openapi.json has changed. If a rite or route was '
+            . 'added, extend expectedWriteOperations() — the new operation inherits the `data` contract.'
+        );
+    }
+
+    /**
+     * Every documented write response declares `disposition`.
+     *
+     * Asserted rather than used as a provider filter: filtering on it would let a response that
+     * lost the key vanish from the run instead of failing it.
+     */
+    #[DataProvider('documentedWriteOperations')]
+    public function testEveryDataWriteOperationDocumentsDisposition(string $path, string $method, string $status): void
+    {
+        /** @var array<string, array<string, array<string, mixed>>> $pathItem */
+        $pathItem = self::openapiPaths()[$path];
+        $schema   = self::jsonSchemaOf($pathItem[$method]['responses'][$status]);
+
+        self::assertIsArray($schema);
+        self::assertIsArray($schema['properties'] ?? null);
+        self::assertArrayHasKey(
+            'disposition',
+            $schema['properties'],
+            strtoupper($method) . " {$path} ({$status}) must document `disposition`; it is what tells a client whether `data` was stored"
+        );
     }
 
     /**

--- a/phpunit_tests/Handlers/RegionalDataWriteResponseSchemaTest.php
+++ b/phpunit_tests/Handlers/RegionalDataWriteResponseSchemaTest.php
@@ -1,0 +1,487 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Database\Connection;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\RegionalDataHandler;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
+use LiturgicalCalendar\Tests\Support\OpenApiPathItemTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Swaggest\JsonSchema\Schema;
+
+/**
+ * The `/data/*` write responses, validated against the response schemas `openapi.json` declares
+ * for them (#933).
+ *
+ * Those schemas are `additionalProperties: false` and used to declare only `success`,
+ * `disposition` and `change_request`, while `RegionalDataHandler` also sets `$responseObj->data`
+ * on every one of them. The disagreement was a **wrong-red**: a strict response validator run
+ * against a correct server rejected a response the API is designed to return, and a client
+ * generated from the document did not know the key existed even though the frontend already read
+ * it. `data` is now documented; this class is what stops the two drifting apart again.
+ *
+ * # Why queue mode
+ *
+ * Finishing a write in disk mode would create real files under `jsondata/sourcedata` — the reason
+ * `RegionalDataHandlerTest` stops short of one. Queue mode runs the identical response-assembly
+ * code (the `data` assignment is unconditional and sits above the write-mode branch) without the
+ * handler touching the filesystem, exactly as `RegionalDataQueueModeTest` does.
+ *
+ * That is also the interesting disposition. `data` is set from the raw payload whatever the mode,
+ * so under a queued write it is the PROPOSED payload and not a stored resource — the trap the
+ * documented description warns about, and the one a client that skips the `disposition` branch
+ * falls into.
+ *
+ * # Why six drives and a fourteen-operation static check
+ *
+ * The document has fourteen affected operations, but the handler has six response-assembly sites:
+ * the rite-qualified spellings (`/data/roman/nation/{key}`, `/data/ambrosian/diocese/{key}`)
+ * route to the same code as the bare ones. So the six are driven for real, and
+ * {@see testEveryDataWriteOperationDocumentsData()} asserts that all fourteen documented schemas
+ * carry an identical `data` declaration — which is what carries the live evidence across to the
+ * spellings that share the code.
+ */
+#[CoversClass(RegionalDataHandler::class)]
+final class RegionalDataWriteResponseSchemaTest extends AbstractHandlerTestCase
+{
+    use OpenApiPathItemTrait;
+
+    protected static bool $requiresDatabase = true;
+
+    /** @var array<string, string|false> */
+    private array $originalEnv = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Connection::getInstance()->exec('TRUNCATE TABLE sourcedata_change_requests RESTART IDENTITY CASCADE');
+
+        foreach ([SourceDataWriteMode::FLAG, 'OPENFGA_API_URL', 'OPENFGA_STORE_ID', 'OPENFGA_MODEL_ID'] as $key) {
+            $this->originalEnv[$key] = $_ENV[$key] ?? false;
+        }
+
+        // A store id that cannot exist, so every FGA check fails closed and the submission stays
+        // `submitted` rather than being auto-approved — the disposition under which `data` is at
+        // its most misleading, and therefore the one worth validating.
+        $_ENV[SourceDataWriteMode::FLAG] = 'true';
+        $_ENV['OPENFGA_API_URL']         = 'http://localhost:8083';
+        $_ENV['OPENFGA_STORE_ID']        = 'no-such-store-regional-response-schema-test';
+        $_ENV['OPENFGA_MODEL_ID']        = 'no-such-model-regional-response-schema-test';
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalEnv as $key => $value) {
+            if (false === $value) {
+                unset($_ENV[$key]);
+            } else {
+                $_ENV[$key] = $value;
+            }
+        }
+        $this->originalEnv = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * The fourteen `/data/*` operations the issue enumerates, as (path, method, status) triples
+     * read out of the document rather than restated here — a new rite spelling picks itself up.
+     *
+     * @return array<string, array{0:string, 1:string, 2:string}>
+     */
+    public static function documentedWriteOperations(): array
+    {
+        $operations = [];
+
+        foreach (self::openapiPaths() as $path => $pathItem) {
+            if (!str_starts_with($path, '/data/')) {
+                continue;
+            }
+
+            foreach (array_intersect(self::operationMethods($pathItem), ['put', 'patch']) as $method) {
+                /** @var array<string, array<string, mixed>> $responses */
+                $responses = $pathItem[$method]['responses'];
+                foreach ($responses as $status => $response) {
+                    $schema = self::jsonSchemaOf($response);
+                    if ($schema === null || !isset($schema['properties']['disposition'])) {
+                        continue;
+                    }
+                    $operations[strtoupper($method) . ' ' . $path . ' ' . $status] = [$path, $method, (string) $status];
+                }
+            }
+        }
+
+        return $operations;
+    }
+
+    /**
+     * Every affected operation declares `data`, and declares it identically — the response is
+     * assembled by one code path per verb, so fourteen divergent descriptions of the same key
+     * would be fourteen chances to describe it wrongly.
+     */
+    #[DataProvider('documentedWriteOperations')]
+    public function testEveryDataWriteOperationDocumentsData(string $path, string $method, string $status): void
+    {
+        /** @var array<string, array<string, array<string, mixed>>> $pathItem */
+        $pathItem = self::openapiPaths()[$path];
+        $schema   = self::jsonSchemaOf($pathItem[$method]['responses'][$status]);
+
+        self::assertIsArray($schema);
+        self::assertArrayHasKey('properties', $schema);
+        self::assertIsArray($schema['properties']);
+        self::assertArrayHasKey(
+            'data',
+            $schema['properties'],
+            strtoupper($method) . " {$path} ({$status}) is additionalProperties:false and the handler emits `data`"
+        );
+
+        /** @var array<string, mixed> $data */
+        $data = $schema['properties']['data'];
+        self::assertSame('object', $data['type'] ?? null);
+        self::assertIsString($data['description'] ?? null);
+
+        // The trap, stated in the document and not only in a commit message: `data` is the
+        // proposed payload unless the disposition says otherwise.
+        self::assertStringContainsString('disposition', $data['description']);
+        self::assertStringContainsString('applied', $data['description']);
+
+        // Not required: the response carries it today, but the documented direction is to stop
+        // emitting it on a non-`applied` disposition, and a client must not be built to need it.
+        $required = $schema['required'] ?? [];
+        self::assertIsArray($required);
+        self::assertNotContains('data', $required);
+    }
+
+    /**
+     * The six response-assembly sites in `RegionalDataHandler`, each with the operation in the
+     * document that describes it.
+     *
+     * IT is patched rather than created because `updateI18nFiles()` requires the locale files it
+     * updates to exist on disk; its single declared locale is `it_IT`, which is what the payload
+     * declares. Nothing is written either way — queue mode stages, it does not save.
+     *
+     * @return array<string, array{0:list<string>, 1:?Rite, 2:string, 3:string, 4:array<string,mixed>, 5:int, 6:string, 7:string, 8:string}>
+     */
+    public static function writeDrives(): array
+    {
+        return [
+            'PUT /data/nation/{key}'        => [
+                ['nation', 'MT'],
+                null,
+                'PUT',
+                '/data/nation/MT',
+                self::nationalPayload('MT'),
+                201,
+                '/data/nation/{key}',
+                'put',
+                '201',
+            ],
+            'PATCH /data/nation/{key}'      => [
+                ['nation', 'IT'],
+                null,
+                'PATCH',
+                '/data/nation/IT',
+                self::nationalPayload('IT'),
+                200,
+                '/data/nation/{key}',
+                'patch',
+                '200',
+            ],
+            'PUT /data/diocese/{key}'       => [
+                ['diocese', 'aachen_de'],
+                null,
+                'PUT',
+                '/data/diocese/aachen_de',
+                self::newDiocesanPayload(),
+                201,
+                '/data/diocese/{key}',
+                'put',
+                '201',
+            ],
+            'PATCH /data/diocese/{key}'     => [
+                ['diocese', 'novara_it'],
+                Rite::AMBROSIAN,
+                'PATCH',
+                '/data/diocese/novara_it',
+                self::existingDiocesanPayload(),
+                200,
+                '/data/ambrosian/diocese/{key}',
+                'patch',
+                '200',
+            ],
+            'PUT /data/widerregion/{key}'   => [
+                ['widerregion', 'Africa'],
+                null,
+                'PUT',
+                '/data/widerregion/Africa',
+                self::widerRegionPayload('Africa'),
+                201,
+                '/data/widerregion/{key}',
+                'put',
+                '201',
+            ],
+            'PATCH /data/widerregion/{key}' => [
+                ['widerregion', 'Europe'],
+                null,
+                'PATCH',
+                '/data/widerregion/Europe',
+                self::widerRegionPayload('Europe'),
+                200,
+                '/data/widerregion/{key}',
+                'patch',
+                '200',
+            ],
+        ];
+    }
+
+    /**
+     * The regression guard proper: the response the handler really produces, validated against
+     * the schema the document really declares.
+     *
+     * @param list<string>        $handlerArgs
+     * @param array<string,mixed> $payload
+     */
+    #[DataProvider('writeDrives')]
+    public function testTheRealResponseValidatesAgainstTheDocumentedSchema(
+        array $handlerArgs,
+        ?Rite $rite,
+        string $method,
+        string $route,
+        array $payload,
+        int $expectedStatus,
+        string $docPath,
+        string $docMethod,
+        string $docStatus
+    ): void {
+        $handler  = $rite === null ? new RegionalDataHandler($handlerArgs) : new RegionalDataHandler($handlerArgs, $rite);
+        $headers  = $method === 'PATCH' ? ['Accept-Language' => 'it-IT'] : [];
+        $response = $handler->handle(
+            $this->withOidcUser($this->requestFor($method, $route, $headers, $payload), 'editor-1')
+        );
+
+        self::assertSame($expectedStatus, $response->getStatusCode(), (string) $response->getBody());
+
+        $body = json_decode((string) $response->getBody(), flags: JSON_THROW_ON_ERROR);
+        self::assertInstanceOf(\stdClass::class, $body);
+
+        // The premise: the handler does emit `data`, unconditionally, even though this write was
+        // queued and nothing was stored. If this ever stops being true, the documented
+        // description above has become a lie and must be revised with it.
+        self::assertObjectHasProperty('data', $body);
+        self::assertSame('submitted', $body->disposition ?? null);
+
+        Schema::import(self::pointerTo($docPath, $docMethod, $docStatus))->in($body);
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * A `$ref`-able URI naming one response schema inside `openapi.json`, with the JSON Pointer
+     * escaping (`/` → `~1`) the path keys need.
+     */
+    private static function pointerTo(string $path, string $method, string $status): string
+    {
+        $escaped = str_replace(['~', '/'], ['~0', '~1'], $path);
+
+        return dirname(__DIR__, 2) . '/jsondata/schemas/openapi.json'
+            . "#/paths/{$escaped}/{$method}/responses/{$status}/content/application~1json/schema";
+    }
+
+    /**
+     * @var array<string, mixed>|null
+     */
+    private static ?array $openapi = null;
+
+    /**
+     * Loaded lazily: the data providers enumerate the document, and PHPUnit runs providers before
+     * any fixture method.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private static function openapiPaths(): array
+    {
+        if (null === self::$openapi) {
+            $raw = file_get_contents(dirname(__DIR__, 2) . '/jsondata/schemas/openapi.json');
+            if (false === $raw) {
+                throw new \RuntimeException('Could not read openapi.json');
+            }
+            /** @var array<string, mixed> $decoded */
+            $decoded       = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+            self::$openapi = $decoded;
+        }
+
+        /** @var array<string, array<string, mixed>> $paths */
+        $paths = self::$openapi['paths'];
+
+        return $paths;
+    }
+
+    /**
+     * The `application/json` schema of a response object, or null when it declares no JSON body.
+     *
+     * @param array<string, mixed> $response
+     *
+     * @return array<string, mixed>|null
+     */
+    private static function jsonSchemaOf(array $response): ?array
+    {
+        $content = $response['content'] ?? null;
+        if (!is_array($content) || !isset($content['application/json'])) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $json */
+        $json   = $content['application/json'];
+        $schema = $json['schema'] ?? null;
+
+        return is_array($schema) ? $schema : null;
+    }
+
+    /**
+     * A schema-valid national-calendar payload. `wider_region` is Europe for both fixture nations,
+     * and the single declared locale matches the one i18n file the PATCH path expects to find.
+     *
+     * @return array<string, mixed>
+     */
+    private static function nationalPayload(string $nation): array
+    {
+        $locale = $nation === 'IT' ? 'it_IT' : 'en_MT';
+
+        return [
+            'litcal'   => [
+                [
+                    'liturgical_event' => ['event_key' => 'StGeorgeMartyr', 'grade' => 4],
+                    'metadata'         => [
+                        'action'     => 'makePatron',
+                        'since_year' => 1868,
+                        'url'        => 'https://www.vatican.va/',
+                    ],
+                ],
+            ],
+            'settings' => [
+                'epiphany'               => 'JAN6',
+                'ascension'              => 'SUNDAY',
+                'corpus_christi'         => 'SUNDAY',
+                'eternal_high_priest'    => false,
+                'holydays_of_obligation' => [
+                    'Christmas'            => true,
+                    'Epiphany'             => false,
+                    'Ascension'            => false,
+                    'CorpusChristi'        => false,
+                    'MaryMotherOfGod'      => true,
+                    'ImmaculateConception' => true,
+                    'Assumption'           => true,
+                    'StJoseph'             => false,
+                    'StsPeterPaulAp'       => false,
+                    'AllSaints'            => false,
+                ],
+            ],
+            'metadata' => [
+                'nation'       => $nation,
+                'wider_region' => 'Europe',
+                'missals'      => ['IT_1983'],
+                'locales'      => [$locale],
+            ],
+            'i18n'     => [
+                $locale => ['StGeorgeMartyr' => 'Saint George, Martyr'],
+            ],
+        ];
+    }
+
+    /**
+     * A diocese with a schema-valid name that has no calendar in the tree, so PUT is a genuine
+     * create rather than a conflict.
+     *
+     * @return array<string, mixed>
+     */
+    private static function newDiocesanPayload(): array
+    {
+        return [
+            'litcal'   => [
+                [
+                    'liturgical_event' => [
+                        'event_key' => 'StsProtaseGervase',
+                        'color'     => ['red'],
+                        'grade'     => 3,
+                        'common'    => ['Proper'],
+                        'day'       => 19,
+                        'month'     => 6,
+                    ],
+                    'metadata'         => ['since_year' => 2024, 'form_rownum' => 0],
+                ],
+            ],
+            'metadata' => [
+                'nation'       => 'DE',
+                'diocese_id'   => 'aachen_de',
+                'diocese_name' => 'Aachen',
+                'locales'      => ['de_DE'],
+                'timezone'     => 'Europe/Berlin',
+                'rite'         => 'roman',
+            ],
+            'i18n'     => [
+                'de_DE' => ['StsProtaseGervase' => 'Heilige Protasius und Gervasius'],
+            ],
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private static function existingDiocesanPayload(): array
+    {
+        return [
+            'litcal'   => [
+                [
+                    'liturgical_event' => [
+                        'event_key' => 'StsProtaseGervase',
+                        'color'     => ['morello'],
+                        'grade'     => 3,
+                        'common'    => ['Proper'],
+                        'day'       => 19,
+                        'month'     => 6,
+                    ],
+                    'metadata'         => ['since_year' => 2024, 'form_rownum' => 0],
+                ],
+            ],
+            'metadata' => [
+                'nation'       => 'IT',
+                'diocese_id'   => 'novara_it',
+                'diocese_name' => 'Diocesi di Novara',
+                'locales'      => ['it_IT'],
+                'timezone'     => 'Europe/Rome',
+                'rite'         => 'ambrosian',
+            ],
+            'i18n'     => [
+                'it_IT' => ['StsProtaseGervase' => 'Santi Protaso e Gervaso'],
+            ],
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private static function widerRegionPayload(string $region): array
+    {
+        return [
+            'litcal'             => [
+                [
+                    'liturgical_event' => ['event_key' => 'StBenedict', 'grade' => 4],
+                    'metadata'         => [
+                        'action'       => 'makePatron',
+                        'since_year'   => 1964,
+                        'url'          => 'https://www.vatican.va/',
+                        'url_lang_map' => ['it' => 'it', 'la' => 'la'],
+                    ],
+                ],
+            ],
+            'national_calendars' => ['Italy' => 'IT', 'France' => 'FR'],
+            'metadata'           => [
+                'wider_region' => $region,
+                'locales'      => ['it_IT'],
+            ],
+            'i18n'               => [
+                'it_IT' => ['StBenedict' => 'San Benedetto'],
+            ],
+        ];
+    }
+}

--- a/phpunit_tests/Repositories/SourceDataChangeRequestSchemaTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestSchemaTest.php
@@ -123,17 +123,73 @@ final class SourceDataChangeRequestSchemaTest extends RepositoryTestCase
         );
     }
 
+    /**
+     * The review-decision notification's substrate (#925): the outcome AS DECIDED, nullable
+     * because an undecided batch has none, and constrained to the two values `decideBatch()`
+     * writes. It exists separately from `review_status` because `markBatchClosedUnmerged()`
+     * rewrites that column to `rejected` on a batch a human approved.
+     */
+    public function testReviewDecisionColumnExistsAndIsConstrained(): void
+    {
+        $stmt = self::$pdo->query(
+            "SELECT data_type, is_nullable
+               FROM information_schema.columns
+              WHERE table_name = 'sourcedata_change_requests'
+                AND column_name = 'review_decision'"
+        );
+        self::assertNotFalse($stmt);
+        /** @var array<string, mixed>|false $row */
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+
+        self::assertIsArray($row, 'review_decision must exist');
+        self::assertSame('character varying', $row['data_type']);
+        self::assertSame('YES', $row['is_nullable']);
+
+        // The CHECK admits approved and rejected, and refuses anything else — including
+        // `submitted` and `withdrawn`, which are review STATUSES but never decisions.
+        foreach (['approved', 'rejected'] as $decision) {
+            $id = $this->insertRow(
+                ChangeOperation::UPDATE,
+                ChangeReviewStatus::APPROVED,
+                ChangePublicationStatus::NONE,
+                reviewDecision: $decision
+            );
+            self::assertNotSame('', $id, "review_decision {$decision} was rejected by its CHECK constraint");
+            self::$pdo->exec('DELETE FROM sourcedata_change_requests');
+        }
+
+        $this->expectException(\PDOException::class);
+        $this->insertRow(
+            ChangeOperation::UPDATE,
+            ChangeReviewStatus::SUBMITTED,
+            ChangePublicationStatus::NONE,
+            reviewDecision: 'submitted'
+        );
+    }
+
+    public function testTheReviewDecisionIndexExists(): void
+    {
+        $stmt = self::$pdo->query(
+            "SELECT indexname FROM pg_indexes
+              WHERE tablename = 'sourcedata_change_requests'
+                AND indexname = 'idx_scr_decided_for_submitter'"
+        );
+        self::assertNotFalse($stmt);
+        self::assertSame(['idx_scr_decided_for_submitter'], $stmt->fetchAll(\PDO::FETCH_COLUMN));
+    }
+
     private function insertRow(
         ChangeOperation $operation,
         ChangeReviewStatus $reviewStatus,
         ChangePublicationStatus $publicationStatus,
-        ?string $content = 'body'
+        ?string $content = 'body',
+        ?string $reviewDecision = null
     ): string {
         $stmt = self::$pdo->prepare(
             'INSERT INTO sourcedata_change_requests
-                (batch_id, resource_type, resource_id, path, operation, content, submitted_by_sub, review_status, publication_status)
+                (batch_id, resource_type, resource_id, path, operation, content, submitted_by_sub, review_status, publication_status, review_decision)
              VALUES
-                (gen_random_uuid(), :resource_type, :resource_id, :path, :operation, :content, :sub, :review_status, :publication_status)
+                (gen_random_uuid(), :resource_type, :resource_id, :path, :operation, :content, :sub, :review_status, :publication_status, :review_decision)
              RETURNING id'
         );
         $stmt->execute([
@@ -145,6 +201,7 @@ final class SourceDataChangeRequestSchemaTest extends RepositoryTestCase
             'sub'                => 'user-1',
             'review_status'      => $reviewStatus->value,
             'publication_status' => $publicationStatus->value,
+            'review_decision'    => $reviewDecision,
         ]);
 
         return (string) $stmt->fetchColumn();

--- a/phpunit_tests/Repositories/UserNotificationRepositoryTest.php
+++ b/phpunit_tests/Repositories/UserNotificationRepositoryTest.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Repositories;
 
+use LiturgicalCalendar\Api\Enum\ChangeOperation;
+use LiturgicalCalendar\Api\Enum\ChangePublicationStatus;
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
 use LiturgicalCalendar\Api\Repositories\UserNotificationRepository;
+use LiturgicalCalendar\Api\Services\ChangeResource;
 use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
 
 final class UserNotificationRepositoryTest extends AbstractHandlerTestCase
@@ -14,6 +19,7 @@ final class UserNotificationRepositoryTest extends AbstractHandlerTestCase
 
     private UserNotificationRepository $repo;
     private AccessRequestRepository $accessReqRepo;
+    private SourceDataChangeRequestRepository $changeReqRepo;
 
     protected function setUp(): void
     {
@@ -26,6 +32,44 @@ final class UserNotificationRepositoryTest extends AbstractHandlerTestCase
 
         $this->repo          = new UserNotificationRepository(self::$pdo);
         $this->accessReqRepo = new AccessRequestRepository(self::$pdo);
+        $this->changeReqRepo = new SourceDataChangeRequestRepository(self::$pdo);
+    }
+
+    /**
+     * Submit a real batch through SourceDataChangeRequestRepository, so that the review-decision
+     * half of the inbox is exercised against rows `decideBatch()` actually wrote — the point being
+     * that `review_decision` is populated by the production write path and not by the fixture.
+     *
+     * @param int $files How many paths the batch covers, to prove the inbox collapses to one item.
+     */
+    private function submittedBatch(string $sub, string $resourceId = 'US', int $files = 1): string
+    {
+        $paths = [];
+        for ($i = 0; $i < $files; $i++) {
+            $paths[] = [
+                'path'      => "jsondata/sourcedata/rite/roman/calendars/nations/{$resourceId}/file{$i}.json",
+                'operation' => ChangeOperation::CREATE,
+                'content'   => '{"litcal":[]}',
+            ];
+        }
+
+        return $this->changeReqRepo->submitBatch(
+            ChangeResource::nationalCalendar(Rite::ROMAN, $resourceId),
+            $paths,
+            $sub,
+            'Submitter',
+            'submitter@example.test',
+            true
+        )['batch_id'];
+    }
+
+    /** Shift a decided batch's review cursor, so ordering and the seen bookmark are testable. */
+    private function backdateDecision(string $batchId, string $interval): void
+    {
+        $stmt = self::$pdo->prepare(
+            'UPDATE sourcedata_change_requests SET approved_at = NOW() + :offset::interval WHERE batch_id = :batch_id'
+        );
+        $stmt->execute(['offset' => $interval, 'batch_id' => $batchId]);
     }
 
     /**
@@ -521,6 +565,183 @@ final class UserNotificationRepositoryTest extends AbstractHandlerTestCase
             '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00$/',
             $item['settled_at']
         );
+    }
+
+    // ---------------------------------------------------------------- review decisions (#925)
+
+    /**
+     * The bug this half exists for. A rejected batch never publishes, so before
+     * `change_request_reviewed` existed its submitter got no notification of any kind — the
+     * proposal simply stopped.
+     */
+    public function testARejectedBatchNotifiesItsSubmitter(): void
+    {
+        $batchId = $this->submittedBatch('user-1');
+        self::assertGreaterThan(0, $this->changeReqRepo->rejectBatch($batchId, 'reviewer-1', 'Wrong feast rank'));
+
+        $inbox = $this->repo->fetchInbox('user-1');
+
+        self::assertSame(1, $inbox['total']);
+        self::assertSame(1, $inbox['unread_count']);
+        $item = $inbox['items'][0];
+        self::assertSame('change_request_reviewed', $item['type']);
+        self::assertSame($batchId, $item['batch_id']);
+        self::assertSame('rejected', $item['review_status']);
+        self::assertSame('Wrong feast rank', $item['rejected_reason']);
+        self::assertSame('national_calendar', $item['resource_type']);
+        self::assertSame('roman/US', $item['resource_id']);
+        self::assertTrue($item['unread']);
+        self::assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00$/',
+            $item['reviewed_at']
+        );
+    }
+
+    /**
+     * An approval is news at the moment it is made, not only when GitHub eventually settles it:
+     * publication can be a queue wait, a grace window and a human pull-request review away.
+     */
+    public function testAnApprovedBatchNotifiesItsSubmitterBeforeItPublishes(): void
+    {
+        $batchId = $this->submittedBatch('user-1');
+        $this->changeReqRepo->approveBatch($batchId, 'reviewer-1');
+
+        $inbox = $this->repo->fetchInbox('user-1');
+
+        self::assertSame(1, $inbox['total']);
+        $item = $inbox['items'][0];
+        self::assertSame('change_request_reviewed', $item['type']);
+        self::assertSame('approved', $item['review_status']);
+        self::assertNull($item['rejected_reason']);
+    }
+
+    /**
+     * A resource admin's own write is auto-approved inside the same request, and the write
+     * response already answered `disposition: "approved"`. Telling them afterwards what they just
+     * did is noise, so a decision whose decider IS the submitter produces nothing.
+     */
+    public function testADecisionAnEditorMadeOnTheirOwnBatchIsNotNews(): void
+    {
+        $batchId = $this->submittedBatch('user-1');
+        $this->changeReqRepo->approveBatch($batchId, 'user-1');
+
+        self::assertSame(0, $this->repo->fetchInbox('user-1')['total']);
+    }
+
+    public function testAnUndecidedBatchIsNotNews(): void
+    {
+        $this->submittedBatch('user-1');
+
+        self::assertSame(0, $this->repo->fetchInbox('user-1')['total']);
+    }
+
+    /**
+     * An editor who changed a calendar and its i18n files proposed ONE thing, and one decision was
+     * made about it — the same collapse `change_request_published` performs.
+     */
+    public function testOneReviewItemPerBatchNotPerFile(): void
+    {
+        $batchId = $this->submittedBatch('user-1', files: 3);
+        $this->changeReqRepo->rejectBatch($batchId, 'reviewer-1', 'no');
+
+        $inbox = $this->repo->fetchInbox('user-1');
+
+        self::assertCount(1, $inbox['items']);
+        self::assertSame(1, $inbox['total']);
+    }
+
+    /**
+     * The reason `review_decision` exists at all.
+     *
+     * `markBatchClosedUnmerged()` writes `review_status = 'rejected'` when a published batch's pull
+     * request closes without merging — on a batch a human APPROVED. An inbox keyed on
+     * `review_status` would tell this submitter their proposal was refused, and date the refusal to
+     * the moment they were approved. The decision item must keep saying `approved`; the close is
+     * reported by the publication item, at the time it actually happened.
+     */
+    public function testAClosedUnmergedPullRequestDoesNotRewriteTheReviewDecision(): void
+    {
+        $batchId = $this->submittedBatch('user-1');
+        $this->changeReqRepo->approveBatch($batchId, 'reviewer-1');
+        $this->changeReqRepo->markBatchPublicationStatus($batchId, ChangePublicationStatus::OPEN);
+        self::assertGreaterThan(
+            0,
+            $this->changeReqRepo->markBatchClosedUnmerged($batchId, 'Closed without merging')
+        );
+
+        // Sanity: the row really does now claim to be rejected.
+        $stmt = self::$pdo->prepare('SELECT review_status, review_decision FROM sourcedata_change_requests WHERE batch_id = :b LIMIT 1');
+        $stmt->execute(['b' => $batchId]);
+        /** @var array<string,string> $row */
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        self::assertSame('rejected', $row['review_status']);
+        self::assertSame('approved', $row['review_decision']);
+
+        $inbox = $this->repo->fetchInbox('user-1');
+
+        self::assertSame(2, $inbox['total'], 'the decision and the publication are both news');
+        $byType = [];
+        foreach ($inbox['items'] as $item) {
+            $byType[$item['type']] = $item;
+        }
+        self::assertArrayHasKey('change_request_reviewed', $byType);
+        self::assertArrayHasKey('change_request_published', $byType);
+        self::assertSame('approved', $byType['change_request_reviewed']['review_status']);
+        self::assertSame('closed', $byType['change_request_published']['publication_status']);
+
+        // markBatchClosedUnmerged() also writes its own close text into `rejected_reason`. An
+        // APPROVAL must not surface it: `rejected_reason` on this item is the reason for THIS
+        // decision, and an approval has none.
+        self::assertNull($byType['change_request_reviewed']['rejected_reason']);
+    }
+
+    public function testAnotherUsersDecisionIsInvisible(): void
+    {
+        $batchId = $this->submittedBatch('user-2');
+        $this->changeReqRepo->rejectBatch($batchId, 'reviewer-1', 'no');
+
+        self::assertSame(0, $this->repo->fetchInbox('user-1')['total']);
+    }
+
+    public function testTheSeenBookmarkMarksAReviewDecisionRead(): void
+    {
+        $older = $this->submittedBatch('user-1', 'US');
+        $this->changeReqRepo->rejectBatch($older, 'reviewer-1', 'no');
+        $this->backdateDecision($older, '-2 hours');
+
+        $this->repo->markSeen('user-1');
+
+        $newer = $this->submittedBatch('user-1', 'CA');
+        $this->changeReqRepo->approveBatch($newer, 'reviewer-1');
+
+        $inbox = $this->repo->fetchInbox('user-1');
+
+        self::assertSame(2, $inbox['total']);
+        self::assertSame(1, $inbox['unread_count']);
+        self::assertSame($newer, $inbox['items'][0]['batch_id'], 'newest decision first');
+    }
+
+    /**
+     * The cursor is `approved_at`, which the decision writes once — NOT `updated_at`, which moves
+     * on every claim, release, reclaim and publication-status write. A batch whose row is touched
+     * after the user has read its decision must not silently become unread again.
+     */
+    public function testALaterRowTouchDoesNotResurrectAReadDecision(): void
+    {
+        $batchId = $this->submittedBatch('user-1');
+        $this->changeReqRepo->approveBatch($batchId, 'reviewer-1');
+        $this->backdateDecision($batchId, '-2 hours');
+
+        $this->repo->markSeen('user-1');
+
+        // Moves updated_at to NOW(), and leaves approved_at alone.
+        $this->changeReqRepo->markBatchPublicationStatus($batchId, ChangePublicationStatus::QUEUED);
+
+        $inbox = $this->repo->fetchInbox('user-1');
+
+        self::assertSame(1, $inbox['total']);
+        self::assertSame(0, $inbox['unread_count']);
+        self::assertFalse($inbox['items'][0]['unread']);
     }
 
     public function testChangeRequestTotalReflectsAllSettledBatchesNotJustThePage(): void

--- a/src/Handlers/Auth/NotificationsHandler.php
+++ b/src/Handlers/Auth/NotificationsHandler.php
@@ -28,12 +28,27 @@ use Psr\Http\Message\ServerRequestInterface;
  * user_notification_state row.
  *
  * The GET response's `items` is a DISCRIMINATED list: each item carries a
- * `type` of either `access_request_reviewed` (an editor's own access
- * request was approved, rejected or revoked) or `change_request_published`
- * (one of an editor's submitted source-data change-request batches merged
- * or was closed, unmerged, on GitHub). The two shapes share only `type` and
- * `unread` — clients MUST switch on `type` before reading any other key.
- * See UserNotificationRepository::fetchInbox() for the full item shapes.
+ * `type` of
+ *
+ * - `access_request_reviewed` — an editor's own access request was approved,
+ *   rejected or revoked;
+ * - `change_request_reviewed` — a reviewer approved or REJECTED one of an
+ *   editor's submitted source-data change-request batches. The outcome is in
+ *   `review_status` (`approved` | `rejected`) and a refusal carries its
+ *   `rejected_reason`, so a client distinguishes the two without a second
+ *   request. Decisions an editor made on their own batch — the auto-approval
+ *   a resource admin's write receives inline — never appear here;
+ * - `change_request_published` — one of those batches merged or was closed,
+ *   unmerged, on GitHub.
+ *
+ * A batch can produce one of each, at different times: the decision when a
+ * human judged it, the publication when GitHub settled it. A REJECTED batch
+ * never publishes, so before `change_request_reviewed` existed (#925) a
+ * refusal produced no notification at all.
+ *
+ * The shapes share only `type` and `unread` — clients MUST switch on `type`
+ * before reading any other key. See UserNotificationRepository::fetchInbox()
+ * for the full item shapes.
  */
 final class NotificationsHandler extends AbstractHandler
 {

--- a/src/Migrations/Version20260901120000.php
+++ b/src/Migrations/Version20260901120000.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Snapshot the review DECISION, so a rejected change request can notify its submitter (#925).
+ *
+ * # Why a new column, when `review_status` already says approved or rejected
+ *
+ * Because `review_status` is not a record of the decision — it is the batch's CURRENT position,
+ * and something else moves it afterwards. `SourceDataChangeRequestRepository::markBatchClosedUnmerged()`
+ * writes `review_status = 'rejected'` when a published batch's pull request is closed without
+ * merging, on a batch a human APPROVED. Reading `review_status` to describe a review decision
+ * would therefore tell that submitter "your proposal was rejected" and stamp it with the moment
+ * they were approved — a notification that reports an untruth, which is exactly the class of
+ * defect this repository has had to fix repeatedly elsewhere.
+ *
+ * `review_decision` is written by `decideBatch()` and by nothing else. It is the outcome AS
+ * DECIDED, frozen at the decision, and no later transition touches it.
+ *
+ * # Why there is no `review_settled_at` alongside it
+ *
+ * There is already a single-write review-decision cursor: `approved_at`. Despite its name it is
+ * stamped for BOTH outcomes — `decideBatch()` sets `approved_at = NOW()` on approve and on reject
+ * alike — and its `WHERE review_status = 'submitted'` guard is what makes the decision single-shot,
+ * so the column is written exactly once in a batch's lifetime and never moved again. That is
+ * precisely the property `publication_settled_at` was added for on the publication axis, and
+ * `updated_at` (which moves on every claim, release, reclaim and record) fails. Adding a
+ * `review_settled_at` that would always equal `approved_at` would buy nothing and create a pair
+ * that can drift. The column comment below carries the correction so the misleading name cannot
+ * mislead a reader of the schema.
+ *
+ * # Backfill
+ *
+ * Existing decided batches get their decision reconstructed, in two exact cases rather than by
+ * copying `review_status` wholesale:
+ *
+ *  - A batch that never left `publication_status = 'none'` was never published, so nothing can have
+ *    rewritten its `review_status`: it still says what was decided.
+ *  - A batch that reached any other publication status must have been approved to get there —
+ *    `claimNextPublishableBatch()` claims only `review_status = 'approved'` rows — regardless of
+ *    what its `review_status` says now. This is the case that repairs the closed-unmerged rows.
+ *
+ * A batch with `approved_at IS NULL` was never decided and stays NULL, which the inbox reads as
+ * "no review-decision notification for this row".
+ *
+ * The backfill makes historical decisions visible in the inbox the first time a user opens it,
+ * exactly as adding `publication_settled_at` did for historical publications. That is intended:
+ * the point of the issue is that these decisions were never announced at all.
+ */
+final class Version20260901120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add sourcedata_change_requests.review_decision so a review decision — approve OR reject — can notify its submitter (#925)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql('ALTER TABLE sourcedata_change_requests ADD COLUMN review_decision VARCHAR(20) NULL');
+
+        $this->addSql(
+            'ALTER TABLE sourcedata_change_requests '
+            . "ADD CONSTRAINT chk_scr_review_decision CHECK (review_decision IS NULL OR review_decision IN ('approved', 'rejected'))"
+        );
+
+        $this->addSql(
+            'COMMENT ON COLUMN sourcedata_change_requests.review_decision IS '
+            . "'The review outcome AS DECIDED, written once by decideBatch(); review_status is the CURRENT position and is rewritten by markBatchClosedUnmerged()'"
+        );
+
+        // The name predates the discovery that it stamps rejections too. Correct it here rather
+        // than renaming the column, which every query and test would have to follow.
+        $this->addSql(
+            'COMMENT ON COLUMN sourcedata_change_requests.approved_at IS '
+            . "'When the batch was DECIDED, approved or rejected alike; written once by decideBatch(), and the review-decision notification cursor'"
+        );
+
+        // The notifications inbox reads a submitter's decided batches, newest first — the review
+        // -decision counterpart of idx_scr_settled_for_submitter.
+        $this->addSql(
+            'CREATE INDEX idx_scr_decided_for_submitter ON sourcedata_change_requests '
+            . '(submitted_by_sub, approved_at DESC) WHERE review_decision IS NOT NULL'
+        );
+
+        // A batch still at publication_status 'none' was never published, so nothing has
+        // rewritten its review_status: it still records the decision.
+        $this->addSql(
+            'UPDATE sourcedata_change_requests SET review_decision = review_status '
+            . "WHERE approved_at IS NOT NULL AND publication_status = 'none' "
+            . "AND review_status IN ('approved', 'rejected')"
+        );
+
+        // Anything that got past 'none' was claimed for publication, which requires approval —
+        // whatever its review_status says today.
+        $this->addSql(
+            "UPDATE sourcedata_change_requests SET review_decision = 'approved' "
+            . "WHERE approved_at IS NOT NULL AND publication_status <> 'none'"
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql('DROP INDEX IF EXISTS idx_scr_decided_for_submitter');
+        $this->addSql('ALTER TABLE sourcedata_change_requests DROP CONSTRAINT IF EXISTS chk_scr_review_decision');
+        $this->addSql('ALTER TABLE sourcedata_change_requests DROP COLUMN IF EXISTS review_decision');
+        $this->addSql(
+            'COMMENT ON COLUMN sourcedata_change_requests.approved_at IS NULL'
+        );
+    }
+}

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -1613,6 +1613,23 @@ class SourceDataChangeRequestRepository
      * reading it. `updated_at` moves here, and will move again when phase 2 sets
      * `publication_status`, which is why that column is NOT what the accumulation base
      * orders by.
+     *
+     * # `review_decision` and `approved_at` — the review-decision notification's substrate
+     *
+     * This method is the ONLY writer of `review_decision`, and that exclusivity is the point
+     * (#925). `review_status` is the batch's CURRENT position, not a record of what a human
+     * decided: {@see markBatchClosedUnmerged()} rewrites it to `rejected` when a published
+     * batch's pull request closes unmerged — on a batch that was APPROVED. A notification built
+     * from `review_status` would tell that submitter their proposal was refused, and date the
+     * refusal to the moment they were approved. `review_decision` is the outcome as decided,
+     * frozen here, and no later transition touches it.
+     *
+     * `approved_at` is stamped on BOTH outcomes, despite the name — it is "when this was
+     * decided", not "when this was approved" — and the `review_status = 'submitted'` guard above
+     * makes that a single write per batch. That is what qualifies it as the review-decision
+     * cursor, the same property `publication_settled_at` has on the publication axis and
+     * `updated_at` conspicuously lacks. See Version20260901120000, which also carries the
+     * correction as a `COMMENT ON COLUMN` so a reader of the schema is not misled by the name.
      */
     private function decideBatch(
         string $batchId,
@@ -1623,6 +1640,7 @@ class SourceDataChangeRequestRepository
         $stmt = $this->db->prepare(
             'UPDATE sourcedata_change_requests
                 SET review_status = :status,
+                    review_decision = :decision,
                     approved_by_sub = :decider,
                     approved_at = NOW(),
                     rejected_reason = :reason,
@@ -1632,6 +1650,9 @@ class SourceDataChangeRequestRepository
         );
         $stmt->execute([
             'status'    => $status->value,
+            // Same value as :status today, bound separately because PDO's named-parameter
+            // rewriting does not reliably allow one placeholder to appear twice.
+            'decision'  => $status->value,
             'decider'   => $deciderSub,
             'reason'    => $reason,
             'batch_id'  => $batchId,

--- a/src/Repositories/UserNotificationRepository.php
+++ b/src/Repositories/UserNotificationRepository.php
@@ -10,10 +10,17 @@ use LiturgicalCalendar\Api\Database\Connection;
  * Repository for user-facing notification state and inbox queries.
  *
  * Backs the GET /auth/notifications and POST /auth/notifications/seen
- * endpoints. Reads from two sources — access_requests (filtered to reviewed
- * rows for the authenticated user) and sourcedata_change_requests (filtered
- * to settled batches submitted by the authenticated user) — merges them in
- * PHP, and reads/writes the user_notification_state bookmark table.
+ * endpoints. Reads from three sources — access_requests (filtered to reviewed
+ * rows for the authenticated user), sourcedata_change_requests filtered to
+ * REVIEWED batches submitted by the authenticated user, and the same table
+ * filtered to SETTLED batches — merges them in PHP, and reads/writes the
+ * user_notification_state bookmark table.
+ *
+ * The two change-request halves are different events at different times and
+ * both are news: a review decision is the moment a human judged the proposal,
+ * a publication is the moment GitHub settled it. A rejected batch never
+ * publishes at all, so before the review half existed (#925) a refusal
+ * produced no notification of any kind.
  *
  * The "no row yet = unseen since epoch" semantics are handled in the
  * read path via a NULL → '1970-01-01' fallback. Reads never insert.
@@ -38,7 +45,17 @@ use LiturgicalCalendar\Api\Database\Connection;
  *     settled_at: string,
  *     unread: bool
  * }
- * @phpstan-type InboxItem AccessRequestItem|ChangeRequestItem
+ * @phpstan-type ChangeRequestReviewedItem array{
+ *     type: 'change_request_reviewed',
+ *     batch_id: string,
+ *     resource_type: string,
+ *     resource_id: string,
+ *     review_status: 'approved'|'rejected',
+ *     rejected_reason: ?string,
+ *     reviewed_at: string,
+ *     unread: bool
+ * }
+ * @phpstan-type InboxItem AccessRequestItem|ChangeRequestItem|ChangeRequestReviewedItem
  */
 final class UserNotificationRepository
 {
@@ -56,25 +73,36 @@ final class UserNotificationRepository
      * Fetch the user's inbox + unread badge metadata.
      *
      * `items` is a DISCRIMINATED list: reviewed access requests
-     * (`type: 'access_request_reviewed'`) and settled source-data change
-     * requests (`type: 'change_request_published'`) are interleaved
-     * newest-first. The two shapes share only `type` and `unread` — clients
-     * MUST switch on `type` before reading any other key.
+     * (`type: 'access_request_reviewed'`), decided source-data change requests
+     * (`type: 'change_request_reviewed'`) and settled ones
+     * (`type: 'change_request_published'`) are interleaved newest-first. The
+     * shapes share only `type` and `unread` — clients MUST switch on `type`
+     * before reading any other key.
      *
-     * # Why two queries and a PHP merge, rather than one UNION
+     * # Why three queries and a PHP merge, rather than one UNION
      *
-     * The two sources have genuinely different shapes, and `total` / `unread_count` are window
+     * The sources have genuinely different shapes, and `total` / `unread_count` are window
      * counts over the FULL filtered set rather than over the returned page — so a UNION would need
-     * `COUNT(*) OVER ()` spanning both halves, over rows whose columns do not line up. That is one
-     * query that is hard to read and harder to prove right. Two straightforward queries plus a
+     * `COUNT(*) OVER ()` spanning every branch, over rows whose columns do not line up. That is one
+     * query that is hard to read and harder to prove right. Three straightforward queries plus a
      * `usort` are verifiable by inspection, and each source is already capped at 50 rows, so the
      * merge is bounded.
      *
-     * # Why `publication_settled_at` and not `updated_at`
+     * # Why the two change-request halves are separate items, not one
+     *
+     * A batch produces at most one of each, at different times, and either can exist without the
+     * other: a rejected batch is decided and never published; an approved batch is decided long
+     * before its pull request settles. Collapsing them would either delay the decision until
+     * publication (which for a rejection never comes — the bug #925 is about) or overwrite the
+     * decision with the publication.
+     *
+     * # Why `publication_settled_at` / `approved_at` and not `updated_at`
      *
      * `updated_at` moves on every claim, release, reclaim and record, so it answers "when was this
      * row last touched", not "when did this become news". `publication_settled_at` is written once,
-     * by the transition to `merged` or `closed`.
+     * by the transition to `merged` or `closed`. `approved_at` is likewise written once, by
+     * `decideBatch()` under its `review_status = 'submitted'` guard, for approvals AND rejections
+     * alike despite the column's name — see that method's docblock.
      *
      * # One item per batch
      *
@@ -119,11 +147,12 @@ final class UserNotificationRepository
         $lastSeen    = $hasBookmark ? $lastSeenRaw : self::EPOCH;
         $lastSeenIso = $hasBookmark ? $this->iso8601($lastSeen) : self::EPOCH_ISO8601;
 
-        $access = $this->accessRequestItems($userId, $lastSeen, $limit);
-        $change = $this->changeRequestItems($userId, $lastSeen, $limit);
+        $access   = $this->accessRequestItems($userId, $lastSeen, $limit);
+        $change   = $this->changeRequestItems($userId, $lastSeen, $limit);
+        $reviewed = $this->changeRequestReviewedItems($userId, $lastSeen, $limit);
 
         /** @var list<InboxItem> $items */
-        $items = array_merge($access['items'], $change['items']);
+        $items = array_merge($access['items'], $change['items'], $reviewed['items']);
         usort(
             $items,
             static fn (array $a, array $b): int => strcmp(
@@ -132,12 +161,12 @@ final class UserNotificationRepository
             )
         );
 
-        // total and unread_count span the FULL filtered set of both sources, not the merged page —
-        // both accessRequestItems() and changeRequestItems() compute their own total/unread_count
-        // via a window function over their full filtered set, so this is a plain sum of two
-        // already-correct numbers, not a re-derivation from either returned page.
-        $total       = $access['total'] + $change['total'];
-        $unreadCount = $access['unread_count'] + $change['unread_count'];
+        // total and unread_count span the FULL filtered set of every source, not the merged page —
+        // each of the three helpers computes its own total/unread_count via a window function over
+        // its full filtered set, so this is a plain sum of already-correct numbers, not a
+        // re-derivation from any returned page.
+        $total       = $access['total'] + $change['total'] + $reviewed['total'];
+        $unreadCount = $access['unread_count'] + $change['unread_count'] + $reviewed['unread_count'];
 
         return [
             'items'        => array_slice($items, 0, $limit),
@@ -311,6 +340,137 @@ final class UserNotificationRepository
     }
 
     /**
+     * Source-data change-request batches submitted by `$userId` that a reviewer has DECIDED —
+     * approved or rejected — one item per batch, plus window-function counts over the full
+     * filtered set. Same CTE-then-window shape as {@see changeRequestItems()}, and for the same
+     * reason: `DISTINCT ON` must collapse the per-file rows to batches BEFORE `COUNT(*) OVER ()`
+     * counts them, or the counts are per-file.
+     *
+     * # Why `review_decision` and not `review_status`
+     *
+     * Because `review_status` is where the batch is NOW, not what was decided.
+     * `SourceDataChangeRequestRepository::markBatchClosedUnmerged()` rewrites it to `rejected`
+     * when a published batch's pull request closes unmerged — on a batch a human approved. Keying
+     * this notification on it would tell that submitter their proposal was refused and date the
+     * refusal to their approval. `review_decision` is written only by `decideBatch()`, at the
+     * decision, and never moved.
+     *
+     * That same batch is not left silent: its close is a publication event, and
+     * {@see changeRequestItems()} reports it as `change_request_published` with
+     * `publication_status: 'closed'` at the time it actually closed.
+     *
+     * # Why a self-decision produces nothing
+     *
+     * `approved_by_sub IS DISTINCT FROM submitted_by_sub` suppresses the auto-approval a resource
+     * admin's own write receives inside the very same request (see
+     * `ChangeRequestSourceDataWriter::commitStagedFiles()`), and equally an admin who approves
+     * their own batch through the admin endpoint. Telling someone what they just did is noise, and
+     * the write response already answers `disposition: "approved"` synchronously. `IS DISTINCT
+     * FROM` rather than `<>` so a NULL decider — which `decideBatch()` never writes, but which a
+     * hand-repaired row could hold — does not silently swallow the notification.
+     *
+     * @return array{items: list<ChangeRequestReviewedItem>, total: int, unread_count: int}
+     */
+    private function changeRequestReviewedItems(string $userId, string $lastSeen, int $limit): array
+    {
+        $sql  = <<<'SQL'
+            WITH batches AS (
+                SELECT DISTINCT ON (batch_id)
+                    batch_id,
+                    resource_type,
+                    resource_id,
+                    review_decision,
+                    -- `rejected_reason` belongs to THIS decision, so an approval must not carry
+                    -- one. The column is written a second time by markBatchClosedUnmerged(),
+                    -- which stamps its close reason onto a batch that was APPROVED; without this
+                    -- guard an approval item would surface that text as though the reviewer had
+                    -- refused it. The close is reported by the publication item instead.
+                    CASE WHEN review_decision = 'rejected' THEN rejected_reason END AS rejected_reason,
+                    approved_at,
+                    (approved_at > :last_seen::timestamptz) AS unread
+                FROM sourcedata_change_requests
+                WHERE submitted_by_sub = :uid
+                  AND review_decision IS NOT NULL
+                  AND approved_at IS NOT NULL
+                  AND approved_by_sub IS DISTINCT FROM submitted_by_sub
+                ORDER BY batch_id, approved_at DESC
+            )
+            SELECT
+                batch_id,
+                resource_type,
+                resource_id,
+                review_decision,
+                rejected_reason,
+                approved_at,
+                unread,
+                COUNT(*) OVER () AS total,
+                COUNT(*) FILTER (WHERE unread) OVER () AS unread_count
+            FROM batches
+            ORDER BY approved_at DESC
+            LIMIT :limit
+        SQL;
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindValue(':uid', $userId);
+        $stmt->bindValue(':last_seen', $lastSeen);
+        $stmt->bindValue(':limit', $limit, \PDO::PARAM_INT);
+        $stmt->execute();
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        if ($rows === []) {
+            return [
+                'items'        => [],
+                'total'        => 0,
+                'unread_count' => 0,
+            ];
+        }
+
+        $total       = $this->toInt($rows[0]['total']);
+        $unreadCount = $this->toInt($rows[0]['unread_count']);
+
+        $items = array_map(
+            function (array $row): array {
+                $reason = $row['rejected_reason'] ?? null;
+                return [
+                    'type'            => 'change_request_reviewed',
+                    'batch_id'        => $this->toString($row['batch_id']),
+                    'resource_type'   => $this->toString($row['resource_type']),
+                    'resource_id'     => $this->toString($row['resource_id']),
+                    'review_status'   => $this->toReviewDecision($row['review_decision']),
+                    'rejected_reason' => $reason === null ? null : $this->toString($reason),
+                    'reviewed_at'     => $this->iso8601($this->toString($row['approved_at'])),
+                    'unread'          => in_array($row['unread'], [true, 't', 'true', '1', 1], true),
+                ];
+            },
+            $rows
+        );
+
+        return [
+            'items'        => array_values($items),
+            'total'        => $total,
+            'unread_count' => $unreadCount,
+        ];
+    }
+
+    /**
+     * Narrow `review_decision` to the two values `chk_scr_review_decision` admits, so the wire
+     * shape's enum is guaranteed by this class rather than merely hoped for. Anything else means
+     * the constraint was dropped or the column was written by something other than
+     * `decideBatch()` — a bug worth surfacing, not worth passing through to a client that
+     * switches on it.
+     *
+     * @return 'approved'|'rejected'
+     */
+    private function toReviewDecision(mixed $value): string
+    {
+        $decision = $this->toString($value);
+        if ($decision !== 'approved' && $decision !== 'rejected') {
+            throw new \UnexpectedValueException('Unexpected review_decision: ' . $decision);
+        }
+        return $decision;
+    }
+
+    /**
      * The timestamp an InboxItem sorts by, regardless of which shape it is.
      *
      * `$item['settled_at'] ?? $item['reviewed_at']` would work at runtime, but PHPStan L10 flags it
@@ -328,6 +488,7 @@ final class UserNotificationRepository
     {
         return match ($item['type']) {
             'change_request_published' => $item['settled_at'],
+            'change_request_reviewed'  => $item['reviewed_at'],
             'access_request_reviewed'  => $item['reviewed_at'],
         };
     }


### PR DESCRIPTION
Closes #925
Closes #933

Two contract fixes to the source-data change-request surface. They are unrelated
in mechanism but both are cases where the API's observable behaviour and its
documented contract disagreed.

## #925 — a rejected change request notified nobody

Phase 3 announced a batch only once it **settled on GitHub**
(`change_request_published`, on merge or close). The review decision itself
produced nothing, and the two outcomes were asymmetric in the worst way:

- **Approved** → publishes, merges, submitter eventually gets
  `change_request_published`. Late, but it arrives.
- **Rejected** → `review_status` becomes `rejected`, `publication_status` stays
  `none`, nothing is ever published, so **no notification was ever generated**.

`GET /auth/notifications` now carries a third item shape,
`change_request_reviewed`.

### Design decisions

**One type, not two.** `change_request_reviewed` carries the outcome in a
`review_status` field (`approved` | `rejected`), exactly as the union's existing
`access_request_reviewed` carries `approved` | `rejected` | `revoked` in its
`status`. Two types would give clients two shapes identical apart from a
constant, and would make "did anything happen to my batch" a two-branch question
in every consumer. The frontend distinguishes the outcomes from the one field,
with no second request.

**The outcome comes from a new column, not from `review_status`.** This is the
load-bearing decision. `review_status` is where the batch is *now*, not what was
decided: `markBatchClosedUnmerged()` writes `review_status = 'rejected'` when a
published batch's pull request closes unmerged — on a batch a human **approved**.
An inbox keyed on it would tell that submitter their proposal was refused, and
date the refusal to the moment they were approved. So
`sourcedata_change_requests.review_decision` records the outcome **as decided**,
is written only by `decideBatch()`, and is never moved. That batch is not left
silent either: its close is reported by the publication item, with
`publication_status: "closed"`, at the time it actually closed. Both halves are
pinned by `testAClosedUnmergedPullRequestDoesNotRewriteTheReviewDecision`.

`rejected_reason` is likewise scoped to the decision in SQL
(`CASE WHEN review_decision = 'rejected' …`), because `markBatchClosedUnmerged()`
also stamps its close text into that column — an approval must not surface it.

**The cursor is `approved_at`, and no `review_settled_at` was added.** The issue
suggested either reusing `updated_at` (impossible — it moves on every claim,
release, reclaim and record) or adding a stamp. Neither was needed: despite its
name, `decideBatch()` already stamps `approved_at` for **both** outcomes, and its
`WHERE review_status = 'submitted'` guard makes that a single write per batch —
precisely the property `publication_settled_at` has on the publication axis. A
`review_settled_at` would always equal it and could only drift. The misleading
name is corrected in a `COMMENT ON COLUMN` so a reader of the schema is not
misled, and in the `decideBatch()` docblock.

**Self-decisions are suppressed** via
`approved_by_sub IS DISTINCT FROM submitted_by_sub`. The auto-approval a resource
admin's own write receives inside the same request is not news, and the write
response already answered `disposition: "approved"` synchronously. This equally
covers an admin approving their own batch through the admin endpoint.

**Composition with #924 (concurrent, separate branch).** That issue exposes
`rejected_reason` on `ChangeRequestBatch`. Nothing here touches
`ChangeRequestBatch` or its schema. The new notification declares its **own**
`rejected_reason` property inline, reading the same DB column, so the two compose
(the notification shows the reason inline; the batch endpoint remains the place
to fetch it for a batch not in the inbox page) and the OpenAPI edits do not
overlap.

**Backfill.** Historical decisions are reconstructed in two exact cases rather
than by copying `review_status` wholesale: a batch still at
`publication_status = 'none'` was never published so nothing rewrote its status;
anything past `none` must have been approved to be claimable. They become visible
the first time a user opens their inbox — intended, since these decisions were
never announced at all.

**Known, out of scope.** As the issue notes, the frontend bell polls
`/admin/notifications` in admin mode and will not show any of this to admins
until that is fixed frontend-side.

## #933 — the OpenAPI `/data` write responses contradicted the handler

All fourteen `/data/*` `PUT`/`PATCH` response schemas were
`additionalProperties: false` and declared only `success`, `disposition` and
`change_request`, while `RegionalDataHandler` also sets `$responseObj->data`
(`:399`, `:516`, `:584`, `:702`, `:787`, `:877`). A strict response validator
therefore rejected a response the API is designed to return, and a client written
from the spec did not know the key existed — while the frontend's `extending.js`
already depends on it.

**Option 1 implemented: document `data`, do not remove it.** Removing it is the
better long-term shape but a breaking contract change the frontend must land
first, and the frontend fix for exactly this is being written concurrently.

The description does not merely add the key; it states the trap: `data` is set
from the raw payload **unconditionally**, in both disk mode and queue mode, so
when `disposition` is not `applied` nothing was written and `data` is the
*proposed* payload, not a stored resource — a client must branch on `disposition`
before trusting it. It also records that the `i18n` member is stripped before the
echo, since those translations are written as separate per-locale files.

`data` is deliberately **not** in `required`, so a later revision may stop
emitting it on non-`applied` dispositions without a second breaking change.

`openapi.json` was edited programmatically; the file round-trips exactly through
`json.dumps(indent=2, ensure_ascii=False)`, verified before and after.

## The regression guard

`phpunit_tests/Handlers/RegionalDataWriteResponseSchemaTest.php`:

- drives the **six real response-assembly sites** (nation/diocese/widerregion ×
  PUT/PATCH) through `RegionalDataHandler` in queue mode — the disposition under
  which `data` is at its most misleading — and validates each real response body
  against the response schema `openapi.json` declares for that operation, via a
  JSON Pointer into the document;
- asserts all **fourteen** documented operations declare `data` identically (the
  rite-qualified spellings route to the same code), that the description states
  the `disposition`/`applied` condition, and that `data` is not `required`.

`NotificationsHandlerTest::testTheInboxValidatesAgainstTheDocumentedUnion` does
the same on the other side: a real inbox containing both an
`access_request_reviewed` and a `change_request_reviewed` item, validated against
`UserNotificationsResponse`. Because every member of the `oneOf` is
`additionalProperties: false`, an item shape the union does not list matches zero
branches and fails.

## Verification

```
$ composer lint          → exit 0
$ composer analyse       → [OK] No errors (PHPStan level 10, 390 files)
$ composer lint:openapi  → Woohoo! Your API description is valid. 🎉
$ openapi round-trip     → canonical round-trip identical: True
```

`composer test:quick` reports `Tests: 4179, Errors: 21, Failures: 100`. **Every
one of those is in `phpunit_tests/Routes/` (104) or `phpunit_tests/WebSocket/`
(53)** — the suites that talk to `localhost:8000` and the WebSocket server, and
in this environment `localhost:8000` answers `404` to everything (including
`/easter`, which this branch does not touch). Verified pre-existing: with the
branch stashed, i.e. a tree identical to `origin/development`,
`Routes/Readonly/EasterTest` + `HealthTest` fail identically with
`Failed asserting that 404 is identical to 200`.

Everything this branch actually touches is green:

```
$ vendor/bin/phpunit --exclude-group slow --exclude-group golden-master-generate \
    phpunit_tests/{Handlers,Repositories,Schemas,Services,Models,Http,Params,Methods,Enum,Database}
OK, but there were issues!
Tests: 3306, Assertions: 34572, Warnings: 1, Skipped: 6.
```

(The one warning is the pre-existing `mkdir(): File exists` in
`DiskSourceDataWriterTest`.)

## Migration

`Version20260901120000` adds `review_decision` (nullable, `CHECK` on
`approved`/`rejected`), a `COMMENT ON COLUMN` correcting `approved_at`'s
misleading name, a partial index `idx_scr_decided_for_submitter`, and the
backfill. Applied and verified locally; pinned by two new assertions in
`SourceDataChangeRequestSchemaTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuyQTWwdmkzsxxjBEJcBG3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inbox notifications when submitted change requests are approved or rejected, including the decision and any rejection reason.
  * Notifications distinguish review outcomes from later publication updates and exclude decisions made by the submitter.
  * Documented the `data` field returned by `/data/*` write operations, allowing clients to inspect submitted payloads alongside the disposition.

* **Documentation**
  * Updated API and notification documentation to describe the new response and notification formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->