### PR TITLE
feat(locales): add /admin/locales write route for locale curation

### DIFF
--- a/jsondata/schemas/SupportedLocales.json
+++ b/jsondata/schemas/SupportedLocales.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "SupportedLocales",
+    "type": "object",
+    "description": "The curated promise of which locales this deployment considers officially supported. Not a description of what happens to be on disk: an official locale is served strictly, so a missing readings entry throws rather than degrading quietly. Keyed by calendar, though the General Roman Calendar is currently the only calendar that curates a set.",
+    "additionalProperties": false,
+    "required": ["general_roman_calendar"],
+    "properties": {
+        "general_roman_calendar": {
+            "$ref": "#/definitions/CuratedLocaleSet"
+        }
+    },
+    "definitions": {
+        "CuratedLocaleSet": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["official"],
+            "properties": {
+                "official": {
+                    "type": "array",
+                    "description": "The locales officially supported for this calendar. Never empty: an empty list is indistinguishable from an unreadable file, and SupportedLocales::official() would silently substitute its built-in fallback for it.",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "./CommonDef.json#/definitions/Locale"
+                    }
+                },
+                "candidates": {
+                    "type": "object",
+                    "description": "Locales that have resources but are not officially supported, each mapped to the prose reason it has not been promoted. A locale must not appear both here and in `official`; a promotion drops its candidate note.",
+                    "propertyNames": {
+                        "$ref": "./CommonDef.json#/definitions/Locale"
+                    },
+                    "additionalProperties": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -4756,6 +4756,123 @@
         }
       }
     },
+    "/admin/locales/{locale}/promote": {
+      "post": {
+        "tags": [
+          "Admin - Supported Locales"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Promote a locale to officially supported",
+        "operationId": "adminPromoteSupportedLocale",
+        "description": "Adds the locale to `general_roman_calendar.official` in jsondata/supportedLocales.json, through the same write seam every other source-data edit uses: a reviewable change request where SOURCEDATA_CHANGE_REQUESTS is configured, a direct disk write where it is not. See the `curation` object of GET /admin/locales for which of the two this deployment will do.\n\nTakes no request body.\n\nGated on the readiness probes of GET /admin/locales/{locale}, and the gate is NOT bypassable — there is no force parameter and no role that skips it. Promotion is not a label: an official locale is served strictly, so `ReadingsMap::getReadings()` throws on a missing readings entry instead of degrading quietly. Promoting an unready locale therefore converts silent gaps into 500s on a calendar the API advertises as supported.\n\nA promotion also drops the locale's note from `candidates`, whose prose says why it was not yet official and is false once it is.\n\nRestricted to global admins. Holding `admin` on `general_roman_calendar:supported_locales` does not open the endpoint; it decides whether the resulting change request is auto-approved or waits for a reviewer.",
+        "parameters": [
+          {
+            "name": "locale",
+            "in": "path",
+            "required": true,
+            "description": "The locale to promote. Must be one of the candidates returned by GET /admin/locales.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "hr"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportedLocaleCurationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict409"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable503"
+          }
+        }
+      }
+    },
+    "/admin/locales/{locale}/demote": {
+      "post": {
+        "tags": [
+          "Admin - Supported Locales"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Demote a locale from officially supported",
+        "operationId": "adminDemoteSupportedLocale",
+        "description": "Removes the locale from `general_roman_calendar.official` in jsondata/supportedLocales.json, through the same write seam as the promotion above. Takes no request body.\n\nDeliberately NOT readiness-gated, and the asymmetry is the point: demotion LOOSENS enforcement, so the same missing readings that would have thrown now degrade quietly, and it can never turn a working calendar into a 500. What it can do is change published output silently — /calendars stops advertising the locale, and affected events serve nothing instead of erroring — which is a governance risk answered by review and the audit trail, not by a readiness probe.\n\nTwo integrity guards still apply, both 409: the locale must currently be official, and the LAST official locale may not be removed. An empty `official` list is indistinguishable from an unreadable resource, so the API would silently fall back to its built-in list rather than supporting nothing.\n\nRestricted to global admins.",
+        "parameters": [
+          {
+            "name": "locale",
+            "in": "path",
+            "required": true,
+            "description": "The locale to demote. Must currently appear in `official`.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "hr"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportedLocaleCurationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict409"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable503"
+          }
+        }
+      }
+    },
     "/admin/outbox": {
       "get": {
         "tags": [
@@ -11001,20 +11118,69 @@
           },
           "curation": {
             "type": "object",
-            "description": "Whether promotion can be performed through the API, and why not when it cannot.",
+            "description": "Whether curation can be performed through this API right now, what a write would actually do, and prose an operator can read verbatim.",
             "required": [
               "writable",
+              "mode",
               "reason"
             ],
             "additionalProperties": false,
             "properties": {
               "writable": {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Whether a POST to /admin/locales/{locale}/promote or /demote from this caller will be accepted. False only when `mode` is `misconfigured`."
+              },
+              "mode": {
+                "type": "string",
+                "enum": [
+                  "change_request",
+                  "disk",
+                  "misconfigured"
+                ],
+                "description": "`change_request`: SOURCEDATA_CHANGE_REQUESTS is enabled with Postgres and OpenFGA behind it, so a promotion or demotion is recorded as a reviewable change request against jsondata/supportedLocales.json — auto-approved when the caller administers `general_roman_calendar:supported_locales`, queued for a reviewer otherwise.\n\n`disk`: this deployment writes source data straight to disk, which is what a self-hosted instance without that stack has always done. The edit is real and immediate, but a deployment that syncs its tree from git will overwrite it on the next deploy.\n\n`misconfigured`: SOURCEDATA_CHANGE_REQUESTS is set but Postgres and/or OpenFGA are not both reachable. Curation is refused (503) rather than silently falling back to a disk write on the very deployment that asked for durable, reviewable edits."
               },
               "reason": {
-                "type": "string"
+                "type": "string",
+                "description": "Human-readable explanation of `mode`, intended to be rendered verbatim in an admin interface."
               }
             }
+          }
+        }
+      },
+      "SupportedLocaleCurationResponse": {
+        "type": "object",
+        "description": "The outcome of a promotion or demotion. `official` is the curated list AS PROPOSED by this request: in `disk` mode that is also the list now in force, while in `change_request` mode nothing has changed yet and the list takes effect only once the batch is published.",
+        "required": [
+          "locale",
+          "action",
+          "official",
+          "disposition"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "locale": {
+            "type": "string",
+            "example": "hr"
+          },
+          "action": {
+            "type": "string",
+            "enum": [
+              "promote",
+              "demote"
+            ]
+          },
+          "official": {
+            "type": "array",
+            "description": "The official set after applying this change, alphabetically sorted.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "disposition": {
+            "$ref": "#/components/schemas/ChangeRequestDisposition"
+          },
+          "change_request": {
+            "$ref": "#/components/schemas/ChangeRequestSubmission"
           }
         }
       },

--- a/phpunit_tests/Enum/SchemaRoleTest.php
+++ b/phpunit_tests/Enum/SchemaRoleTest.php
@@ -29,7 +29,8 @@ final class SchemaRoleTest extends TestCase
             LitSchema::PROPRIUMDETEMPORE,
             LitSchema::DECREES_SRC,
             LitSchema::I18N,
-            LitSchema::TEST_SRC
+            LitSchema::TEST_SRC,
+            LitSchema::SUPPORTED_LOCALES
         ];
 
         foreach ($expected as $case) {

--- a/phpunit_tests/Handlers/LocalesAdminCurationTest.php
+++ b/phpunit_tests/Handlers/LocalesAdminCurationTest.php
@@ -1,0 +1,487 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\Admin\LocalesAdminHandler;
+use LiturgicalCalendar\Api\Http\Exception\ConflictException;
+use LiturgicalCalendar\Api\Http\Exception\ForbiddenException;
+use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
+use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
+use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Http\Exception\UnprocessableContentException;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\ChangeResource;
+use LiturgicalCalendar\Api\Services\SourceData\DiskSourceDataWriter;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
+use LiturgicalCalendar\Api\Services\SupportedLocales;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * `POST /admin/locales/{locale}/promote|demote` in DISK mode — the behaviour a self-hosted
+ * deployment without Postgres and OpenFGA gets, and the one every refusal branch is shared with.
+ *
+ * Every test runs against a throwaway tree whose `jsondata/supportedLocales.json` is a real,
+ * writable copy and whose data folders are symlinks into the repository. That is what makes a
+ * completed disk write safe to assert: the handler genuinely writes a file, and the file it
+ * writes is not the committed resource. Rewriting the committed one would work too, right up
+ * until a fatal left it rewritten in the working tree and every later test in the process read
+ * a list this class invented — the trap `HealthLocaleReadinessTest` documents.
+ *
+ * The refusal branches are forced rather than assumed. A normally-configured run exercises
+ * none of them: it promotes nothing, is never misconfigured, and never meets an unready locale.
+ *
+ * @see LocalesAdminQueueModeTest for the same route with change requests enabled.
+ */
+#[CoversClass(LocalesAdminHandler::class)]
+#[CoversClass(DiskSourceDataWriter::class)]
+#[CoversClass(SourceDataWriteMode::class)]
+#[CoversClass(ChangeResource::class)]
+final class LocalesAdminCurationTest extends AbstractHandlerTestCase
+{
+    /** @var list<string> */
+    private array $tempRoots = [];
+
+    /** @var array<string, string|false> */
+    private array $originalEnv = [];
+
+    private string $savedApiFilePath = '';
+
+    /** Digest of the COMMITTED resource, so a stray write to it fails this class rather than the next one. */
+    private string $committedResourceDigest = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->savedApiFilePath        = Router::$apiFilePath;
+        $this->committedResourceDigest = (string) md5_file(self::committedResourcePath());
+
+        foreach ([SourceDataWriteMode::FLAG, 'OPENFGA_API_URL', 'OPENFGA_STORE_ID', 'OPENFGA_MODEL_ID'] as $key) {
+            $this->originalEnv[$key] = $_ENV[$key] ?? false;
+        }
+
+        // Disk mode by default: the flag decides, and it must not be inherited from .env.local.
+        unset($_ENV[SourceDataWriteMode::FLAG]);
+
+        SupportedLocales::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        Router::$apiFilePath = $this->savedApiFilePath;
+
+        foreach ($this->originalEnv as $key => $value) {
+            if (false === $value) {
+                unset($_ENV[$key]);
+            } else {
+                $_ENV[$key] = $value;
+            }
+        }
+        $this->originalEnv = [];
+
+        foreach ($this->tempRoots as $root) {
+            self::removeTree($root);
+        }
+        $this->tempRoots = [];
+
+        SupportedLocales::reset();
+
+        self::assertSame(
+            $this->committedResourceDigest,
+            (string) md5_file(self::committedResourcePath()),
+            'a test wrote to the committed jsondata/supportedLocales.json instead of its throwaway copy'
+        );
+
+        parent::tearDown();
+    }
+
+    // ---------------------------------------------------------------- promotion
+
+    /**
+     * The happy path, built by seeding the throwaway resource with one official locale
+     * REMOVED. The locale is therefore ready by construction — it is officially supported on
+     * the committed data, so every probe passes — while being absent from the list this
+     * request curates. That beats inventing a synthetic locale's worth of lectionary corpora,
+     * and it fails loudly if the readiness probes ever stop agreeing with the committed list.
+     */
+    public function testPromotingAReadyLocaleAddsItToTheOfficialSetOnDisk(): void
+    {
+        $victim = self::committedOfficial()[0];
+        $rest   = array_values(array_diff(self::committedOfficial(), [$victim]));
+        $root   = $this->seedResource($rest, [$victim => 'held back by this test']);
+
+        $body = $this->curate($root, $victim, 'promote');
+
+        self::assertSame('applied', $body['disposition']);
+        self::assertArrayNotHasKey('change_request', $body, 'disk mode records no proposal');
+        self::assertSame($victim, $body['locale']);
+        self::assertSame(self::committedOfficial(), $body['official']);
+
+        $written = self::readResource($root);
+        self::assertSame(self::committedOfficial(), $written['general_roman_calendar']['official']);
+        self::assertArrayNotHasKey(
+            'candidates',
+            $written['general_roman_calendar'],
+            'a promoted locale is no longer a candidate, and its "why not yet" note is now false'
+        );
+    }
+
+    /**
+     * The official list is re-sorted, so the file keeps its alphabetical order rather than
+     * growing an append-ordered tail.
+     */
+    public function testTheOfficialListStaysSorted(): void
+    {
+        $official = self::committedOfficial();
+        $victim   = $official[count($official) - 1];
+        $root     = $this->seedResource(array_values(array_diff($official, [$victim])));
+
+        $body = $this->curate($root, $victim, 'promote');
+
+        $sorted = $body['official'];
+        sort($sorted);
+        self::assertSame($sorted, $body['official']);
+    }
+
+    /**
+     * The gate this route exists to enforce, and it is not bypassable: there is no force
+     * parameter to pass and no role that skips it. `hr` has a complete lectionary and a
+     * gettext catalogue but an unnamed decreed event, which is exactly the gap that took the
+     * Croatian calendar down once it was served strictly.
+     */
+    public function testAnUnreadyLocaleIsRefused(): void
+    {
+        $root = $this->seedResource(self::committedOfficial());
+
+        try {
+            $this->curate($root, 'hr', 'promote');
+            self::fail('an unready locale must not be promotable');
+        } catch (UnprocessableContentException $e) {
+            self::assertStringContainsString('not ready to be promoted', $e->getMessage());
+            self::assertStringContainsString('decree_names', $e->getMessage());
+        }
+
+        self::assertSame(
+            self::committedOfficial(),
+            self::readResource($root)['general_roman_calendar']['official'],
+            'a refused promotion must leave the resource untouched'
+        );
+    }
+
+    public function testPromotingAnAlreadyOfficialLocaleIsAConflict(): void
+    {
+        $root = $this->seedResource(self::committedOfficial());
+
+        $this->expectException(ConflictException::class);
+        $this->expectExceptionMessage('already officially supported');
+
+        $this->curate($root, self::committedOfficial()[0], 'promote');
+    }
+
+    public function testPromotingALocaleWithNoResourcesIsNotFound(): void
+    {
+        $root = $this->seedResource(self::committedOfficial());
+
+        $this->expectException(NotFoundException::class);
+
+        $this->curate($root, 'zz', 'promote');
+    }
+
+    // ----------------------------------------------------------------- demotion
+
+    /**
+     * Demotion is deliberately NOT readiness-gated: it loosens enforcement rather than
+     * tightening it, so it cannot turn a working calendar into a 500. Proved by demoting a
+     * locale that is fully ready — the readiness probes have no say either way.
+     */
+    public function testDemotingRemovesTheLocaleWithoutConsultingReadiness(): void
+    {
+        $official = self::committedOfficial();
+        $victim   = $official[0];
+        $root     = $this->seedResource($official);
+
+        $body = $this->curate($root, $victim, 'demote');
+
+        self::assertSame('applied', $body['disposition']);
+        self::assertSame(array_values(array_diff($official, [$victim])), $body['official']);
+        self::assertSame(
+            array_values(array_diff($official, [$victim])),
+            self::readResource($root)['general_roman_calendar']['official']
+        );
+    }
+
+    public function testDemotingALocaleThatIsNotOfficialIsAConflict(): void
+    {
+        $root = $this->seedResource(self::committedOfficial());
+
+        $this->expectException(ConflictException::class);
+        $this->expectExceptionMessage('is not officially supported');
+
+        $this->curate($root, 'hr', 'demote');
+    }
+
+    /**
+     * Emptying the list does not do what it says. `SupportedLocales::official()` substitutes
+     * its built-in FALLBACK for an empty or unreadable resource, so a demotion that emptied
+     * the file would silently RESTORE the historical five rather than support nothing.
+     */
+    public function testTheLastOfficialLocaleCannotBeDemoted(): void
+    {
+        $only = self::committedOfficial()[0];
+        $root = $this->seedResource([$only]);
+
+        try {
+            $this->curate($root, $only, 'demote');
+            self::fail('the last official locale must not be removable');
+        } catch (ConflictException $e) {
+            self::assertStringContainsString('last officially supported locale', $e->getMessage());
+        }
+
+        self::assertSame([$only], self::readResource($root)['general_roman_calendar']['official']);
+    }
+
+    // -------------------------------------------------------------- write modes
+
+    /**
+     * Queue mode asked for, stack absent. Every other write handler falls back to disk here
+     * and logs a warning; this one refuses, because a promotion silently reverted by the next
+     * deploy is worse than a promotion that did not happen, and unlike calendar editing there
+     * is an understood manual alternative.
+     */
+    public function testCurationIsRefusedWhenQueueModeIsMisconfigured(): void
+    {
+        $root = $this->seedResource(self::committedOfficial());
+        $this->misconfigureQueueMode();
+
+        try {
+            $this->curate($root, 'hr', 'promote');
+            self::fail('a misconfigured queue mode must refuse rather than fall back to disk');
+        } catch (ServiceUnavailableException $e) {
+            self::assertStringContainsString('SOURCEDATA_CHANGE_REQUESTS', $e->getMessage());
+        }
+    }
+
+    public function testTheListReportsMisconfiguredCurationAsNotWritable(): void
+    {
+        $root = $this->seedResource(self::committedOfficial());
+        $this->misconfigureQueueMode();
+
+        $body = $this->listPayload($root);
+
+        self::assertFalse($body['curation']['writable']);
+        self::assertSame('misconfigured', $body['curation']['mode']);
+    }
+
+    public function testTheListReportsDiskModeAsWritableWithItsCaveat(): void
+    {
+        $root = $this->seedResource(self::committedOfficial());
+
+        $body = $this->listPayload($root);
+
+        self::assertTrue($body['curation']['writable']);
+        self::assertSame('disk', $body['curation']['mode']);
+        self::assertStringContainsString('SOURCEDATA_CHANGE_REQUESTS', $body['curation']['reason']);
+    }
+
+    // ------------------------------------------------------------ route surface
+
+    public function testAnUnknownCurationActionIsNotFound(): void
+    {
+        $root = $this->seedResource(self::committedOfficial());
+
+        $this->expectException(NotFoundException::class);
+
+        $this->curate($root, 'hr', 'annoint');
+    }
+
+    public function testCurationWithoutALocaleIsNotFound(): void
+    {
+        $this->seedResource(self::committedOfficial());
+
+        $this->expectException(NotFoundException::class);
+
+        ( new LocalesAdminHandler(['locales']) )->handle(
+            $this->requestFor('POST', '/admin/locales')->withAttribute('oidc_user', self::globalAdmin())
+        );
+    }
+
+    public function testAnUnauthenticatedCallerCannotCurate(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+
+        ( new LocalesAdminHandler(['locales', 'hr', 'promote']) )
+            ->handle($this->requestFor('POST', '/admin/locales/hr/promote'));
+    }
+
+    public function testANonAdminCannotCurate(): void
+    {
+        $this->expectException(ForbiddenException::class);
+
+        ( new LocalesAdminHandler(['locales', 'hr', 'promote']) )->handle(
+            $this->requestFor('POST', '/admin/locales/hr/promote')
+                ->withAttribute('oidc_user', ['sub' => 'editor-1', 'roles' => ['calendar_editor']])
+        );
+    }
+
+    /**
+     * The route curates through POST only. `return_type` and REST-shaped verbs are not the
+     * house idiom for admin actions — `/admin/access-requests/{id}/approve` and
+     * `/admin/change-requests/{batchId}/approve` are both POST — so PUT must be refused
+     * rather than quietly aliased.
+     */
+    public function testPutIsNotAllowed(): void
+    {
+        $this->expectException(MethodNotAllowedException::class);
+
+        ( new LocalesAdminHandler(['locales', 'hr', 'promote']) )
+            ->handle($this->requestFor('PUT', '/admin/locales/hr/promote'));
+    }
+
+    // ---------------------------------------------------------------- machinery
+
+    /**
+     * Drive `POST /admin/locales/{locale}/{action}` against the tree rooted at `$root`.
+     *
+     * @return array<string, mixed>
+     */
+    private function curate(string $root, string $locale, string $action): array
+    {
+        Router::$apiFilePath = $root;
+        SupportedLocales::reset();
+
+        return $this->decodeJsonBody(
+            ( new LocalesAdminHandler(['locales', $locale, $action]) )->handle(
+                $this->requestFor('POST', sprintf('/admin/locales/%s/%s', $locale, $action))
+                    ->withAttribute('oidc_user', self::globalAdmin())
+            )
+        );
+    }
+
+    /** @return array<string, mixed> */
+    private function listPayload(string $root): array
+    {
+        Router::$apiFilePath = $root;
+        SupportedLocales::reset();
+
+        return $this->decodeJsonBody(
+            ( new LocalesAdminHandler(['locales']) )->handle(
+                $this->requestFor('GET', '/admin/locales')->withAttribute('oidc_user', self::globalAdmin())
+            )
+        );
+    }
+
+    /** @return array<string, mixed> */
+    private static function globalAdmin(): array
+    {
+        return ['sub' => 'admin-1', 'roles' => ['admin']];
+    }
+
+    /**
+     * The flag on, the stack gone. `SourceDataWriteMode::stackAvailable()` needs the OpenFGA
+     * triple, so clearing it is enough and no database has to be taken away.
+     */
+    private function misconfigureQueueMode(): void
+    {
+        $_ENV[SourceDataWriteMode::FLAG] = 'true';
+        unset($_ENV['OPENFGA_API_URL'], $_ENV['OPENFGA_STORE_ID'], $_ENV['OPENFGA_MODEL_ID']);
+
+        self::assertTrue(SourceDataWriteMode::isMisconfigured(), 'the precondition this test forces did not take');
+    }
+
+    /**
+     * A tree indistinguishable from the repository to every reader the handler has, except
+     * that `jsondata/supportedLocales.json` is a real writable copy carrying `$official`.
+     *
+     * @param list<string>          $official
+     * @param array<string, string> $candidates
+     * @return string The root, with a trailing separator, as `Router::$apiFilePath` carries it.
+     */
+    private function seedResource(array $official, array $candidates = []): string
+    {
+        $repo = dirname(__DIR__, 2) . '/';
+        $root = sys_get_temp_dir() . '/litcal-locale-curation-' . bin2hex(random_bytes(6)) . '/';
+        mkdir($root . 'jsondata', 0o755, true);
+        $this->tempRoots[] = $root;
+
+        symlink($repo . 'i18n', $root . 'i18n');
+        symlink($repo . 'jsondata/sourcedata', $root . 'jsondata/sourcedata');
+        symlink($repo . 'jsondata/schemas', $root . 'jsondata/schemas');
+
+        $set = ['official' => $official];
+        if ($candidates !== []) {
+            $set['candidates'] = $candidates;
+        }
+
+        file_put_contents(
+            $root . 'jsondata/supportedLocales.json',
+            json_encode(
+                ['general_roman_calendar' => $set],
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR
+            ) . "\n"
+        );
+
+        return $root;
+    }
+
+    /** @return array<string, array<string, mixed>> */
+    private static function readResource(string $root): array
+    {
+        /** @var array<string, array<string, mixed>> $decoded */
+        $decoded = json_decode(
+            (string) file_get_contents($root . 'jsondata/supportedLocales.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        return $decoded;
+    }
+
+    private static function committedResourcePath(): string
+    {
+        return dirname(__DIR__, 2) . '/jsondata/supportedLocales.json';
+    }
+
+    /**
+     * The committed official list, read straight off disk rather than through
+     * `SupportedLocales::official()`, which these tests keep re-pointing at temp trees.
+     *
+     * @return list<string>
+     */
+    private static function committedOfficial(): array
+    {
+        /** @var array{general_roman_calendar: array{official: list<string>}} $decoded */
+        $decoded = json_decode((string) file_get_contents(self::committedResourcePath()), true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded['general_roman_calendar']['official'];
+    }
+
+    private static function removeTree(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $it = new \RecursiveIteratorIterator(
+            // No FOLLOW_SYMLINKS: the tree is made of symlinks into the repository, and
+            // descending into them would delete the repository's own source data.
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($it as $item) {
+            /** @var \SplFileInfo $item */
+            if ($item->isLink() || !$item->isDir()) {
+                unlink($item->getPathname());
+                continue;
+            }
+            rmdir($item->getPathname());
+        }
+
+        rmdir($dir);
+    }
+}

--- a/phpunit_tests/Handlers/LocalesAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/LocalesAdminHandlerTest.php
@@ -72,15 +72,39 @@ final class LocalesAdminHandlerTest extends AbstractHandlerTestCase
     }
 
     /**
-     * An operator seeing a green "ready" must be told why there is no promote
-     * button, rather than being left to wonder.
+     * `curation` is derived from the deployment's actual write mode, not hardcoded. This
+     * asserts the invariant that holds in every mode — the only thing this suite can say
+     * without dictating the environment it runs in; `LocalesAdminCurationTest` forces each
+     * mode in turn and pins its exact prose.
+     *
+     * The old assertion here was `writable === false` and a reason naming #902, which had
+     * already shipped: a constant that had quietly become a lie.
      */
-    public function testTheListExplainsWhyCurationIsNotWritableYet(): void
+    public function testTheListReportsTheRealCurationState(): void
     {
         $body = $this->json(['locales'], '/admin/locales', $this->globalAdmin());
 
-        self::assertFalse($body['curation']['writable']);
-        self::assertStringContainsString('#902', $body['curation']['reason']);
+        self::assertContains($body['curation']['mode'], ['change_request', 'disk', 'misconfigured']);
+        self::assertSame(
+            $body['curation']['mode'] !== 'misconfigured',
+            $body['curation']['writable'],
+            'writable must follow the mode, never be asserted independently of it'
+        );
+        // The frontend renders this verbatim, so it must read as prose in every branch.
+        self::assertNotSame('', $body['curation']['reason']);
+        self::assertStringNotContainsString('#902', $body['curation']['reason']);
+    }
+
+    /**
+     * `/admin/locales/{locale}/promote` is a POST route. A GET on it must not be answered
+     * as a readiness report for a locale called "promote".
+     */
+    public function testAGetOnACurationPathIsNotFound(): void
+    {
+        $this->expectException(NotFoundException::class);
+
+        ( new LocalesAdminHandler(['locales', 'hr', 'promote']) )
+            ->handle($this->request('/admin/locales/hr/promote', $this->globalAdmin()));
     }
 
     public function testASingleLocaleReturnsItsFullReport(): void

--- a/phpunit_tests/Handlers/LocalesAdminQueueModeTest.php
+++ b/phpunit_tests/Handlers/LocalesAdminQueueModeTest.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Database\Connection;
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Handlers\Admin\LocalesAdminHandler;
+use LiturgicalCalendar\Api\Http\Exception\ConflictException;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\ChangeResource;
+use LiturgicalCalendar\Api\Services\SourceData\ChangeRequestSchemaValidator;
+use LiturgicalCalendar\Api\Services\SourceData\ChangeRequestSourceDataWriter;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataSchemaResolver;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
+use LiturgicalCalendar\Api\Services\SupportedLocales;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * `POST /admin/locales/{locale}/promote` with change requests enabled.
+ *
+ * Three things only this mode can prove, and all three were the point of routing curation
+ * through the writer seam rather than writing the file directly:
+ *
+ * 1. A promotion becomes a reviewable proposal against
+ *    `general_roman_calendar:supported_locales`, and touches no file.
+ * 2. `supportedLocales.json` is an AGGREGATE — one file holding the whole official set — so a
+ *    second promotion must accumulate onto the submitter's first, unpublished one. Rebuilding
+ *    from disk here would silently drop it, which is the defect that once lost a decree behind
+ *    a `201`.
+ * 3. The batch's content is claimed by a schema, so the #918 approval-time re-validation gate
+ *    actually checks it. Before this branch there was no `SupportedLocales.json` at all, and
+ *    `SourceDataSchemaResolver::forPath()` answered null — which
+ *    {@see ChangeRequestSchemaValidator} reads as "not validated", not "invalid", so a
+ *    malformed promotion would have sailed through approval.
+ *
+ * Auto-approval is deliberately steered OFF by pointing OpenFGA at a store that does not
+ * exist, exactly as `RegionalDataQueueModeTest` does: `ChangeRequestReview::administers()`
+ * fails closed, so every submission here stays `submitted` and the assertions read a stable
+ * disposition.
+ */
+#[CoversClass(LocalesAdminHandler::class)]
+#[CoversClass(ChangeRequestSourceDataWriter::class)]
+#[CoversClass(SourceDataSchemaResolver::class)]
+#[CoversClass(ChangeRequestSchemaValidator::class)]
+#[CoversClass(ChangeResource::class)]
+final class LocalesAdminQueueModeTest extends AbstractHandlerTestCase
+{
+    protected static bool $requiresDatabase = true;
+
+    /** @var array<string, string|false> */
+    private array $originalEnv = [];
+
+    private string $savedApiFilePath = '';
+
+    private string $root = '';
+
+    private string $committedResourceDigest = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Connection::getInstance()->exec('TRUNCATE TABLE sourcedata_change_requests RESTART IDENTITY CASCADE');
+
+        $this->savedApiFilePath        = Router::$apiFilePath;
+        $this->committedResourceDigest = (string) md5_file(self::committedResourcePath());
+
+        foreach ([SourceDataWriteMode::FLAG, 'OPENFGA_API_URL', 'OPENFGA_STORE_ID', 'OPENFGA_MODEL_ID'] as $key) {
+            $this->originalEnv[$key] = $_ENV[$key] ?? false;
+        }
+
+        $_ENV[SourceDataWriteMode::FLAG] = 'true';
+        $_ENV['OPENFGA_API_URL']         = 'http://localhost:8083';
+        $_ENV['OPENFGA_STORE_ID']        = 'no-such-store-locale-curation-test';
+        $_ENV['OPENFGA_MODEL_ID']        = 'no-such-model-locale-curation-test';
+
+        // Two official locales withheld, so both are ready by construction and there is a
+        // second promotion to accumulate onto the first.
+        $this->root = $this->seedResource(array_slice(self::committedOfficial(), 2));
+
+        Router::$apiFilePath = $this->root;
+        SupportedLocales::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        Router::$apiFilePath = $this->savedApiFilePath;
+
+        foreach ($this->originalEnv as $key => $value) {
+            if (false === $value) {
+                unset($_ENV[$key]);
+            } else {
+                $_ENV[$key] = $value;
+            }
+        }
+        $this->originalEnv = [];
+
+        if ($this->root !== '') {
+            self::removeTree($this->root);
+            $this->root = '';
+        }
+
+        SupportedLocales::reset();
+
+        self::assertSame(
+            $this->committedResourceDigest,
+            (string) md5_file(self::committedResourcePath()),
+            'a test wrote to the committed jsondata/supportedLocales.json instead of its throwaway copy'
+        );
+
+        parent::tearDown();
+    }
+
+    public function testAPromotionBecomesAChangeRequestAndWritesNoFile(): void
+    {
+        $before  = (string) file_get_contents($this->resourcePath());
+        $promote = self::committedOfficial()[0];
+
+        $body = $this->promote($promote);
+
+        self::assertSame('submitted', $body['disposition']);
+        self::assertSame('general_roman_calendar', $body['change_request']['resource']['type']);
+        self::assertSame('supported_locales', $body['change_request']['resource']['id']);
+        self::assertSame(['jsondata/supportedLocales.json'], $body['change_request']['paths']);
+        self::assertSame($before, (string) file_get_contents($this->resourcePath()), 'queue mode must touch no file');
+    }
+
+    /**
+     * The reason `readCuratedResource()` goes through `unpublishedSourceContent()` rather than
+     * reading the file: in queue mode the first promotion never reached disk, so a second one
+     * rebuilt from disk would propose a list missing the first locale.
+     */
+    public function testASecondPromotionAccumulatesOntoTheFirstUnpublishedOne(): void
+    {
+        [$first, $second] = array_slice(self::committedOfficial(), 0, 2);
+
+        $this->promote($first);
+        $body = $this->promote($second);
+
+        self::assertContains($first, $body['official'], 'the first, still unpublished, promotion was dropped');
+        self::assertContains($second, $body['official']);
+    }
+
+    /**
+     * The corollary: a locale already promoted in flight is already official as far as the
+     * next request is concerned, so promoting it twice is a conflict rather than a duplicate
+     * entry in the list.
+     */
+    public function testPromotingTheSameLocaleTwiceConflictsOnTheUnpublishedList(): void
+    {
+        $locale = self::committedOfficial()[0];
+        $this->promote($locale);
+
+        $this->expectException(ConflictException::class);
+        $this->expectExceptionMessage('already officially supported');
+
+        $this->promote($locale);
+    }
+
+    /**
+     * The #918 gate, end to end: the row a promotion queues is claimed by
+     * `SupportedLocales.json`, and its content passes.
+     */
+    public function testTheQueuedRowIsClaimedByTheSupportedLocalesSchemaAndValidates(): void
+    {
+        $body = $this->promote(self::committedOfficial()[0]);
+        $rows = ( new SourceDataChangeRequestRepository(self::$pdo) )->getBatch($body['change_request']['batch_id']);
+
+        self::assertCount(1, $rows);
+        self::assertSame(
+            LitSchema::SUPPORTED_LOCALES,
+            SourceDataSchemaResolver::forPath((string) $rows[0]['path']),
+            'an unclaimed path is treated as "not validated", so a malformed promotion would approve unchecked'
+        );
+        self::assertSame([], ( new ChangeRequestSchemaValidator() )->violations($rows));
+    }
+
+    /**
+     * The other half of the same gate: content that would be accepted while nothing claimed
+     * the path is now a named violation. `official` may not be empty — an empty list is
+     * indistinguishable from an unreadable resource, and the API would silently fall back to
+     * its built-in five.
+     */
+    public function testAnEmptyOfficialListIsAViolationOfTheSupportedLocalesSchema(): void
+    {
+        $violations = ( new ChangeRequestSchemaValidator() )->violations([
+            [
+                'path'    => 'jsondata/supportedLocales.json',
+                'content' => '{"general_roman_calendar":{"official":[]}}',
+            ],
+        ]);
+
+        self::assertCount(1, $violations);
+        self::assertSame('SupportedLocales.json', $violations[0]['schema']);
+    }
+
+    // ---------------------------------------------------------------- machinery
+
+    /** @return array<string, mixed> */
+    private function promote(string $locale): array
+    {
+        return $this->decodeJsonBody(
+            ( new LocalesAdminHandler(['locales', $locale, 'promote']) )->handle(
+                $this->requestFor('POST', '/admin/locales/' . $locale . '/promote')
+                    ->withAttribute('oidc_user', ['sub' => 'admin-1', 'roles' => ['admin']])
+            )
+        );
+    }
+
+    private function resourcePath(): string
+    {
+        return $this->root . 'jsondata/supportedLocales.json';
+    }
+
+    /**
+     * @param list<string> $official
+     */
+    private function seedResource(array $official): string
+    {
+        $repo = dirname(__DIR__, 2) . '/';
+        $root = sys_get_temp_dir() . '/litcal-locale-queue-' . bin2hex(random_bytes(6)) . '/';
+        mkdir($root . 'jsondata', 0o755, true);
+
+        symlink($repo . 'i18n', $root . 'i18n');
+        symlink($repo . 'jsondata/sourcedata', $root . 'jsondata/sourcedata');
+        symlink($repo . 'jsondata/schemas', $root . 'jsondata/schemas');
+
+        file_put_contents(
+            $root . 'jsondata/supportedLocales.json',
+            json_encode(
+                ['general_roman_calendar' => ['official' => $official]],
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR
+            ) . "\n"
+        );
+
+        return $root;
+    }
+
+    private static function committedResourcePath(): string
+    {
+        return dirname(__DIR__, 2) . '/jsondata/supportedLocales.json';
+    }
+
+    /** @return list<string> */
+    private static function committedOfficial(): array
+    {
+        /** @var array{general_roman_calendar: array{official: list<string>}} $decoded */
+        $decoded = json_decode((string) file_get_contents(self::committedResourcePath()), true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded['general_roman_calendar']['official'];
+    }
+
+    private static function removeTree(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $it = new \RecursiveIteratorIterator(
+            // No FOLLOW_SYMLINKS: the tree is symlinks into the repository.
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($it as $item) {
+            /** @var \SplFileInfo $item */
+            if ($item->isLink() || !$item->isDir()) {
+                unlink($item->getPathname());
+                continue;
+            }
+            rmdir($item->getPathname());
+        }
+
+        rmdir($dir);
+    }
+}

--- a/phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php
+++ b/phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php
@@ -26,7 +26,7 @@ final class AccessRequestRepositoryConstantsTest extends TestCase
         // Independently pin the exact set of valid ids, so this test fails if the
         // production constant gains, loses, or reorders an entry.
         self::assertSame(
-            ['temporale', 'EDITIO_TYPICA_1970', 'EDITIO_TYPICA_2002', 'EDITIO_TYPICA_2008', 'decrees'],
+            ['temporale', 'EDITIO_TYPICA_1970', 'EDITIO_TYPICA_2002', 'EDITIO_TYPICA_2008', 'decrees', 'supported_locales'],
             AccessRequestRepository::GRC_OBJECT_IDS
         );
 

--- a/phpunit_tests/Schemas/OpenApiAdminLocalesTest.php
+++ b/phpunit_tests/Schemas/OpenApiAdminLocalesTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Schemas;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * What `openapi.json` says about the supported-locale curation routes.
+ *
+ * `GET /admin/locales` was documented as read-only, with a `curation` object whose whole
+ * content was a boolean and a sentence. The route can now be written to, and a generated
+ * client that cannot see the write route is as good as not having one — so the two POST paths
+ * and the widened `curation` object are pinned here rather than left to drift (issue #926).
+ */
+#[CoversNothing]
+final class OpenApiAdminLocalesTest extends TestCase
+{
+    /** @var array<string, mixed>|null */
+    private static ?array $openapi = null;
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function openapi(): array
+    {
+        if (null === self::$openapi) {
+            /** @var array<string, mixed> $decoded */
+            $decoded       = json_decode(
+                (string) file_get_contents(dirname(__DIR__, 2) . '/jsondata/schemas/openapi.json'),
+                true,
+                512,
+                JSON_THROW_ON_ERROR
+            );
+            self::$openapi = $decoded;
+        }
+
+        return self::$openapi;
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function curationPaths(): array
+    {
+        return [
+            'promote' => ['/admin/locales/{locale}/promote', 'adminPromoteSupportedLocale'],
+            'demote'  => ['/admin/locales/{locale}/demote', 'adminDemoteSupportedLocale'],
+        ];
+    }
+
+    #[DataProvider('curationPaths')]
+    public function testTheCurationRouteIsDocumentedAsAPost(string $path, string $operationId): void
+    {
+        /** @var array<string, array<string, mixed>> $paths */
+        $paths = self::openapi()['paths'];
+
+        self::assertArrayHasKey($path, $paths);
+        self::assertSame(['post'], array_keys($paths[$path]), 'curation is a POST action, matching the other admin verbs');
+
+        /** @var array<string, mixed> $operation */
+        $operation = $paths[$path]['post'];
+        self::assertSame($operationId, $operation['operationId']);
+        self::assertSame(['Admin - Supported Locales'], $operation['tags']);
+        self::assertArrayNotHasKey('requestBody', $operation, 'the locale and the action are both in the path');
+
+        /** @var array<string, mixed> $responses */
+        $responses = $operation['responses'];
+        foreach (['200', '401', '403', '404', '409', '503'] as $status) {
+            self::assertArrayHasKey($status, $responses, $path . ' does not document a ' . $status);
+        }
+
+        self::assertSame(
+            '#/components/schemas/SupportedLocaleCurationResponse',
+            $responses['200']['content']['application/json']['schema']['$ref']
+        );
+    }
+
+    /**
+     * The readiness gate is the reason this route can refuse a request that is authorized,
+     * well-formed and names a real locale, so it must be documented as a distinct outcome.
+     * Demotion carries no such gate, by design, and must not claim one.
+     */
+    public function testOnlyPromotionDocumentsTheReadinessRefusal(): void
+    {
+        /** @var array<string, array<string, mixed>> $paths */
+        $paths = self::openapi()['paths'];
+
+        self::assertArrayHasKey('422', $paths['/admin/locales/{locale}/promote']['post']['responses']);
+        self::assertArrayNotHasKey('422', $paths['/admin/locales/{locale}/demote']['post']['responses']);
+    }
+
+    /**
+     * `writable` is no longer a constant, so what it depends on has to be visible: `mode` is
+     * the difference between an edit recorded for review and one written to a file the next
+     * deploy may overwrite.
+     */
+    public function testTheCurationObjectDeclaresTheWriteMode(): void
+    {
+        /** @var array<string, mixed> $curation */
+        $curation = self::openapi()['components']['schemas']['SupportedLocalesResponse']['properties']['curation'];
+
+        self::assertSame(['writable', 'mode', 'reason'], $curation['required']);
+        self::assertSame(
+            ['change_request', 'disk', 'misconfigured'],
+            $curation['properties']['mode']['enum']
+        );
+    }
+}

--- a/phpunit_tests/Schemas/SupportedLocalesSchemaTest.php
+++ b/phpunit_tests/Schemas/SupportedLocalesSchemaTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Schemas;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\SchemaRole;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Swaggest\JsonSchema\Schema;
+
+/**
+ * `SupportedLocales.json`, the schema `jsondata/supportedLocales.json` had gone without.
+ *
+ * It exists for a specific job: a curation change request stores a path, and
+ * `SourceDataSchemaResolver` must be able to say what shape the bytes at that path should
+ * have. A path no schema claims is read by `ChangeRequestSchemaValidator` as "not validated"
+ * rather than "invalid", so without this a malformed promotion would be approved unchecked
+ * (issue #926, gate #918).
+ *
+ * The constraint worth having a schema for at all is `official`'s `minItems`. An empty list is
+ * NOT the same as no official locales: `SupportedLocales::official()` substitutes its built-in
+ * FALLBACK for an empty or unreadable resource, so a write that emptied the list would
+ * silently restore the historical five instead of doing what it said.
+ */
+#[CoversNothing]
+final class SupportedLocalesSchemaTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        // LitSchema::path() and JsonData::*->path() both read Router::$apiFilePath.
+        Router::getApiPaths();
+    }
+
+    private static function schema(): Schema
+    {
+        $schema = Schema::import(LitSchema::SUPPORTED_LOCALES->path());
+        self::assertInstanceOf(Schema::class, $schema);
+
+        return $schema;
+    }
+
+    /**
+     * SOURCE, not OUTPUT: these are bytes this repository stores and a change request
+     * proposes, never a response the API emits.
+     */
+    public function testTheSchemaIsClassifiedAsSourceData(): void
+    {
+        self::assertSame(SchemaRole::SOURCE, LitSchema::SUPPORTED_LOCALES->role());
+    }
+
+    public function testTheCommittedResourceValidates(): void
+    {
+        self::schema()->in(json_decode((string) file_get_contents(JsonData::SUPPORTED_LOCALES_FILE->path())));
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAMinimalResourceValidates(): void
+    {
+        self::schema()->in(json_decode('{"general_roman_calendar":{"official":["la"]}}'));
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidResources(): array
+    {
+        return [
+            'no official list'          => ['{"general_roman_calendar":{}}'],
+            'empty official list'       => ['{"general_roman_calendar":{"official":[]}}'],
+            'duplicated official entry' => ['{"general_roman_calendar":{"official":["la","la"]}}'],
+            'unknown locale'            => ['{"general_roman_calendar":{"official":["zz"]}}'],
+            'non-string official entry' => ['{"general_roman_calendar":{"official":[7]}}'],
+            'candidate without a note'  => ['{"general_roman_calendar":{"official":["la"],"candidates":{"hr":""}}}'],
+            'candidate note not prose'  => ['{"general_roman_calendar":{"official":["la"],"candidates":{"hr":true}}}'],
+            'unknown candidate locale'  => ['{"general_roman_calendar":{"official":["la"],"candidates":{"zz":"why"}}}'],
+            'stray key in the set'      => ['{"general_roman_calendar":{"official":["la"],"pending":["hr"]}}'],
+            'unknown calendar'          => ['{"general_roman_calendar":{"official":["la"]},"ambrosian_calendar":{"official":["it"]}}'],
+            'no calendar at all'        => ['{}'],
+        ];
+    }
+
+    #[DataProvider('invalidResources')]
+    public function testAMalformedResourceIsRejected(string $json): void
+    {
+        $this->expectException(\Swaggest\JsonSchema\Exception::class);
+
+        self::schema()->in(json_decode($json));
+    }
+}

--- a/phpunit_tests/Services/ChangeResourceTest.php
+++ b/phpunit_tests/Services/ChangeResourceTest.php
@@ -41,6 +41,21 @@ final class ChangeResourceTest extends TestCase
         self::assertSame('decrees', $resource->id);
     }
 
+    /**
+     * A supported-locale set is not a calendar and is Roman by construction, so like the
+     * decrees corpus it takes a bare, non-rite-qualified id on the general_roman_calendar
+     * type. Reusing the existing type is what keeps this off the OpenFGA model: ids are not
+     * part of the model, only types and relations are (issue #926).
+     */
+    public function testSupportedLocalesIsTheGeneralRomanCalendarSupportedLocalesObject(): void
+    {
+        $resource = ChangeResource::supportedLocales();
+
+        self::assertSame('general_roman_calendar', $resource->type);
+        self::assertSame('supported_locales', $resource->id);
+        self::assertNotSame(ChangeResource::decrees()->branch(), $resource->branch());
+    }
+
     public function testTestScopeIdsAreRiteQualified(): void
     {
         $resource = ChangeResource::test(Rite::AMBROSIAN, 'diocesan_calendar_test', 'lugano_ch');
@@ -135,6 +150,7 @@ final class ChangeResourceTest extends TestCase
             ChangeResource::diocesanCalendar(Rite::ROMAN, 'romamo_it'),
             ChangeResource::widerRegion('Americas'),
             ChangeResource::decrees(),
+            ChangeResource::supportedLocales(),
             ChangeResource::test(Rite::ROMAN, 'national_calendar_test', 'US'),
             ChangeResource::test(Rite::AMBROSIAN, 'diocesan_calendar_test', 'lugano_ch'),
             ChangeResource::test(Rite::AMBROSIAN, 'general_roman_calendar_test', 'general_roman_calendar'),

--- a/phpunit_tests/Services/SourceData/SourceDataSchemaResolverTest.php
+++ b/phpunit_tests/Services/SourceData/SourceDataSchemaResolverTest.php
@@ -51,6 +51,7 @@ final class SourceDataSchemaResolverTest extends TestCase
             'decrees corpus'               => ['jsondata/sourcedata/rite/roman/decrees/decrees.json', LitSchema::DECREES_SRC],
             'decrees i18n sidecar'         => ['jsondata/sourcedata/rite/roman/decrees/i18n/en.json', LitSchema::I18N],
             'decrees lectionary sidecar'   => ['jsondata/sourcedata/rite/roman/decrees/lectionary/en.json', LitSchema::LECTIONARY],
+            'supported locales resource'   => ['jsondata/supportedLocales.json', LitSchema::SUPPORTED_LOCALES],
             'roman test definition'        => ['jsondata/tests/roman/AllSaintsTest.json', LitSchema::TEST_SRC],
             'ambrosian test definition'    => ['jsondata/tests/ambrosian/AllSaintsTest.json', LitSchema::TEST_SRC],
         ];

--- a/src/Enum/LitSchema.php
+++ b/src/Enum/LitSchema.php
@@ -27,6 +27,23 @@ enum LitSchema: string
     case DATA              = '/LitCalDataPath.json';
     case SCHEMAS           = '/LitCalSchemasPath.json';
     case VALIDATIONS       = '/LitCalValidationsPath.json';
+    /**
+     * `jsondata/supportedLocales.json` — the curated set of officially supported locales.
+     *
+     * SOURCE, not OUTPUT: these are bytes the repository stores and a change request writes,
+     * not a response this API emits. The file sits beside `jsondata/sourcedata` rather than
+     * inside it, which is a fact about where reference resources live, not about what the
+     * schema validates — see {@see SchemaRole::SOURCE}.
+     *
+     * Deliberately NOT a `CheckableItem`. `/validations` enumerates the source corpus a
+     * calendar is assembled from — calendars, missals, lectionary folders — and answers
+     * "exists / parses / validates / covers" for each. This resource is a single top-level
+     * file with no locale-folder shape to cover, and its real invariant is not its shape but
+     * whether the locales it names actually have their data — which `composer lint:locales`
+     * and `/health`'s `locale_readiness` block already assert, far more strongly than a
+     * schema could.
+     */
+    case SUPPORTED_LOCALES = '/SupportedLocales.json';
     case WEBSOCKET_MESSAGE = '/WebSocketMessage.json';
     case WEBSOCKET_FRAME   = '/WebSocketFrame.json';
 
@@ -71,6 +88,7 @@ enum LitSchema: string
             LitSchema::DATA     => $ERRMSG . 'Data path data not valid',
             LitSchema::SCHEMAS  => $ERRMSG . 'Schemas path data not valid',
             LitSchema::VALIDATIONS => $ERRMSG . 'Validations path data not valid',
+            LitSchema::SUPPORTED_LOCALES => $ERRMSG . 'Supported locales resource not created / updated',
             LitSchema::WEBSOCKET_MESSAGE => $ERRMSG . 'WebSocket message not valid',
             LitSchema::WEBSOCKET_FRAME   => $ERRMSG . 'WebSocket frame not valid'
         };
@@ -95,6 +113,7 @@ enum LitSchema: string
             LitSchema::DECREES_SRC,
             LitSchema::I18N,
             LitSchema::TEST_SRC,
+            LitSchema::SUPPORTED_LOCALES,
             LitSchema::LECTIONARY        => SchemaRole::SOURCE,
             LitSchema::LITCAL,
             LitSchema::METADATA,
@@ -135,6 +154,7 @@ enum LitSchema: string
             LitSchema::DATA->path()              => LitSchema::DATA,
             LitSchema::SCHEMAS->path()           => LitSchema::SCHEMAS,
             LitSchema::VALIDATIONS->path()       => LitSchema::VALIDATIONS,
+            LitSchema::SUPPORTED_LOCALES->path() => LitSchema::SUPPORTED_LOCALES,
             LitSchema::WEBSOCKET_MESSAGE->path() => LitSchema::WEBSOCKET_MESSAGE,
             LitSchema::WEBSOCKET_FRAME->path()   => LitSchema::WEBSOCKET_FRAME,
             default                              => throw new ValidationException('Invalid schema URL: ' . $url)

--- a/src/Enum/SchemaRole.php
+++ b/src/Enum/SchemaRole.php
@@ -22,7 +22,16 @@ namespace LiturgicalCalendar\Api\Enum;
  */
 enum SchemaRole: string
 {
-    /** Validates data as it is stored under `jsondata/sourcedata/`. */
+    /**
+     * Validates data as this repository STORES it — the `jsondata/sourcedata/` corpus, and
+     * the curated reference resources that sit beside it at the top of `jsondata/`
+     * (`supportedLocales.json`).
+     *
+     * The line this role draws is stored-versus-emitted, not which directory a file happens
+     * to live in. What makes a schema SOURCE is that a change request can propose bytes for
+     * it and {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataSchemaResolver} must
+     * be able to name the schema those bytes are checked against.
+     */
     case SOURCE = 'source';
 
     /** Validates a response this API emits. */

--- a/src/Handlers/Admin/LocalesAdminHandler.php
+++ b/src/Handlers/Admin/LocalesAdminHandler.php
@@ -4,38 +4,89 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Api\Handlers\Admin;
 
+use LiturgicalCalendar\Api\Enum\ChangeOperation;
+use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Handlers\AbstractHandler;
+use LiturgicalCalendar\Api\Handlers\Concerns\ResolvesFgaClient;
+use LiturgicalCalendar\Api\Handlers\Concerns\WritesSourceData;
 use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
 use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
 use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use LiturgicalCalendar\Api\Http\Exception\ConflictException;
 use LiturgicalCalendar\Api\Http\Exception\ForbiddenException;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
+use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Http\Exception\UnprocessableContentException;
+use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
 use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
+use LiturgicalCalendar\Api\Services\ChangeResource;
 use LiturgicalCalendar\Api\Services\Locale\LocaleReadinessChecker;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
 use LiturgicalCalendar\Api\Services\SupportedLocales;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
 
 /**
- * Curation surface for the officially supported locales (#904).
+ * Curation surface for the officially supported locales (#904, #926).
  *
- * - `GET /admin/locales`            — every candidate locale, official flag, readiness
- * - `GET /admin/locales/{locale}`   — the full readiness report for one locale
+ * - `GET  /admin/locales`                   — every candidate locale, official flag, readiness
+ * - `GET  /admin/locales/{locale}`           — the full readiness report for one locale
+ * - `POST /admin/locales/{locale}/promote`   — add the locale to the official set
+ * - `POST /admin/locales/{locale}/demote`    — remove it again
  *
- * Read-only by design, for now. Promotion writes `jsondata/supportedLocales.json`
- * on the deployed server, which the next deploy would overwrite — the problem
- * tracked in #902. Until change requests can carry that write, promotion stays a
- * reviewed pull request, and this endpoint exists to tell an operator whether
- * such a pull request would be safe to open.
+ * **Where a promotion goes.** Through {@see WritesSourceData}, exactly like every other
+ * source-data write: a reviewable change request where queue mode is configured, a direct
+ * disk write where it is not. That is what #902 was waiting for, and it is why the endpoint
+ * no longer has to tell operators to open a pull request by hand.
  *
- * Restricted to global (Zitadel) admins: this is a governance decision about the
- * API's published contract, not a per-resource one, so resource-admin scopes do
- * not apply.
+ * **What a promotion is gated on, and what it is not.** Promotion is not a label — it
+ * changes behaviour. `ReadingsMap::getReadings()` throws for an official locale and degrades
+ * quietly for every other one, so promoting a locale whose data is incomplete converts silent
+ * gaps into 500s on a calendar the API advertises. {@see LocaleReadinessChecker} is the
+ * pre-flight for exactly that, and it is **not bypassable**: there is no `force` parameter and
+ * no role that skips it. If the data is complete the checker says so; if the checker is wrong
+ * the fix is to the checker, not a flag that routes around it.
+ *
+ * Demotion is deliberately NOT readiness-gated, and the asymmetry is the point. Removing a
+ * locale from the official set LOOSENS enforcement — the same missing readings that would
+ * have thrown now degrade quietly — so it can never turn a working calendar into a 500. What
+ * it can do is silently change published output: `/calendars` stops advertising the locale and
+ * affected events start serving nothing instead of erroring. That is a governance risk, not a
+ * data-integrity one, so the control that applies to it is review (the change request and its
+ * audit trail), not a readiness probe. Two integrity guards do still apply: the locale must
+ * actually be official, and the last official locale may not be removed — an empty `official`
+ * list is indistinguishable from an unreadable file, and {@see SupportedLocales::official()}
+ * would silently substitute its built-in fallback for it.
+ *
+ * **Reading before writing.** `supportedLocales.json` is an AGGREGATE file — one file holding
+ * the whole official set plus every candidate note — so the current content is read through
+ * {@see WritesSourceData::unpublishedSourceContent()} rather than straight off disk. In queue
+ * mode a submitter's previous promotion never reaches disk, and rebuilding from disk would
+ * silently drop it.
+ *
+ * Restricted to global (Zitadel) admins: which locales the API declares supported is a
+ * governance decision about its published contract, not a per-resource one, so resource-admin
+ * scopes do not open the endpoint. They do decide what happens to a submission once it is
+ * made: a caller holding `admin` on `general_roman_calendar:supported_locales` has their change
+ * auto-approved, and everyone else's waits for a reviewer — the ordinary change-request rule.
  */
 final class LocalesAdminHandler extends AbstractHandler
 {
+    use ResolvesFgaClient;
+    use WritesSourceData;
+
+    private const ACTION_PROMOTE = 'promote';
+
+    private const ACTION_DEMOTE = 'demote';
+
+    /** The one calendar that curates a supported-locale set. Mirrors the resource's own top-level key. */
+    private const CALENDAR_KEY = 'general_roman_calendar';
+
     private ?LocaleReadinessChecker $checker;
+
+    private ?LoggerInterface $auditLogger = null;
 
     /**
      * @param string[] $requestPathParams
@@ -45,7 +96,7 @@ final class LocalesAdminHandler extends AbstractHandler
         parent::__construct($requestPathParams);
 
         $this->checker               = $checker;
-        $this->allowedRequestMethods = [RequestMethod::GET];
+        $this->allowedRequestMethods = [RequestMethod::GET, RequestMethod::POST];
         $this->allowedAcceptHeaders  = [AcceptHeader::JSON];
         $this->allowCredentials      = true;
     }
@@ -75,6 +126,14 @@ final class LocalesAdminHandler extends AbstractHandler
             throw new ForbiddenException('Global admin role required to curate supported locales');
         }
 
+        if ($method === RequestMethod::POST) {
+            // Captured before any staging, the same way every other write handler does it:
+            // the change request's author is the authenticated identity of this request.
+            $this->captureSubmitter($request);
+
+            return $this->encodeResponseBody($response, $this->curate());
+        }
+
         $locale = $this->requestedLocale();
 
         return $this->encodeResponseBody(
@@ -91,6 +150,12 @@ final class LocalesAdminHandler extends AbstractHandler
      */
     private function requestedLocale(): ?string
     {
+        if (count($this->requestPathParams) > 2) {
+            // `/admin/locales/{locale}/promote` is a POST route; a GET on it is not a
+            // readiness report for a locale called "promote".
+            throw new NotFoundException('The readiness report path is /admin/locales/{locale}');
+        }
+
         $segment = $this->requestPathParams[1] ?? null;
 
         return is_string($segment) && $segment !== '' ? $segment : null;
@@ -115,12 +180,51 @@ final class LocalesAdminHandler extends AbstractHandler
         return [
             'official'   => SupportedLocales::official(),
             'candidates' => $reports,
-            // Surfaced rather than left implicit: an operator who sees a green
-            // "ready" here should know why there is no promote button yet.
-            'curation'   => [
+            'curation'   => $this->curationState(),
+        ];
+    }
+
+    /**
+     * Whether curation is available here, and what a write would actually do.
+     *
+     * Computed rather than constant. `writable` answers the question the admin interface
+     * asks — "will a promote/demote from this caller be accepted?" — and `mode` says what
+     * accepting it means, because a change recorded as a reviewable request and a change
+     * written straight to a file that the next deploy may overwrite are not the same
+     * promise. The frontend renders `reason` verbatim, so it must read as prose to a human
+     * in every branch, not only the refusing one.
+     *
+     * @return array{writable: bool, mode: string, reason: string}
+     */
+    private function curationState(): array
+    {
+        if (SourceDataWriteMode::isMisconfigured()) {
+            return [
                 'writable' => false,
-                'reason'   => 'Promotion writes jsondata/supportedLocales.json, which the next deploy would overwrite (see issue #902). Promote by opening a pull request against that file.',
-            ],
+                'mode'     => 'misconfigured',
+                'reason'   => 'SOURCEDATA_CHANGE_REQUESTS is set, but Postgres and/or OpenFGA are not both reachable. '
+                    . 'A promotion here would silently fall back to writing jsondata/supportedLocales.json on the very '
+                    . 'deployment that asked for durable, reviewable edits, and the next deploy would revert it with no '
+                    . 'trace. Curation is refused until the stack is reachable again.',
+            ];
+        }
+
+        if (SourceDataWriteMode::changeRequestsEnabled()) {
+            return [
+                'writable' => true,
+                'mode'     => 'change_request',
+                'reason'   => 'A promotion or demotion is recorded as a reviewable change request against '
+                    . 'jsondata/supportedLocales.json. It is approved immediately if you administer '
+                    . 'general_roman_calendar:supported_locales, and waits for a reviewer otherwise.',
+            ];
+        }
+
+        return [
+            'writable' => true,
+            'mode'     => 'disk',
+            'reason'   => 'A promotion or demotion is written straight to jsondata/supportedLocales.json. '
+                . 'A deployment that syncs its tree from git will overwrite the edit on the next deploy; set '
+                . 'SOURCEDATA_CHANGE_REQUESTS to record curation as reviewable change requests instead.',
         ];
     }
 
@@ -141,8 +245,246 @@ final class LocalesAdminHandler extends AbstractHandler
         return $payload;
     }
 
+    /**
+     * `POST /admin/locales/{locale}/{promote|demote}`.
+     *
+     * @return array<string, mixed>
+     */
+    private function curate(): array
+    {
+        if (count($this->requestPathParams) !== 3) {
+            throw new NotFoundException(
+                'Curation requires POST /admin/locales/{locale}/promote or POST /admin/locales/{locale}/demote'
+            );
+        }
+
+        $locale = $this->requestPathParams[1];
+        $action = $this->requestPathParams[2];
+
+        if (false === in_array($action, [self::ACTION_PROMOTE, self::ACTION_DEMOTE], true)) {
+            throw new NotFoundException(sprintf(
+                'Unknown curation action "%s"; expected %s or %s',
+                $action,
+                self::ACTION_PROMOTE,
+                self::ACTION_DEMOTE
+            ));
+        }
+
+        if (SourceDataWriteMode::isMisconfigured()) {
+            // Fail closed rather than falling back to disk, unlike the calendar write
+            // handlers. They tolerate the fallback because refusing would stop calendar
+            // editing outright; promotion is a rare governance action with an understood
+            // manual alternative, so a silently-reverted edit is the worse outcome here.
+            throw new ServiceUnavailableException($this->curationState()['reason']);
+        }
+
+        $resource = $this->readCuratedResource();
+        $official = $this->officialFrom($resource);
+
+        $official = $action === self::ACTION_PROMOTE
+            ? $this->promoted($locale, $official)
+            : $this->demoted($locale, $official);
+
+        $set             = $resource[self::CALENDAR_KEY];
+        $set['official'] = $official;
+
+        if ($action === self::ACTION_PROMOTE && isset($set['candidates']) && is_array($set['candidates'])) {
+            // A promoted locale is no longer a candidate, and the prose reason it was not
+            // yet official is now false. Leaving it would make the file contradict itself.
+            unset($set['candidates'][$locale]);
+            if ($set['candidates'] === []) {
+                unset($set['candidates']);
+            }
+        }
+
+        $resource[self::CALENDAR_KEY] = $set;
+
+        $path = JsonData::SUPPORTED_LOCALES_FILE->path();
+        $this->stageFile($path, ChangeOperation::UPDATE, self::encode($resource));
+        $result = $this->commitStagedFiles(ChangeResource::supportedLocales());
+
+        // The memo is per process and would otherwise keep serving the pre-write list to
+        // everything else in this request — including the payload assembled just below.
+        SupportedLocales::reset();
+
+        $this->auditLogger()->info('Supported locale curated', [
+            'operation'   => strtoupper($action),
+            'resource'    => 'supported_locales',
+            'locale'      => $locale,
+            'official'    => $official,
+            'disposition' => $result['disposition'] ?? null,
+        ]);
+
+        return array_merge(
+            [
+                'locale'   => $locale,
+                'action'   => $action,
+                'official' => $official,
+            ],
+            $result
+        );
+    }
+
+    /**
+     * The official set with `$locale` added, or a refusal explaining why it may not be.
+     *
+     * @param list<string> $official
+     * @return list<string>
+     */
+    private function promoted(string $locale, array $official): array
+    {
+        $checker = $this->checker();
+
+        if (false === in_array($locale, $checker->knownLocales(), true)) {
+            throw new NotFoundException(sprintf('No resources found for locale "%s"', $locale));
+        }
+
+        if (in_array($locale, $official, true)) {
+            throw new ConflictException(sprintf('Locale "%s" is already officially supported', $locale));
+        }
+
+        $report = $checker->check($locale);
+        if (false === $report->ready()) {
+            throw new UnprocessableContentException(sprintf(
+                'Locale "%s" is not ready to be promoted: %s. An official locale is served strictly — a missing '
+                    . 'readings entry throws rather than degrading — so promoting it now would turn silent gaps into '
+                    . '500s. Complete the data first; GET /admin/locales/%s names the exact files and event keys.',
+                $locale,
+                $report->describe(),
+                $locale
+            ));
+        }
+
+        $official[] = $locale;
+        // Sorted, so the file keeps its alphabetical order and a promotion is a one-line diff
+        // wherever the locale happens to land.
+        sort($official);
+
+        return $official;
+    }
+
+    /**
+     * The official set with `$locale` removed, or a refusal explaining why it may not be.
+     *
+     * @param list<string> $official
+     * @return list<string>
+     */
+    private function demoted(string $locale, array $official): array
+    {
+        if (false === in_array($locale, $official, true)) {
+            throw new ConflictException(sprintf('Locale "%s" is not officially supported, so it cannot be demoted', $locale));
+        }
+
+        if (count($official) === 1) {
+            throw new ConflictException(
+                'Refusing to demote the last officially supported locale: an empty list is indistinguishable from '
+                . 'an unreadable resource, and the API would silently fall back to its built-in list rather than '
+                . 'supporting nothing. Promote a replacement first.'
+            );
+        }
+
+        return array_values(array_filter($official, static fn (string $l): bool => $l !== $locale));
+    }
+
+    /**
+     * The curated resource as it stands for THIS submitter — their own unpublished edit when
+     * they have one in flight, otherwise the committed file.
+     *
+     * @return array<string, array<array-key, mixed>>
+     */
+    private function readCuratedResource(): array
+    {
+        $path = JsonData::SUPPORTED_LOCALES_FILE->path();
+        $raw  = $this->unpublishedSourceContent($path);
+
+        if ($raw === null) {
+            $onDisk = is_file($path) ? file_get_contents($path) : false;
+            $raw    = $onDisk === false ? null : $onDisk;
+        }
+
+        if ($raw === null) {
+            throw new ServiceUnavailableException('The supported locales resource could not be read');
+        }
+
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new ServiceUnavailableException('The supported locales resource is not valid JSON: ' . $e->getMessage());
+        }
+
+        if (false === is_array($decoded) || false === isset($decoded[self::CALENDAR_KEY])) {
+            throw new ServiceUnavailableException(sprintf(
+                'The supported locales resource has no "%s" object to curate',
+                self::CALENDAR_KEY
+            ));
+        }
+
+        // Every top-level value is a per-calendar curated set. Checked rather than assumed,
+        // because the annotation below is what lets the curation code index into one without
+        // re-testing at every step.
+        $resource = [];
+        foreach ($decoded as $calendar => $set) {
+            if (false === is_string($calendar) || false === is_array($set)) {
+                throw new ServiceUnavailableException('The supported locales resource is not a map of calendars to curated sets');
+            }
+            $resource[$calendar] = $set;
+        }
+
+        return $resource;
+    }
+
+    /**
+     * The DECLARED official list, which is not the same thing as
+     * {@see SupportedLocales::official()}: that method substitutes its built-in fallback
+     * when the resource cannot be read, and curating a list nobody wrote would write the
+     * fallback into the file as though an operator had chosen it.
+     *
+     * @param array<string, array<array-key, mixed>> $resource
+     * @return list<string>
+     */
+    private function officialFrom(array $resource): array
+    {
+        $declared = $resource[self::CALENDAR_KEY]['official'] ?? null;
+
+        if (false === is_array($declared)) {
+            throw new ServiceUnavailableException('The supported locales resource declares no official list to curate');
+        }
+
+        $official = [];
+        foreach ($declared as $value) {
+            if (is_string($value) && $value !== '') {
+                $official[] = $value;
+            }
+        }
+
+        if ($official === []) {
+            throw new ServiceUnavailableException('The supported locales resource declares an empty official list');
+        }
+
+        return $official;
+    }
+
+    /**
+     * Serialised the way the committed file is written, so a disk-mode edit produces a
+     * one-line diff rather than reformatting the whole resource.
+     *
+     * @param array<string, array<array-key, mixed>> $resource
+     */
+    private static function encode(array $resource): string
+    {
+        return json_encode(
+            $resource,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR
+        ) . "\n";
+    }
+
     private function checker(): LocaleReadinessChecker
     {
         return $this->checker ??= new LocaleReadinessChecker();
+    }
+
+    private function auditLogger(): LoggerInterface
+    {
+        return $this->auditLogger ??= LoggerFactory::create('audit', null, 90, false, true, false);
     }
 }

--- a/src/Repositories/AccessRequestRepository.php
+++ b/src/Repositories/AccessRequestRepository.php
@@ -57,7 +57,7 @@ class AccessRequestRepository
      *
      * @var array<int, string>
      */
-    public const GRC_OBJECT_IDS = ['temporale', 'EDITIO_TYPICA_1970', 'EDITIO_TYPICA_2002', 'EDITIO_TYPICA_2008', 'decrees'];
+    public const GRC_OBJECT_IDS = ['temporale', 'EDITIO_TYPICA_1970', 'EDITIO_TYPICA_2002', 'EDITIO_TYPICA_2008', 'decrees', 'supported_locales'];
 
     /**
      * Valid OpenFGA object types on permission tuples.

--- a/src/Router.php
+++ b/src/Router.php
@@ -583,9 +583,11 @@ class Router
                         $applicationAdminHandler = new ApplicationAdminHandler();
                         $this->handler           = $applicationAdminHandler;
                     } elseif ($adminRoute === 'locales') {
-                        // Supported-locale curation (#904)
-                        // GET /admin/locales           - Candidate locales, official flag, readiness
-                        // GET /admin/locales/{locale}  - Full readiness report for one locale
+                        // Supported-locale curation (#904, #926)
+                        // GET  /admin/locales                  - Candidate locales, official flag, readiness
+                        // GET  /admin/locales/{locale}         - Full readiness report for one locale
+                        // POST /admin/locales/{locale}/promote - Add the locale to the official set
+                        // POST /admin/locales/{locale}/demote  - Remove it again
                         $localesAdminHandler = new LocalesAdminHandler($requestPathParts);
                         $this->handler       = $localesAdminHandler;
                     } elseif ($adminRoute === 'outbox') {

--- a/src/Services/ChangeResource.php
+++ b/src/Services/ChangeResource.php
@@ -76,6 +76,27 @@ final readonly class ChangeResource
     }
 
     /**
+     * The curated set of officially supported locales — a fixed object id on the
+     * general_roman_calendar type, exactly like {@see decrees()}.
+     *
+     * `jsondata/supportedLocales.json` is keyed by `general_roman_calendar` at its top
+     * level and {@see \LiturgicalCalendar\Api\Services\SupportedLocales::official()}
+     * describes itself as "the locales officially supported for the General Roman
+     * Calendar", so the scoping is already the resource's own. A supported-locale set is
+     * likewise not a calendar and is Roman by construction, which is why the id stays
+     * bare rather than rite-qualified — see the class docblock.
+     *
+     * A fixed id on an existing type needs no OpenFGA model migration: ids are not part
+     * of the authorization model, only types and relations are. The accepted consequence
+     * is that whoever administers the General Roman Calendar curates its supported
+     * locales (issue #926).
+     */
+    public static function supportedLocales(): self
+    {
+        return new self('general_roman_calendar', 'supported_locales');
+    }
+
+    /**
      * @param string $objectType One of AccessRequestRepository::VALID_OBJECT_TYPES ending in `_test`.
      * @param string $calendarId The calendar the test is scoped to, unqualified.
      */

--- a/src/Services/SourceData/SourceDataSchemaResolver.php
+++ b/src/Services/SourceData/SourceDataSchemaResolver.php
@@ -111,6 +111,15 @@ final class SourceDataSchemaResolver
             [JsonData::LECTIONARY_DECREES_FILE, LitSchema::LECTIONARY],
             [JsonData::DECREES_FILE, LitSchema::DECREES_SRC],
 
+            // The one curated reference resource a write handler can stage. It lives at the
+            // top of `jsondata/`, not under `jsondata/sourcedata` — which changes nothing
+            // here: this table answers "which schema governs this location", and the path
+            // still comes from the same JsonData constant the handler writes through.
+            // Without this row `forPath()` answers null, which
+            // ChangeRequestSchemaValidator reads as "not validated" rather than "invalid",
+            // and a malformed promotion would be approved unchecked (issue #926).
+            [JsonData::SUPPORTED_LOCALES_FILE, LitSchema::SUPPORTED_LOCALES],
+
             // The calendar files themselves.
             [JsonData::NATIONAL_CALENDAR_FILE, LitSchema::NATIONAL],
             [JsonData::DIOCESAN_CALENDAR_FILE, LitSchema::DIOCESAN],


### PR DESCRIPTION
Closes #926. Unblocks LiturgicalCalendarFrontend#506 — the read-only notice in `admin-locales.php` can become a Promote action.

## What this does

`GET /admin/locales` reported `curation.writable = false` unconditionally, with a reason citing #902 — which had already shipped. The durable write path the curation UI was waiting for existed; nothing was wired to it and there was no write route.

- `POST /admin/locales/{locale}/promote`
- `POST /admin/locales/{locale}/demote`

Both go through the `SourceDataWriter` seam, so a promotion is a reviewable change request in queue mode and a direct disk write in disk mode, exactly like every other source-data write. POST matches the house idiom for admin actions (`/admin/access-requests/{id}/approve`, `/admin/change-requests/{batchId}/approve`); neither takes a request body.

## Resource identity — the decision from #926, applied

`ChangeResource::supportedLocales()` returns `general_roman_calendar:supported_locales`, a fixed id on the existing type, exactly as `decrees()` does, and `supported_locales` joins `AccessRequestRepository::GRC_OBJECT_IDS`.

**No OpenFGA model migration.** Object ids are not part of the authorization model — only types and relations are — so this needs none, which matters while the dev store is deliberately held on the additive model until both APIs run merged code.

## The validation gap this had to close first

`SourceDataSchemaResolver` had no mapping for `jsondata/supportedLocales.json`, and there was **no schema for the file at all**. `forPath()` answered `null`, which `ChangeRequestSchemaValidator` reads as *not validated* rather than *invalid* — a malformed promotion would have been approved unchecked (#918's gate, blind here).

So this adds `jsondata/schemas/SupportedLocales.json` (draft-07, no `$id`, `$ref`s `CommonDef.json#/definitions/Locale`), a `LitSchema::SUPPORTED_LOCALES` case with role **`SOURCE`**, and the resolver mapping built from the same `JsonData::SUPPORTED_LOCALES_FILE` constant the handler writes through.

`SOURCE` because the line that role draws is stored-versus-emitted, not which directory a file sits in: these are bytes the repository stores and a change request proposes, never a response the API emits. `SchemaRole::SOURCE`'s docblock is widened to say so. The file is deliberately **not** a `CheckableItem` — `/validations` enumerates the corpus a calendar is assembled from and asks exists/parses/validates/covers, while this is one top-level file with no locale-folder shape to cover, whose real invariant (do the locales it names actually have their data?) is already asserted far more strongly by `composer lint:locales` and `/health`'s `locale_readiness` block.

The load-bearing constraint the schema encodes is `official`'s `minItems: 1`: an empty list is **not** "no official locales" — `SupportedLocales::official()` substitutes its built-in `FALLBACK` for an empty or unreadable resource, so a write that emptied it would silently restore the historical five.

## Promotion is gated; demotion is gated differently, on purpose

**Promotion** requires `LocaleReadinessChecker::check($locale)->ready()`, and the gate is **not bypassable** — no `force` parameter, no role that skips it. An official locale is served strictly (`ReadingsMap::getReadings()` throws instead of degrading), so promoting an unready locale converts silent gaps into 500s on a calendar the API advertises. If the data is complete the checker says so; if the checker is wrong, the fix is to the checker. A promotion also drops the locale's `candidates` note, whose prose is false once it is official.

**Demotion is deliberately not readiness-gated.** Removing a locale *loosens* enforcement — the same missing readings that would have thrown now degrade quietly — so it can never turn a working calendar into a 500. What it *can* do is change published output silently: `/calendars` stops advertising the locale and affected events serve nothing instead of erroring. That is a governance risk, answered by review and the audit trail, not by a readiness probe. Two integrity guards still apply, both `409`: the locale must currently be official, and the **last** official locale may not be removed, for the `FALLBACK` reason above.

## `writable` now reflects reality

`curation` reports `writable`, a new `mode` (`change_request` | `disk` | `misconfigured`) and prose the frontend still renders verbatim. A **misconfigured** queue mode — flag set, Postgres and/or OpenFGA unreachable — refuses the write with `503` instead of falling back to disk. The calendar write handlers tolerate that fallback because refusing would stop calendar editing outright; promotion is a rare governance action with an understood manual alternative, so an edit the next deploy silently reverts is the worse outcome.

## Aggregate-file read

`supportedLocales.json` holds the whole official set in one file, so the handler reads current content through `unpublishedSourceContent()` rather than off disk. In queue mode a submitter's previous promotion never reaches disk, and rebuilding from disk would drop it — the defect that once lost a decree behind a `201`.

## Tests

- `Handlers/LocalesAdminCurationTest` — disk mode against a throwaway tree (real writable resource copy, symlinked data folders), asserting every refusal branch is *forced* rather than assumed: unready locale, already-official, unknown locale, non-official demote, last-locale demote, misconfigured mode, unknown action, unauthenticated, non-admin, wrong method. `tearDown` digests the committed resource so a stray write to it fails this class rather than the next one.
- `Handlers/LocalesAdminQueueModeTest` — queue mode (DB-gated, skips cleanly): the proposal targets `general_roman_calendar:supported_locales`, no file is touched, a second promotion accumulates onto the first unpublished one, and the queued row is claimed by `SupportedLocales.json` and passes `ChangeRequestSchemaValidator`.
- `Schemas/SupportedLocalesSchemaTest`, `Schemas/OpenApiAdminLocalesTest`, plus updates to `ChangeResourceTest`, `SchemaRoleTest`, `SourceDataSchemaResolverTest`, `AccessRequestRepositoryConstantsTest` and `LocalesAdminHandlerTest` (whose `writable === false` / `#902` assertion had become a lie).

Nothing added to the `slow` group.

## Verification

```
composer lint       → exit 0
composer analyse    → [OK] No errors (PHPStan level 10, 389 files)
composer lint:openapi → Woohoo! Your API description is valid. 🎉
phpunit (all in-process suites: Database Enum Handlers Http Methods Models
         Params Repositories Schemas Services Test)
                    → OK, Tests: 3371, Assertions: 34634, Warnings: 1, Skipped: 6
```

`composer test:quick` also reports 21 errors / 100 failures, entirely in `Routes/*` and `WebSocket/*`. Those are HTTP tests against the shared `localhost:8000` / `:8082` servers, which do not serve this branch. Confirmed pre-existing: `origin/development` at `3aa2dd8b` produces the byte-identical tally — `Tests: 157, Errors: 21, Failures: 100, Warnings: 1, Skipped: 11` — from the same worktree.

`jsondata/supportedLocales.json` itself is unmodified; `openapi.json` edits were made programmatically and are confined to the `/admin/locales` paths plus one new component, to stay out of the way of the branches concurrently editing that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuyQTWwdmkzsxxjBEJcBG3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Administrators can promote eligible locales to the official supported list.
  - Administrators can demote officially supported locales, with safeguards preventing removal of the final official locale.
  - Locale changes can be applied directly or submitted as change requests, depending on deployment configuration.
  - The locale administration view now reports the active curation mode and a clear explanation.

- **Bug Fixes**
  - Promotion requests now validate locale readiness and prevent duplicate or invalid changes.
  - Improved handling of unavailable or misconfigured locale-management resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->