### PR TITLE
fix(tests): keep RegionalDataHandlerTest off the real jsondata tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -489,9 +489,19 @@ Other notable test infrastructure:
   proves a mismatch, never a match — a stale container whose `jsondata/` agrees with yours still passes it.
 
 **Never mutate `jsondata/` in a test.** Point `Router::$apiFilePath` at a temporary copy instead — every `JsonData::…->path()` resolves against it,
-for the handler AND for the test's own assertions (`Handlers/DecreesHandlerWriteTest` and `Services/Locale/LocaleReadinessCheckerTest` do exactly
-that). Backup-and-restore in `tearDown()` is not equivalent: a run that never reaches `tearDown()` — a fatal, an OOM kill, a `timeout`, a Ctrl-C —
-leaves tracked source data deleted or half-restored, and the next run then fails for reasons unrelated to the change under test (#921).
+for the handler AND for the test's own assertions. `phpunit_tests/Support/ShadowProjectRootTrait.php` builds that copy: `createShadowProjectRoot()`
+copies `jsondata/` and symlinks the read-only gettext catalogs, and `removeTree()` is hard-fenced to `sys_get_temp_dir()` and unlinks symlinks rather
+than descending them. `Handlers/DecreesHandlerWriteTest`, `Handlers/RegionalDataHandlerTest` and `Services/Locale/LocaleReadinessCheckerTest` all work
+that way. Backup-and-restore in `tearDown()` is not equivalent: a run that never reaches `tearDown()` — a fatal, an OOM kill, a `timeout`, a Ctrl-C —
+leaves tracked source data deleted or half-restored, and the next run then fails for reasons unrelated to the change under test (#921, #935).
+
+Two things a class that repoints the root must get right:
+
+- **Pin anything that memoises a path derived from the root, before the root moves.** `LoggerFactory` caches both the resolved `logs/` folder and each
+  channel for the whole process, so call `LoggerFactory::create('audit', <real logs>, …)` while `Router::$apiFilePath` still points at the project
+  root — otherwise every later test class in that process logs into a directory this one deletes.
+- **Class-level guards must `throw`, never `self::fail()`.** PHPUnit 12 cannot render a failure raised from `setUpBeforeClass()` and crashes the runner
+  with `Call to undefined method BeforeFirstTestMethodFailed::test()`. A `markTestSkipped()` there is fine, and skips the whole class.
 
 **Test Groups:**
 

--- a/phpunit_tests/Handlers/DecreesHandlerWriteTest.php
+++ b/phpunit_tests/Handlers/DecreesHandlerWriteTest.php
@@ -12,6 +12,7 @@ use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\ShadowProjectRootTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
@@ -41,6 +42,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(DecreesHandler::class)]
 final class DecreesHandlerWriteTest extends AbstractHandlerTestCase
 {
+    use ShadowProjectRootTrait;
+
     /**
      * Temporary shadow of the project root. Empty until setUpBeforeClass() allocates it.
      *
@@ -77,12 +80,8 @@ final class DecreesHandlerWriteTest extends AbstractHandlerTestCase
         }
         LoggerFactory::create('audit', $realLogs, 90, false, true, false);
 
-        self::$fixtureRoot = sys_get_temp_dir() . '/litcal-decrees-fixture-' . bin2hex(random_bytes(6));
-        self::copyTree($realRoot . 'jsondata', self::$fixtureRoot . '/jsondata');
-        // Gettext catalogs are only ever read, so a symlink is enough and keeps the copy small.
-        if (is_dir($realRoot . 'i18n')) {
-            symlink($realRoot . 'i18n', self::$fixtureRoot . '/i18n');
-        }
+        // Copies jsondata/ and symlinks the read-only gettext catalogs; see the trait.
+        self::$fixtureRoot = self::createShadowProjectRoot($realRoot, 'litcal-decrees-fixture');
 
         // Snapshot taken from the untouched working tree, kept inside the fixture so the
         // per-test reset never reads the repository again.
@@ -141,64 +140,6 @@ final class DecreesHandlerWriteTest extends AbstractHandlerTestCase
                 $realDecrees
             ));
         }
-    }
-
-    /** Recursive copy of a directory tree; files only, no symlinks are followed into. */
-    private static function copyTree(string $from, string $to): void
-    {
-        if (!is_dir($to) && !mkdir($to, 0755, true) && !is_dir($to)) {
-            throw new \RuntimeException('Could not create fixture directory ' . $to);
-        }
-
-        foreach (scandir($from) ?: [] as $entry) {
-            if ('.' === $entry || '..' === $entry) {
-                continue;
-            }
-            $source = $from . DIRECTORY_SEPARATOR . $entry;
-            $target = $to . DIRECTORY_SEPARATOR . $entry;
-            if (is_link($source)) {
-                continue;
-            }
-            if (is_dir($source)) {
-                self::copyTree($source, $target);
-                continue;
-            }
-            if (!copy($source, $target)) {
-                throw new \RuntimeException('Could not copy ' . $source . ' to ' . $target);
-            }
-        }
-    }
-
-    /**
-     * Recursive delete, hard-fenced to sys_get_temp_dir().
-     *
-     * Symlinks are unlinked, never descended into: the fixture root holds a symlink to
-     * the repository's `i18n/` folder, and following it would be the very class of
-     * accident this rewrite exists to remove.
-     */
-    private static function removeTree(string $dir): void
-    {
-        $tempDir = realpath(sys_get_temp_dir());
-        $target  = realpath($dir);
-        if (false === $tempDir || false === $target) {
-            return;
-        }
-        if (!str_starts_with($target . DIRECTORY_SEPARATOR, $tempDir . DIRECTORY_SEPARATOR)) {
-            throw new \RuntimeException(sprintf('Refusing to delete %s: it is outside %s.', $target, $tempDir));
-        }
-
-        foreach (scandir($target) ?: [] as $entry) {
-            if ('.' === $entry || '..' === $entry) {
-                continue;
-            }
-            $path = $target . DIRECTORY_SEPARATOR . $entry;
-            if (is_link($path) || !is_dir($path)) {
-                unlink($path);
-                continue;
-            }
-            self::removeTree($path);
-        }
-        rmdir($target);
     }
 
     /** @return array<string,mixed> */

--- a/phpunit_tests/Handlers/RegionalDataHandlerTest.php
+++ b/phpunit_tests/Handlers/RegionalDataHandlerTest.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Handlers;
 
+use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\LitSchema;
 use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Handlers\RegionalDataHandler;
 use LiturgicalCalendar\Api\Http\Exception\UnprocessableContentException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
 use LiturgicalCalendar\Api\Repositories\OutboxBatchInsertInterface;
 use LiturgicalCalendar\Api\Database\Connection;
 use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Api\Services\ResourceTuplePurgeServiceInterface;
+use LiturgicalCalendar\Tests\Support\ShadowProjectRootTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Swaggest\JsonSchema\Schema;
 
@@ -20,124 +23,170 @@ use Swaggest\JsonSchema\Schema;
  * RegionalDataHandler serves and edits per-nation / per-diocese / per-wider-
  * region calendar source data. The PUT/PATCH/DELETE branches are gated by
  * JWT auth middleware (added by the router before handler invocation) and
- * involve disk writes; this suite covers the read paths and the path /
- * category validators that run before any side effects.
+ * involve disk writes; this suite covers the read paths, the write paths, and
+ * the path / category validators that run before any side effects.
+ *
+ * Every write and every delete in this class lands in a throwaway copy of
+ * `jsondata/`, never in the working tree (#935). See the fixture block below.
  */
 #[CoversClass(RegionalDataHandler::class)]
 final class RegionalDataHandlerTest extends AbstractHandlerTestCase
 {
+    use ShadowProjectRootTrait;
+
     // The handler resolves national/diocesan keys against the calendars metadata
     // index, which RegionalDataHandler now builds in-process from local source
-    // data (CalendarMetadataProvider). AbstractHandlerTestCase already pins
-    // Router::$apiFilePath to the project root, so those lookups resolve against
-    // the bundled sourcedata with no HTTP server or fixture needed.
+    // data (CalendarMetadataProvider). Those lookups resolve against whatever
+    // Router::$apiFilePath points at — here, the byte-identical copy of the
+    // bundled sourcedata described below, with no HTTP server needed.
 
     // -------------------------------------------------------------------------
-    // Filesystem backup state for testDeleteCalendarPurgesOperationalTuples.
-    // Croatia (HR) has no diocesan calendars in the bundled source data, so the
-    // DELETE validation passes without a "diocesan calendars depend on this"
-    // error.  We save the file contents before the test runs and restore them
-    // in tearDown — even when the test fails or is skipped — to keep the
-    // working tree clean.
+    // Shadow project root (#935).
+    //
+    // Several tests here drive the handler's write paths: the DELETE tests remove
+    // the Croatian (HR) national calendar, and the create/update tests add a
+    // Maltese (MT) one. Those used to act on the real working tree, with HR's only
+    // surviving copy held in PHP memory until tearDown() wrote it back — so a fatal,
+    // an OOM kill, a `timeout` or a Ctrl-C in between left tracked source files
+    // deleted, and the next run then failed looking exactly like a legitimate
+    // "HR calendar not found" regression.
+    //
+    // The window is removed rather than narrowed: setUpBeforeClass() copies
+    // `jsondata/` into a temporary shadow of the project root and repoints
+    // Router::$apiFilePath at it — the single seam every `JsonData::…->path()`
+    // resolves against, so the handler under test and this class's own assertions
+    // move together. Nothing outside sys_get_temp_dir() is written, chmod'ed or
+    // deleted for the lifetime of the class, and the per-test reset below lives
+    // entirely inside it, so an interruption at any instant is harmless: the worst
+    // outcome is an abandoned temp directory.
     // -------------------------------------------------------------------------
 
-    /** Contents of jsondata/…/nations/HR/HR.json saved before deletion. */
-    private ?string $hrJsonContent = null;
+    /** Temporary shadow of the project root. Empty until setUpBeforeClass() allocates it. */
+    private static string $fixtureRoot = '';
 
-    /** Contents of jsondata/…/nations/HR/i18n/hr_HR.json saved before deletion. */
-    private ?string $hrI18nContent = null;
+    /** The real project root, kept so tests can assert the working tree stays untouched. */
+    private static string $realRoot = '';
 
-    /** Absolute path to HR.json (resolved once in the test, used in tearDown). */
-    private string $hrJsonPath = '';
+    /** Untouched copies of the shipped calendar trees, re-applied before every test. */
+    private static string $pristineCalendars = '';
 
-    /** Absolute path to the i18n directory for HR (used in tearDown). */
-    private string $hrI18nDir = '';
+    /**
+     * The calendar trees inside the fixture — the only trees these tests ever mutate.
+     *
+     * @var array<string,string> rite name => absolute folder inside the fixture
+     */
+    private static array $fixtureCalendars = [];
 
-    /** Absolute path to the HR i18n locale file (used in tearDown). */
-    private string $hrI18nPath = '';
-
-    /** Absolute path to the HR nation directory (used in tearDown). */
-    private string $hrNationDir = '';
-
-    // -------------------------------------------------------------------------
-    // Filesystem cleanup state for testCreateNationalCalendarEnqueuesMemberNationTuple.
-    // Malta (MT) is used as the fixture nation because it has no existing national
-    // calendar in the bundled source data (so PUT does not conflict) and it is a
-    // valid European nation code.  The newly created MT files are deleted in
-    // tearDown regardless of test outcome to keep the working tree clean.
-    // -------------------------------------------------------------------------
-
-    /** Absolute path to the MT nation directory created by the create test. */
-    private string $mtNationDir = '';
-
-    /** Absolute path to MT.json created by the create test. */
-    private string $mtJsonPath = '';
-
-    /** Absolute path to the MT i18n directory created by the create test. */
-    private string $mtI18nDir = '';
-
-    /** Absolute path to the MT i18n locale file created by the create test. */
-    private string $mtI18nPath = '';
-
-    protected function tearDown(): void
+    public static function setUpBeforeClass(): void
     {
-        parent::tearDown();
-        $this->restoreHrFixture();
-        $this->cleanupMtFixture();
+        // Pins Router::$apiFilePath to the real project root (and skips the whole class
+        // when JWT config is absent, before anything below has allocated state).
+        parent::setUpBeforeClass();
+
+        self::$realRoot = Router::$apiFilePath;
+        self::assertShippedCalendarsIntact(self::$realRoot);
+
+        // Pin the audit logger to the REAL logs/ folder while the root still points there.
+        // LoggerFactory memoises both the resolved logs folder and the 'audit' channel for
+        // the whole process; letting RegionalDataHandler's constructor resolve it later —
+        // under the fixture root — would leave every subsequent test class in this process
+        // logging into a directory this class deletes in tearDownAfterClass().
+        $realLogs = self::$realRoot . 'logs';
+        if (!is_dir($realLogs)) {
+            mkdir($realLogs, 0755, true);
+        }
+        LoggerFactory::create('audit', $realLogs, 90, false, true, false);
+
+        // Copies jsondata/ and symlinks the read-only gettext catalogs; see the trait.
+        // The catalogs are safe to share: CalendarMetadataProvider::buildLocales() only
+        // globs them, and nothing in this class or in RegionalDataHandler writes there —
+        // every write the handler makes lands under jsondata/sourcedata/.
+        self::$fixtureRoot = self::createShadowProjectRoot(self::$realRoot, 'litcal-regionaldata-fixture');
+
+        // From here on every JsonData path — handler and assertions alike — resolves
+        // inside the fixture.
+        Router::$apiFilePath = self::$fixtureRoot . DIRECTORY_SEPARATOR;
+
+        self::$fixtureCalendars = [
+            'roman'     => JsonData::CALENDARS_FOLDER->path(),
+            'ambrosian' => dirname(JsonData::AMBROSIAN_DIOCESAN_CALENDARS_FOLDER->path()),
+        ];
+
+        // Snapshots taken from inside the fixture, so the per-test reset never reads the
+        // repository again.
+        self::$pristineCalendars = self::$fixtureRoot . DIRECTORY_SEPARATOR . 'pristine';
+        foreach (self::$fixtureCalendars as $rite => $folder) {
+            self::copyTree($folder, self::$pristineCalendars . DIRECTORY_SEPARATOR . $rite);
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if ('' !== self::$fixtureRoot) {
+            self::removeTree(self::$fixtureRoot);
+            self::$fixtureRoot       = '';
+            self::$realRoot          = '';
+            self::$pristineCalendars = '';
+            self::$fixtureCalendars  = [];
+        }
+        // Restores Router::$apiFilePath to whatever it was before this class ran.
+        parent::tearDownAfterClass();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Reset the mutable calendar trees between tests: the DELETE tests remove HR and
+        // the create tests add MT. Source and destination both live under
+        // sys_get_temp_dir(), so this delete-then-copy can only ever destroy a copy.
+        foreach (self::$fixtureCalendars as $rite => $folder) {
+            self::removeTree($folder);
+            self::copyTree(self::$pristineCalendars . DIRECTORY_SEPARATOR . $rite, $folder);
+        }
     }
 
     /**
-     * Recreates the HR national-calendar fixture files deleted by the delete
-     * test.  Called unconditionally from tearDown so the tree is always clean,
-     * regardless of whether the test passed, failed, or was skipped.
+     * Refuse to run against a working tree that an interrupted run of an earlier version
+     * of this class already damaged, rather than reporting that damage as a code failure.
+     *
+     * This throws rather than calling self::fail(): PHPUnit 12 cannot render a failure
+     * raised from setUpBeforeClass() and crashes the runner with
+     * `Call to undefined method BeforeFirstTestMethodFailed::test()`.
      */
-    private function restoreHrFixture(): void
+    private static function assertShippedCalendarsIntact(string $realRoot): void
     {
-        if ($this->hrJsonContent === null) {
-            return; // no backup was taken — nothing to restore
+        foreach ([self::hrCalendarFile($realRoot), self::hrI18nFile($realRoot)] as $required) {
+            if (!is_file($required)) {
+                throw new \RuntimeException(sprintf(
+                    'The HR national-calendar source data is missing from the working tree (%s). '
+                    . 'An interrupted run of an earlier version of this test may have deleted it; '
+                    . 'recover with `git checkout -- jsondata/`.',
+                    $required
+                ));
+            }
         }
-        if (!is_dir($this->hrNationDir)) {
-            mkdir($this->hrNationDir, 0755, true);
-        }
-        if (!is_dir($this->hrI18nDir)) {
-            mkdir($this->hrI18nDir, 0755, true);
-        }
-        if (!file_exists($this->hrJsonPath)) {
-            file_put_contents($this->hrJsonPath, $this->hrJsonContent);
-        }
-        if (!file_exists($this->hrI18nPath)) {
-            file_put_contents($this->hrI18nPath, $this->hrI18nContent);
-        }
-        $this->hrJsonContent = null;
-        $this->hrI18nContent = null;
     }
 
     /**
-     * Deletes the MT national-calendar files created by the create test.
-     * Called unconditionally from tearDown so the tree is always clean,
-     * regardless of whether the test passed, failed, or was skipped.
+     * Resolve the HR national-calendar file against an explicit project root, so a test can
+     * name the fixture copy and the working-tree original in the same breath. $root must
+     * carry a trailing directory separator, as Router::$apiFilePath does.
      */
-    private function cleanupMtFixture(): void
+    private static function hrCalendarFile(string $root): string
     {
-        if ($this->mtNationDir === '') {
-            return; // create test did not run — nothing to clean up
-        }
-        if ($this->mtI18nPath !== '' && file_exists($this->mtI18nPath)) {
-            unlink($this->mtI18nPath);
-        }
-        if ($this->mtJsonPath !== '' && file_exists($this->mtJsonPath)) {
-            unlink($this->mtJsonPath);
-        }
-        if ($this->mtI18nDir !== '' && is_dir($this->mtI18nDir)) {
-            rmdir($this->mtI18nDir);
-        }
-        if ($this->mtNationDir !== '' && is_dir($this->mtNationDir)) {
-            rmdir($this->mtNationDir);
-        }
-        $this->mtNationDir = '';
-        $this->mtJsonPath  = '';
-        $this->mtI18nDir   = '';
-        $this->mtI18nPath  = '';
+        return $root . strtr(JsonData::NATIONAL_CALENDAR_FILE->value, ['{nation}' => 'HR']);
+    }
+
+    /** The HR i18n locale file, resolved against an explicit project root. */
+    private static function hrI18nFile(string $root): string
+    {
+        return $root . strtr(JsonData::NATIONAL_CALENDAR_I18N_FILE->value, ['{nation}' => 'HR', '{locale}' => 'hr_HR']);
+    }
+
+    /** The MT national-calendar file, resolved against an explicit project root. */
+    private static function mtCalendarFile(string $root): string
+    {
+        return $root . strtr(JsonData::NATIONAL_CALENDAR_FILE->value, ['{nation}' => 'MT']);
     }
 
     /**
@@ -386,22 +435,8 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
 
     public function testDeletePurgeFailureDoesNotFailDeletion(): void
     {
-        // Same HR fixture approach as testDeleteCalendarPurgesOperationalTuples;
-        // tearDown restores the files from these saved contents.
-        $base              = Router::$apiFilePath . 'jsondata/sourcedata/rite/roman/calendars/nations/HR';
-        $this->hrNationDir = $base;
-        $this->hrJsonPath  = $base . '/HR.json';
-        $this->hrI18nDir   = $base . '/i18n';
-        $this->hrI18nPath  = $base . '/i18n/hr_HR.json';
-
-        $hrJsonContent = file_get_contents($this->hrJsonPath);
-        $hrI18nContent = file_get_contents($this->hrI18nPath);
-        if ($hrJsonContent === false || $hrI18nContent === false) {
-            $this->markTestSkipped('HR national-calendar fixture files not found; skipping purge-failure test.');
-        }
-        $this->hrJsonContent = $hrJsonContent;
-        $this->hrI18nContent = $hrI18nContent;
-
+        // Same HR fixture as testDeleteCalendarPurgesOperationalTuples: the delete lands
+        // in the shadow root, and setUp() restores that copy before the next test.
         // The purge throws, but the calendar files are already deleted — the DELETE
         // must still succeed (200); the failure is logged and the reconciler retries.
         $purge = $this->createStub(ResourceTuplePurgeServiceInterface::class);
@@ -423,29 +458,11 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
      * Croatia (HR) is used as the fixture nation because it has no diocesan
      * calendars in the bundled source data, so the DELETE pre-check that
      * rejects nations still in use by diocesan calendars passes cleanly.
-     * The HR files are backed up before the test and restored in tearDown.
+     * The files this deletes are the shadow root's copies; setUp() restores
+     * them from the pristine snapshot before the next test.
      */
     public function testDeleteCalendarPurgesOperationalTuples(): void
     {
-        // --- Arrange: save fixture files so tearDown can restore them --------
-        $base              = Router::$apiFilePath . 'jsondata/sourcedata/rite/roman/calendars/nations/HR';
-        $this->hrNationDir = $base;
-        $this->hrJsonPath  = $base . '/HR.json';
-        $this->hrI18nDir   = $base . '/i18n';
-        $this->hrI18nPath  = $base . '/i18n/hr_HR.json';
-
-        $hrJsonContent = file_get_contents($this->hrJsonPath);
-        $hrI18nContent = file_get_contents($this->hrI18nPath);
-
-        if ($hrJsonContent === false || $hrI18nContent === false) {
-            $this->markTestSkipped(
-                'HR national-calendar fixture files not found; skipping delete/purge test.'
-            );
-        }
-
-        $this->hrJsonContent = $hrJsonContent;
-        $this->hrI18nContent = $hrI18nContent;
-
         // --- Build handler with injected mock purge service ------------------
         $handler = new RegionalDataHandler(['nation', 'HR']);
 
@@ -465,22 +482,60 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
     }
 
     /**
-     * Registers the MT fixture paths for {@see cleanupMtFixture()} and skips
-     * the calling test if an MT national calendar unexpectedly already exists.
+     * #935: a DELETE must consume the shadow root's copy of the HR calendar and leave the
+     * tracked working-tree files alone.
+     *
+     * This is the regression guard for the defect itself rather than for handler behaviour:
+     * before the shadow root, the handler deleted the real files and the only surviving copy
+     * of them was a PHP string in this class, written back in tearDown(). Any run that never
+     * reached tearDown() — a fatal, an OOM kill, a `timeout`, a Ctrl-C — left tracked source
+     * data deleted. Asserting both halves (the fixture copy is gone, the tracked file is not)
+     * pins the redirect: a test that only asserted the deletion would pass just as happily
+     * with Router::$apiFilePath pointing back at the repository.
      */
-    private function armMtFixture(): void
+    public function testDeleteConsumesTheFixtureCopyAndNotTheWorkingTree(): void
     {
-        $base              = Router::$apiFilePath . 'jsondata/sourcedata/rite/roman/calendars/nations/MT';
-        $this->mtNationDir = $base;
-        $this->mtJsonPath  = $base . '/MT.json';
-        $this->mtI18nDir   = $base . '/i18n';
-        $this->mtI18nPath  = $base . '/i18n/en_MT.json';
+        $fixtureHrJson = self::hrCalendarFile(Router::$apiFilePath);
+        $fixtureHrI18n = self::hrI18nFile(Router::$apiFilePath);
+        self::assertFileExists($fixtureHrJson, 'setUp() must have restored the fixture copy of HR.');
 
-        // Defensive guard: if MT already exists (it shouldn't), skip.
-        if (file_exists($this->mtJsonPath)) {
-            $this->markTestSkipped(
-                'MT national-calendar file already exists; skipping to avoid overwriting it.'
-            );
+        $handler = new RegionalDataHandler(['nation', 'HR']);
+        $handler->setPurgeService($this->createStub(ResourceTuplePurgeServiceInterface::class));
+
+        $response = $handler->handle($this->requestFor('DELETE', '/data/nation/HR'));
+        self::assertSame(200, $response->getStatusCode());
+
+        self::assertFileDoesNotExist($fixtureHrJson, 'The DELETE must have removed the fixture copy.');
+        self::assertFileDoesNotExist($fixtureHrI18n, 'The DELETE must have removed the fixture i18n copy.');
+
+        self::assertFileExists(
+            self::hrCalendarFile(self::$realRoot),
+            'The tracked HR national calendar must never be deleted from the working tree (#935).'
+        );
+        self::assertFileExists(
+            self::hrI18nFile(self::$realRoot),
+            'The tracked HR i18n file must never be deleted from the working tree (#935).'
+        );
+    }
+
+    /**
+     * Skips the calling test if an MT national calendar unexpectedly already exists.
+     *
+     * The files the MT tests create are the shadow root's, and setUp() discards them
+     * before the next test, so nothing has to be cleaned up. The guard remains because
+     * a shipped MT calendar would silently turn every "create" assertion below into an
+     * assertion about an update: these tests would then need a different fixture nation.
+     * A stray MT folder in the working tree — the leftover an interrupted pre-#935 run
+     * could produce — is copied into the fixture and shows up here too.
+     */
+    private function requireMtNationAbsent(): void
+    {
+        if (file_exists(self::mtCalendarFile(Router::$apiFilePath))) {
+            $this->markTestSkipped(sprintf(
+                'An MT national calendar already exists (%s); skipping. '
+                . 'If that is a leftover from an interrupted pre-#935 run, delete it and rerun.',
+                self::mtCalendarFile(self::$realRoot)
+            ));
         }
     }
 
@@ -539,11 +594,11 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
      * format createNationalCalendar uses.
      *
      * Creates MT via PUT first (no OpenFGA env forced, so no outbox/DB needed),
-     * then updates it via PATCH. MT files are cleaned up in tearDown.
+     * then updates it via PATCH, both inside the shadow root.
      */
     public function testUpdateNationalCalendarSucceeds(): void
     {
-        $this->armMtFixture();
+        $this->requireMtNationAbsent();
 
         $payload = self::mtNationalCalendarPayload();
 
@@ -571,13 +626,13 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
      * - It has no existing national calendar in the bundled source data, so
      *   the PUT does not trigger a ResourceConflictException.
      *
-     * The new MT files written by the handler are deleted unconditionally in
-     * tearDown via {@see cleanupMtFixture()} to keep the working tree clean.
+     * The MT files the handler writes land in the shadow root, which setUp()
+     * resets before the next test and tearDownAfterClass() deletes outright.
      */
     public function testCreateNationalCalendarEnqueuesMemberNationTuple(): void
     {
-        // --- Arrange: record paths so tearDown can delete the new files -------
-        $this->armMtFixture();
+        // --- Arrange: confirm the fixture really has no MT calendar yet ------
+        $this->requireMtNationAbsent();
 
         // --- Build handler with injected mock OutboxRepository ----------------
         // PUT requests expect exactly TWO path params (category + key); the key

--- a/phpunit_tests/Support/ShadowProjectRootTrait.php
+++ b/phpunit_tests/Support/ShadowProjectRootTrait.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Support;
+
+/**
+ * Builds a throwaway shadow of the project root under `sys_get_temp_dir()`, for test
+ * classes that exercise handlers which write to — or delete from — `jsondata/`.
+ *
+ * `Router::$apiFilePath` is the single seam every `JsonData::…->path()` resolves
+ * against, so repointing it at a shadow root moves the code under test AND the test's
+ * own assertions together. Nothing in the working tree is then written, chmod'ed or
+ * deleted, and an interruption at any instant is harmless: the worst outcome is an
+ * abandoned temp directory (issues #921, #935).
+ *
+ * The contract deliberately has no `tearDown` hook of its own: a class that pins
+ * `Router::$apiFilePath` must restore it itself (`AbstractHandlerTestCase` does), and
+ * a class that allocates a shadow root must discard it in `tearDownAfterClass()`.
+ */
+trait ShadowProjectRootTrait
+{
+    /**
+     * Allocate a shadow project root containing a real copy of `jsondata/` plus a
+     * symlink to the gettext catalogs in `i18n/`.
+     *
+     * The catalogs are symlinked rather than copied because they are only ever read —
+     * no handler and no test writes or chmods them — and copying 1.6 MB of `.mo`/`.po`
+     * files per test class would buy nothing. `removeTree()` unlinks symlinks instead
+     * of descending them, so the shipped catalogs are never at risk from the cleanup.
+     *
+     * @param string $realRoot Project root WITH a trailing directory separator, i.e. the
+     *                         value `Router::$apiFilePath` holds in production and in
+     *                         `AbstractHandlerTestCase::setUpBeforeClass()`.
+     * @param string $prefix   Short name identifying the owning test class in the temp
+     *                         directory listing, e.g. `litcal-regionaldata-fixture`.
+     *
+     * @return string The shadow root, WITHOUT a trailing directory separator.
+     */
+    private static function createShadowProjectRoot(string $realRoot, string $prefix): string
+    {
+        $shadowRoot = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $prefix . '-' . bin2hex(random_bytes(6));
+
+        self::copyTree($realRoot . 'jsondata', $shadowRoot . DIRECTORY_SEPARATOR . 'jsondata');
+
+        if (is_dir($realRoot . 'i18n')) {
+            symlink($realRoot . 'i18n', $shadowRoot . DIRECTORY_SEPARATOR . 'i18n');
+        }
+
+        return $shadowRoot;
+    }
+
+    /** Recursive copy of a directory tree; files only, symlinks are skipped rather than followed. */
+    private static function copyTree(string $from, string $to): void
+    {
+        if (!is_dir($to) && !mkdir($to, 0755, true) && !is_dir($to)) {
+            throw new \RuntimeException('Could not create fixture directory ' . $to);
+        }
+
+        foreach (scandir($from) ?: [] as $entry) {
+            if ('.' === $entry || '..' === $entry) {
+                continue;
+            }
+            $source = $from . DIRECTORY_SEPARATOR . $entry;
+            $target = $to . DIRECTORY_SEPARATOR . $entry;
+            if (is_link($source)) {
+                continue;
+            }
+            if (is_dir($source)) {
+                self::copyTree($source, $target);
+                continue;
+            }
+            if (!copy($source, $target)) {
+                throw new \RuntimeException('Could not copy ' . $source . ' to ' . $target);
+            }
+        }
+    }
+
+    /**
+     * Recursive delete, hard-fenced to `sys_get_temp_dir()`.
+     *
+     * Symlinks are unlinked, never descended into: a shadow root holds a symlink to the
+     * repository's `i18n/` folder, and following it would be the very class of accident
+     * this helper exists to remove.
+     */
+    private static function removeTree(string $dir): void
+    {
+        $tempDir = realpath(sys_get_temp_dir());
+        $target  = realpath($dir);
+        if (false === $tempDir || false === $target) {
+            return;
+        }
+        if (!str_starts_with($target . DIRECTORY_SEPARATOR, $tempDir . DIRECTORY_SEPARATOR)) {
+            throw new \RuntimeException(sprintf('Refusing to delete %s: it is outside %s.', $target, $tempDir));
+        }
+
+        foreach (scandir($target) ?: [] as $entry) {
+            if ('.' === $entry || '..' === $entry) {
+                continue;
+            }
+            $path = $target . DIRECTORY_SEPARATOR . $entry;
+            if (is_link($path) || !is_dir($path)) {
+                unlink($path);
+                continue;
+            }
+            self::removeTree($path);
+        }
+        rmdir($target);
+    }
+}


### PR DESCRIPTION
`RegionalDataHandlerTest` let the handler under test **delete tracked source files from the working tree** while holding their only surviving copy
**in PHP memory**, writing them back in `tearDown()`. Any run that never reached `tearDown()` — a fatal, an OOM kill, a `timeout`, a Ctrl-C — left the
Croatian national calendar and its i18n file deleted, and the next run then failed looking exactly like a legitimate "HR calendar not found" regression.

**Fix:** the one #934 established, applied unchanged. `setUpBeforeClass()` copies `jsondata/` into a temporary shadow of the project root and repoints
`Router::$apiFilePath` at it — the single seam every `JsonData::…->path()` resolves against, so the handler under test and this class's own assertions
move together. Nothing outside `sys_get_temp_dir()` is written, chmod'ed or deleted for the lifetime of the class.

`setUp()` resets the roman and ambrosian calendar trees *inside* the fixture, which retires `restoreHrFixture()` and `cleanupMtFixture()` entirely. The MT
tests keep only their "does an MT calendar already exist" guard: a shipped MT calendar would quietly turn their create assertions into update assertions.
Carried over from #934: a preflight that refuses to start against an already-damaged tree (throwing, not `self::fail()`, which PHPUnit 12 cannot render
from `setUpBeforeClass()`), and the audit logger pinned to the real `logs/` before the root moves, since `LoggerFactory` memoises the resolved folder
process-wide.

The filesystem helpers move to `phpunit_tests/Support/ShadowProjectRootTrait` rather than being copied a second time; `DecreesHandlerWriteTest` now uses
the trait, with no behaviour change (`OK (22 tests, 53 assertions)` before and after).

## Crash-safety evidence

Blind `timeout -s KILL` sampling of the whole class — #934's method — does **not** reproduce this one. #934's window was an `rm -rf` plus a recursive copy
of 23 files; this window is two `file_put_contents()` calls reached a few hundred microseconds after the DELETE returns. Sampling every 10 ms from 0.24 s
to 0.38 s (the interval in which the class runs) hit the MT leftover but never the HR window, in 15 samples.

So the interruption is delivered **deterministically instead**: run the class, and busy-poll the tracked working-tree file, sending `SIGKILL` the instant
it disappears. That is precisely the "process does not survive to `tearDown()`" case, with the timing no longer left to luck.

| watching                                                | branch            | runs | killed in window | outcome                                                             |
| ------------------------------------------------------- | ----------------- | ---- | ---------------- | ------------------------------------------------------------------- |
| `…/nations/HR/HR.json`                                  | `development`     | 6    | 6 / 6            | `D …/HR/HR.json` — **tracked file deleted**, every run              |
| `…/nations/HR/i18n/hr_HR.json`                          | `development`     | 4    | 4 / 4            | `D …/HR/HR.json` + `D …/HR/i18n/hr_HR.json` — **both deleted**      |
| `…/nations/HR/HR.json`                                  | this branch       | 6    | 0 / 6            | never fires; both files present, `git status` clean                 |
| `…/nations/HR/i18n/hr_HR.json`                          | this branch       | 4    | 0 / 4            | never fires; both files present, `git status` clean                 |

On this branch the watcher can never fire, because the file it watches is never the one the handler deletes.

`development` (6 consecutive runs, HR.json watcher):

```text
LABEL        run   killed-in-window HR.json   hr_HR.json  git status --porcelain jsondata/
development  1     yes            DELETED   present      D jsondata/sourcedata/rite/roman/calendars/nations/HR/HR.json
development  2     yes            DELETED   present      D jsondata/sourcedata/rite/roman/calendars/nations/HR/HR.json
development  3     yes            DELETED   present      D jsondata/sourcedata/rite/roman/calendars/nations/HR/HR.json
development  4     yes            DELETED   present      D jsondata/sourcedata/rite/roman/calendars/nations/HR/HR.json
development  5     yes            DELETED   present      D jsondata/sourcedata/rite/roman/calendars/nations/HR/HR.json
development  6     yes            DELETED   present      D jsondata/sourcedata/rite/roman/calendars/nations/HR/HR.json
```

this branch, same watcher:

```text
fix/935      1     no             present   present     (clean)
fix/935      2     no             present   present     (clean)
fix/935      3     no             present   present     (clean)
fix/935      4     no             present   present     (clean)
fix/935      5     no             present   present     (clean)
fix/935      6     no             present   present     (clean)
```

The duration sweep is reported too, since it is the evidence #934 used: `timeout -s KILL` at 0.1 / 0.2 / 0.25 / 0.3 / 0.35 / 0.4 / 0.5 / 0.6 / 0.7 / 0.8 /
0.9 / 1.0 / 1.2 / 1.5 s on this branch — 14 samples, `git status --porcelain jsondata/` empty and both HR files present at every one. Ten of those are
SIGKILLs mid-run (rc 137). The only residue any interrupted run leaves is an abandoned `/tmp/litcal-regionaldata-fixture-*`.

Two more paths, each needing its own proof because a normal run exercises neither:

- **Class skipped** (`JWT_SECRET` unset in the worktree's `.env.local` — the shell env loses to `Dotenv::createMutable`): `Skipped: 28`, and **zero**
  `/tmp/litcal-regionaldata-fixture-*` allocated. The parent's skip aborts the class before any state is pinned, so `tearDownAfterClass()` never running
  is harmless.
- **Damaged tree** (`HR.json` removed by hand): the preflight errors once for the class with
  `RuntimeException: The HR national-calendar source data is missing from the working tree (…). An interrupted run of an earlier version of this test may
  have deleted it; recover with 'git checkout -- jsondata/'.` — no PHPUnit-12 runner crash, and no attempt to compound the damage.

## Verification

```text
composer lint      Time: 20.72 secs; Memory: 54MB          (phpcs, no violations)
composer analyse   [OK] No errors                          (PHPStan level 10, 391 files)
composer test:quick Tests: 4271, Assertions: 187128, Warnings: 1, Skipped: 11
composer lint:md   Summary: 0 issues in 0 files
```

`git status --porcelain` is empty after every run. The single warning is pre-existing and unrelated —
`DiskSourceDataWriter.php:101 mkdir(): File exists`, triggered by `DiskSourceDataWriterTest::testAnUnwritablePathRaisesServiceUnavailable`; both files are
byte-identical to `origin/development` and the warning reproduces when that class is run alone.

## Sibling audit

#934 believed this to be the last instance; that claim was re-checked rather than trusted. Every mutating call in `phpunit_tests/` was enumerated
(`file_put_contents`, `unlink`, `rmdir`, `mkdir`, `rename`, `copy`, `touch`, `chmod`, `symlink`, `shell_exec`) and its destination resolved.

**Confirmed: no other test deletes or overwrites a tracked file under `jsondata/`, and no test chmods one.** (`DecreesHandlerWriteTest` does `chmod 0444`
on decrees sidecars — those already resolve inside its shadow root.) Two things are worth recording without widening this PR:

- `Routes/ReadWrite/DecreesTest::testFullLifecycleCreatePatchDelete` drives `PUT`→`PATCH`→`DELETE` against the **live server**, which rewrites whatever
  tree that server serves. Cleanup is a `finally` DELETE, so an interruption leaves `decrees.json` *modified*, not a file deleted. It is DB-gated and in
  the `slow` group. Out of reach of the `Router::$apiFilePath` seam by construction — it is an HTTP test.
- `Handlers/EasterHandlerTest` replaces `engineCache/easter` with a plain file to simulate an unwritable cache. `engineCache/**` is gitignored, so nothing
  tracked is at risk, but an interrupted run leaves a regular file where a directory belongs, which blocks caching until removed.

Additive-only fixtures in the real tree (`Handlers/TestsHandlerTest`, `TestsQueueModeTest`, `SourceDataChangeRequestSupersedeRegressionTest` writing
`Zzz*Test.json` under `jsondata/tests/`, and `HealthProtocolValidationTest`'s `.leak-probe`) are the safe direction the issue describes: an interruption
leaves stray untracked files, never missing tracked ones.

`CLAUDE.md`'s "never mutate `jsondata/` in a test" rule now names the trait and adds the two things a class repointing the root must get right — pin
anything that memoises a root-derived path *before* the root moves, and `throw` rather than `self::fail()` from `setUpBeforeClass()`.

Closes #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuyQTWwdmkzsxxjBEJcBG3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test isolation by running write and delete scenarios against temporary project copies.
  - Added regression coverage confirming that test operations do not modify tracked project files.
  - Standardised temporary fixture creation and cleanup across relevant handler tests.
  - Added safeguards for temporary resources, including symlink-safe cleanup and protection against deleting outside temporary locations.

- **Documentation**
  - Expanded guidance for safely testing code that repoints project-root paths.
  - Documented requirements for preserving memoised paths and handling setup failures correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->