### PR TITLE
feat(missals,lectionary): aggregated missal i18n and sanctorale lectionary read routes

### DIFF
--- a/jsondata/schemas/LitCalLectionaryPath.json
+++ b/jsondata/schemas/LitCalLectionaryPath.json
@@ -1,0 +1,165 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "LitCalLectionaryPath",
+    "description": "A response of the `/lectionary` path. The section index and a single event's readings are different shapes, so the root is a choice between the two; their required properties are disjoint, so exactly one branch ever matches. This schema describes OUTPUT: the readings it carries are the source entries verbatim, which is why they are validated against CommonDef's SourceReadings rather than against Readings.",
+    "oneOf": [
+        { "$ref": "#/definitions/LectionarySectionIndex" },
+        { "$ref": "#/definitions/LectionaryEventReadings" }
+    ],
+    "definitions": {
+        "Tier": {
+            "type": "string",
+            "title": "Lectionary Tier",
+            "description": "which layer of the corpus a lectionary source belongs to: `rite` for the rite-wide sanctorale lectionary, `missal` for a lectionary that belongs to one Roman Missal edition",
+            "enum": [ "rite", "missal" ]
+        },
+        "SourceId": {
+            "title": "Lectionary Source ID",
+            "description": "identifies the source within its tier: a rite identifier for the `rite` tier, a Missal ID for the `missal` tier",
+            "oneOf": [
+                { "$ref": "./CommonDef.json#/definitions/Rite" },
+                { "$ref": "./CommonDef.json#/definitions/MissalID" }
+            ]
+        },
+        "Locales": {
+            "type": "array",
+            "description": "locales, identified by the basename of the locale file",
+            "items": { "$ref": "./CommonDef.json#/definitions/Locale" },
+            "uniqueItems": true
+        },
+        "SourceRef": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "tier": { "$ref": "#/definitions/Tier" },
+                "source_id": { "$ref": "#/definitions/SourceId" }
+            },
+            "required": [ "tier", "source_id" ]
+        },
+        "SourceSummary": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "tier": { "$ref": "#/definitions/Tier" },
+                "source_id": { "$ref": "#/definitions/SourceId" },
+                "locales": { "$ref": "#/definitions/Locales" },
+                "event_key_count": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "how many distinct event_key values this source carries across all of its locales"
+                }
+            },
+            "required": [ "tier", "source_id", "locales", "event_key_count" ]
+        },
+        "LectionarySectionIndex": {
+            "type": "object",
+            "title": "Lectionary Section Index",
+            "description": "the response of `GET /lectionary/{rite}/sanctorale`",
+            "additionalProperties": false,
+            "properties": {
+                "rite": { "$ref": "./CommonDef.json#/definitions/Rite" },
+                "section": {
+                    "type": "string",
+                    "enum": [ "sanctorale" ]
+                },
+                "lectionary_available": {
+                    "type": "boolean",
+                    "description": "false when the rite has no lectionary data at all, which is a different state from a lectionary that exists but curates nothing for a given event"
+                },
+                "sources": {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/SourceSummary" }
+                },
+                "litcal_lectionary": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "event_key": { "$ref": "./CommonDef.json#/definitions/EventKey" },
+                            "sources": {
+                                "type": "array",
+                                "description": "every source that carries an entry for this event_key, in resolution order",
+                                "items": { "$ref": "#/definitions/SourceRef" },
+                                "minItems": 1
+                            },
+                            "api_path": { "type": "string" }
+                        },
+                        "required": [ "event_key", "sources", "api_path" ]
+                    }
+                },
+                "message": {
+                    "type": "string",
+                    "description": "present only when `lectionary_available` is false, saying so in words"
+                }
+            },
+            "required": [ "rite", "section", "lectionary_available", "sources", "litcal_lectionary" ]
+        },
+        "LectionaryEventReadings": {
+            "type": "object",
+            "title": "Lectionary Readings for one Event",
+            "description": "the response of `GET /lectionary/{rite}/sanctorale/{event_key}`",
+            "additionalProperties": false,
+            "properties": {
+                "rite": { "$ref": "./CommonDef.json#/definitions/Rite" },
+                "section": {
+                    "type": "string",
+                    "enum": [ "sanctorale" ]
+                },
+                "event_key": { "$ref": "./CommonDef.json#/definitions/EventKey" },
+                "lectionary_available": {
+                    "type": "boolean",
+                    "description": "false when the rite has no lectionary data at all; an unknown event_key under a rite that does have one is a 404 instead, so the two states never collide"
+                },
+                "readings": {
+                    "type": "array",
+                    "description": "one entry per source that carries this event_key, in resolution order; a source that carries nothing for it is omitted rather than listed empty",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "tier": { "$ref": "#/definitions/Tier" },
+                            "source_id": { "$ref": "#/definitions/SourceId" },
+                            "locales": {
+                                "$ref": "#/definitions/Locales",
+                                "description": "every locale this source declares, i.e. every locale file present in its folder"
+                            },
+                            "locales_with_entry": {
+                                "$ref": "#/definitions/Locales",
+                                "description": "the declared locales whose file has an entry for this event_key; exactly the keys of `entries`"
+                            },
+                            "locales_without_entry": {
+                                "$ref": "#/definitions/Locales",
+                                "description": "the declared locales whose file has no entry at all for this event_key"
+                            },
+                            "locales_with_empty_entry": {
+                                "$ref": "#/definitions/Locales",
+                                "description": "a subset of `locales_with_entry`: locales whose entry is the all-empty-string placeholder, meaning the structure is in place but the readings are not written yet"
+                            },
+                            "entries": {
+                                "type": "object",
+                                "description": "the source entries verbatim, keyed by locale — empty strings included, so nothing is flattened away",
+                                "propertyNames": { "$ref": "./CommonDef.json#/definitions/Locale" },
+                                "additionalProperties": { "$ref": "./CommonDef.json#/definitions/SourceReadings" }
+                            }
+                        },
+                        "required": [
+                            "tier",
+                            "source_id",
+                            "locales",
+                            "locales_with_entry",
+                            "locales_without_entry",
+                            "locales_with_empty_entry",
+                            "entries"
+                        ]
+                    }
+                },
+                "message": {
+                    "type": "string",
+                    "description": "present only when `lectionary_available` is false, saying so in words"
+                }
+            },
+            "required": [ "rite", "section", "event_key", "lectionary_available", "readings" ]
+        }
+    }
+}

--- a/jsondata/schemas/LitCalMissalSanctoralePath.json
+++ b/jsondata/schemas/LitCalMissalSanctoralePath.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "LitCalMissalSanctoralePath",
+    "description": "The response of `GET /missals/{missal_id}`: the sanctorale rows of one Roman Missal, each carrying the name for the single negotiated locale. openapi.json documented this response as `LitCalMissalsPath.json#/definitions/Missal` — the metadata shape of a row of the `/missals` index (missal_id, name, region, year_published, year_limits, locales, api_path) — which is not what the route emits (issue #941). The rows are the missal's source rows as stored, with the negotiated locale's translation folded into `name`, so the item schema is the source row definition itself rather than a copy of it that would drift: `name` is already optional there, and no other property is added or removed on the way out.",
+    "type": "array",
+    "items": { "$ref": "./PropriumDeSanctis.json#/definitions/PropriumDeSanctis" }
+}

--- a/jsondata/schemas/LitCalMissalTranslationsPath.json
+++ b/jsondata/schemas/LitCalMissalTranslationsPath.json
@@ -1,0 +1,62 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "LitCalMissalTranslationsPath",
+    "description": "The response of `GET /missals/{missal_id}/i18n`: every locale's sanctorale names for one Roman Missal, side by side. This schema describes OUTPUT. Two states the corpus genuinely distinguishes must survive the round trip: an event_key ABSENT from a locale's map has no entry in that locale's file, while an event_key mapped to the EMPTY STRING has an entry whose translation has not been written yet. `coverage` states that per event_key so a client does not have to derive it from a fourteen-locale map.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "missal_id": { "$ref": "./CommonDef.json#/definitions/MissalID" },
+        "locales": {
+            "type": "array",
+            "description": "every locale the missal's i18n folder declares, i.e. the basename of each locale file",
+            "items": { "$ref": "./CommonDef.json#/definitions/Locale" },
+            "uniqueItems": true
+        },
+        "event_keys": {
+            "type": "array",
+            "description": "the event_key of each sanctorale row, in the order the missal's sanctorale file declares them",
+            "items": { "$ref": "./CommonDef.json#/definitions/EventKey" }
+        },
+        "i18n": {
+            "type": "object",
+            "description": "the locale files verbatim, keyed by locale then by event_key",
+            "propertyNames": { "$ref": "./CommonDef.json#/definitions/Locale" },
+            "additionalProperties": {
+                "type": "object",
+                "propertyNames": { "$ref": "./CommonDef.json#/definitions/EventKey" },
+                "additionalProperties": { "type": "string" }
+            }
+        },
+        "coverage": {
+            "type": "object",
+            "description": "for each event_key of `event_keys`, how the declared locales divide between translated, present-but-empty, and absent",
+            "propertyNames": { "$ref": "./CommonDef.json#/definitions/EventKey" },
+            "additionalProperties": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "translated": {
+                        "type": "array",
+                        "description": "locales whose file maps this event_key to a non-empty name",
+                        "items": { "$ref": "./CommonDef.json#/definitions/Locale" },
+                        "uniqueItems": true
+                    },
+                    "empty": {
+                        "type": "array",
+                        "description": "locales whose file maps this event_key to the empty string — an entry exists, the translation is not written yet",
+                        "items": { "$ref": "./CommonDef.json#/definitions/Locale" },
+                        "uniqueItems": true
+                    },
+                    "missing": {
+                        "type": "array",
+                        "description": "locales whose file has no entry for this event_key at all",
+                        "items": { "$ref": "./CommonDef.json#/definitions/Locale" },
+                        "uniqueItems": true
+                    }
+                },
+                "required": [ "translated", "empty", "missing" ]
+            }
+        }
+    },
+    "required": [ "missal_id", "locales", "event_keys", "i18n", "coverage" ]
+}

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -53,6 +53,10 @@
       "description": "Retrieve / create / update / delete Decrees of the Dicastery for Divine Worship and the Discipline of the Sacraments"
     },
     {
+      "name": "Lectionary",
+      "description": "Retrieve the curated lectionary readings for a liturgical event, addressed by `event_key` rather than by computed date"
+    },
+    {
       "name": "Easter",
       "description": "Dates of easter whether gregorian or julian from 1583 to 1999"
     },
@@ -9710,17 +9714,59 @@
         ],
         "responses": {
           "200": {
-            "description": "OK: the data for the requested Roman Missal",
+            "description": "OK: the sanctorale rows of the requested Roman Missal",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "./LitCalMissalsPath.json#/definitions/Missal"
+                  "$ref": "./LitCalMissalSanctoralePath.json"
                 }
               }
             }
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          }
+        },
+        "description": "Returns the sanctorale rows of the Missal: the source rows as stored, with the name for a single negotiated locale folded into each row's `name`. The locale is negotiated from the `Accept-Language` header against the locales the Missal declares, falling back to the Missal's first declared locale (Latin for an editio typica). To see every locale's names at once — and to tell a key that is absent from a locale from one that is present but not yet translated — use `/missals/{missal_id}/i18n`."
+      }
+    },
+    "/missals/{missal_id}/i18n": {
+      "get": {
+        "tags": [
+          "Missals"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve every locale's sanctorale names for a Roman Missal",
+        "operationId": "missalI18nGET",
+        "description": "The aggregated counterpart of `GET /missals/{missal_id}`, which carries one negotiated locale's name per row and so cannot show translations side by side. Returns, for every locale the Missal's i18n folder declares, that locale's file verbatim — keyed by locale, then by `event_key`. Two states the corpus genuinely distinguishes therefore survive: an `event_key` **absent** from a locale's map has no entry in that locale's file, while an `event_key` mapped to the **empty string** has an entry whose translation has not been written yet. `coverage` states that split per `event_key` so a client need not derive it from a fourteen-locale map. This route is locale-agnostic: it returns every locale, so `Accept-Language` is not negotiated.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "missal_id",
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/MissalID"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: every locale's sanctorale names for the requested Roman Missal, with per-event_key coverage",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./LitCalMissalTranslationsPath.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable503"
           }
         }
       }
@@ -10002,6 +10048,237 @@
           },
           "503": {
             "$ref": "#/components/responses/ServiceUnavailable503"
+          }
+        }
+      }
+    },
+    "/lectionary/sanctorale": {
+      "get": {
+        "tags": [
+          "Lectionary"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the index of sanctorale lectionary entries (bare spelling; the canonical form names the rite)",
+        "operationId": "lectionarySanctoraleGET",
+        "description": "An index of every `event_key` for which some lectionary source carries an entry, naming for each the sources that carry it. The sanctorale readings live in two tiers — the rite-wide corpus (`rite/{rite}/lectionary/sanctorum/{locale}.json`) and one folder per national Roman Missal — and an `event_key` may be carried by both, so `sources` names the tier and source of every entry rather than merging them into one answer. A rite with no lectionary data at all (the Ambrosian rite has none) answers `200` with `lectionary_available: false`, an empty `sources`, and a message saying so — which is a different state from a lectionary that exists and curates nothing for a given event. This route is locale-agnostic: it aggregates every locale a source declares, so `Accept-Language` is not negotiated.",
+        "responses": {
+          "200": {
+            "description": "OK: the index of sanctorale lectionary entries for the requested rite",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./LitCalLectionaryPath.json#/definitions/LectionarySectionIndex"
+                }
+              }
+            },
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/lectionary/roman/sanctorale": {
+      "get": {
+        "tags": [
+          "Lectionary"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the index of Roman rite sanctorale lectionary entries",
+        "operationId": "lectionaryRomanSanctoraleGET",
+        "description": "An index of every `event_key` for which some lectionary source carries an entry, naming for each the sources that carry it. The sanctorale readings live in two tiers — the rite-wide corpus (`rite/{rite}/lectionary/sanctorum/{locale}.json`) and one folder per national Roman Missal — and an `event_key` may be carried by both, so `sources` names the tier and source of every entry rather than merging them into one answer. A rite with no lectionary data at all (the Ambrosian rite has none) answers `200` with `lectionary_available: false`, an empty `sources`, and a message saying so — which is a different state from a lectionary that exists and curates nothing for a given event. This route is locale-agnostic: it aggregates every locale a source declares, so `Accept-Language` is not negotiated.",
+        "responses": {
+          "200": {
+            "description": "OK: the index of sanctorale lectionary entries for the requested rite",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./LitCalLectionaryPath.json#/definitions/LectionarySectionIndex"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          }
+        }
+      }
+    },
+    "/lectionary/ambrosian/sanctorale": {
+      "get": {
+        "tags": [
+          "Lectionary"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the index of Ambrosian rite sanctorale lectionary entries",
+        "operationId": "lectionaryAmbrosianSanctoraleGET",
+        "description": "An index of every `event_key` for which some lectionary source carries an entry, naming for each the sources that carry it. The sanctorale readings live in two tiers — the rite-wide corpus (`rite/{rite}/lectionary/sanctorum/{locale}.json`) and one folder per national Roman Missal — and an `event_key` may be carried by both, so `sources` names the tier and source of every entry rather than merging them into one answer. A rite with no lectionary data at all (the Ambrosian rite has none) answers `200` with `lectionary_available: false`, an empty `sources`, and a message saying so — which is a different state from a lectionary that exists and curates nothing for a given event. This route is locale-agnostic: it aggregates every locale a source declares, so `Accept-Language` is not negotiated.",
+        "responses": {
+          "200": {
+            "description": "OK: the index of sanctorale lectionary entries for the requested rite",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./LitCalLectionaryPath.json#/definitions/LectionarySectionIndex"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          }
+        }
+      }
+    },
+    "/lectionary/sanctorale/{event_key}": {
+      "get": {
+        "tags": [
+          "Lectionary"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the sanctorale lectionary readings for an event_key (bare spelling; the canonical form names the rite)",
+        "operationId": "lectionarySanctoraleEventGET",
+        "description": "Every locale's readings for one `event_key`, from every source that carries it, so a client editing readings knows which file it is looking at. Per source, `locales` is every locale the source declares, `locales_with_entry` and `locales_without_entry` split those by whether the locale's file has an entry for this `event_key` at all, and `locales_with_empty_entry` — a subset of the first — flags the entries that are the all-empty-string placeholder, meaning the structure is in place but the readings are not written yet. `entries` carries the source entries verbatim, empty strings included. A rite with no lectionary data answers `200` with `lectionary_available: false` and an empty `readings`; an unknown `event_key` under a rite that does have a lectionary is a `404`, so the two states never collide. This route is locale-agnostic: it returns every locale, so `Accept-Language` is not negotiated.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_key",
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/EventKey"
+            },
+            "required": true,
+            "description": "The `event_key` whose readings are being requested"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: every locale's sanctorale readings for the requested event_key, per source",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./LitCalLectionaryPath.json#/definitions/LectionaryEventReadings"
+                }
+              }
+            },
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/lectionary/roman/sanctorale/{event_key}": {
+      "get": {
+        "tags": [
+          "Lectionary"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the Roman rite sanctorale lectionary readings for an event_key",
+        "operationId": "lectionaryRomanSanctoraleEventGET",
+        "description": "Every locale's readings for one `event_key`, from every source that carries it, so a client editing readings knows which file it is looking at. Per source, `locales` is every locale the source declares, `locales_with_entry` and `locales_without_entry` split those by whether the locale's file has an entry for this `event_key` at all, and `locales_with_empty_entry` — a subset of the first — flags the entries that are the all-empty-string placeholder, meaning the structure is in place but the readings are not written yet. `entries` carries the source entries verbatim, empty strings included. A rite with no lectionary data answers `200` with `lectionary_available: false` and an empty `readings`; an unknown `event_key` under a rite that does have a lectionary is a `404`, so the two states never collide. This route is locale-agnostic: it returns every locale, so `Accept-Language` is not negotiated.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_key",
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/EventKey"
+            },
+            "required": true,
+            "description": "The `event_key` whose readings are being requested"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: every locale's sanctorale readings for the requested event_key, per source",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./LitCalLectionaryPath.json#/definitions/LectionaryEventReadings"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          }
+        }
+      }
+    },
+    "/lectionary/ambrosian/sanctorale/{event_key}": {
+      "get": {
+        "tags": [
+          "Lectionary"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the Ambrosian rite sanctorale lectionary readings for an event_key",
+        "operationId": "lectionaryAmbrosianSanctoraleEventGET",
+        "description": "Every locale's readings for one `event_key`, from every source that carries it, so a client editing readings knows which file it is looking at. Per source, `locales` is every locale the source declares, `locales_with_entry` and `locales_without_entry` split those by whether the locale's file has an entry for this `event_key` at all, and `locales_with_empty_entry` — a subset of the first — flags the entries that are the all-empty-string placeholder, meaning the structure is in place but the readings are not written yet. `entries` carries the source entries verbatim, empty strings included. A rite with no lectionary data answers `200` with `lectionary_available: false` and an empty `readings`; an unknown `event_key` under a rite that does have a lectionary is a `404`, so the two states never collide. This route is locale-agnostic: it returns every locale, so `Accept-Language` is not negotiated.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_key",
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/EventKey"
+            },
+            "required": true,
+            "description": "The `event_key` whose readings are being requested"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: every locale's sanctorale readings for the requested event_key, per source",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./LitCalLectionaryPath.json#/definitions/LectionaryEventReadings"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
           }
         }
       }

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -9725,6 +9725,9 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable503"
           }
         },
         "description": "Returns the sanctorale rows of the Missal: the source rows as stored, with the name for a single negotiated locale folded into each row's `name`. The locale is negotiated from the `Accept-Language` header against the locales the Missal declares, falling back to the Missal's first declared locale (Latin for an editio typica). To see every locale's names at once — and to tell a key that is absent from a locale from one that is present but not yet translated — use `/missals/{missal_id}/i18n`."

--- a/phpunit_tests/Handlers/LectionaryHandlerTest.php
+++ b/phpunit_tests/Handlers/LectionaryHandlerTest.php
@@ -1,0 +1,370 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\LectionaryHandler;
+use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
+use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Swaggest\JsonSchema\Schema;
+
+/**
+ * `GET /lectionary/{rite}/sanctorale[/{event_key}]` — issue #942.
+ *
+ * The four distinctions this route exists to make are asserted against the real corpus rather
+ * than against literal `event_key` fixtures, and the fixtures are discovered by reading the
+ * lectionary files directly with `json_decode` — an oracle independent of the handler's own code
+ * path. That is deliberate on two counts: a hard-coded key is a hostage to renames happening in
+ * parallel (issue #939 is renaming one right now), and a discovered fixture proves the property
+ * holds of the data as it actually is rather than of the one row somebody remembered.
+ */
+#[CoversClass(LectionaryHandler::class)]
+final class LectionaryHandlerTest extends AbstractHandlerTestCase
+{
+    /** @var array<string,array<string,mixed>>|null decoded rite-level sanctorum files, keyed by locale */
+    private static ?array $riteFiles = null;
+
+    /**
+     * The rite-level sanctorum locale files, decoded straight off disk.
+     *
+     * @return array<string,array<string,mixed>>
+     */
+    private static function riteFiles(): array
+    {
+        if (null === self::$riteFiles) {
+            $folder = JsonData::LECTIONARY_SAINTS_FOLDER->path();
+            $files  = glob($folder . '/*.json');
+            self::assertIsArray($files);
+            self::assertNotEmpty($files, 'the rite-level sanctorale lectionary folder is empty');
+            sort($files);
+
+            $decoded = [];
+            foreach ($files as $file) {
+                $raw = file_get_contents($file);
+                self::assertIsString($raw);
+                /** @var array<string,mixed> $map */
+                $map                               = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+                $decoded[basename($file, '.json')] = $map;
+            }
+            self::$riteFiles = $decoded;
+        }
+
+        return self::$riteFiles;
+    }
+
+    /**
+     * @param string[] $pathParams
+     * @return array<string,mixed>
+     */
+    private function get(array $pathParams, Rite $rite = Rite::ROMAN): array
+    {
+        $uri      = '/lectionary/' . $rite->value . '/' . implode('/', $pathParams);
+        $response = ( new LectionaryHandler($pathParams, $rite) )->handle($this->requestFor('GET', $uri));
+        self::assertSame(200, $response->getStatusCode());
+        return $this->decodeJsonBody($response);
+    }
+
+    // ------------------------------------------------------------------ HTTP shape
+
+    public function testOptionsPreflightSucceeds(): void
+    {
+        $response = ( new LectionaryHandler(['sanctorale']) )->handle(
+            $this->requestFor('OPTIONS', '/lectionary/sanctorale', [
+                'Origin'                        => 'https://app.example.test',
+                'Access-Control-Request-Method' => 'GET',
+            ])
+        );
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testPutIsMethodNotAllowed(): void
+    {
+        $this->expectException(MethodNotAllowedException::class);
+        ( new LectionaryHandler(['sanctorale']) )->handle(
+            $this->requestFor('PUT', '/lectionary/sanctorale', [], ['first_reading' => 'nope'])
+        );
+    }
+
+    public function testBarePathIsNotFound(): void
+    {
+        $this->expectException(NotFoundException::class);
+        ( new LectionaryHandler() )->handle($this->requestFor('GET', '/lectionary'));
+    }
+
+    public function testUnknownSectionIsNotFound(): void
+    {
+        $this->expectException(NotFoundException::class);
+        ( new LectionaryHandler(['temporale']) )->handle($this->requestFor('GET', '/lectionary/temporale'));
+    }
+
+    public function testTooManyPathParamsIsNotFound(): void
+    {
+        $this->expectException(NotFoundException::class);
+        ( new LectionaryHandler(['sanctorale', 'SomeEvent', 'extra']) )
+            ->handle($this->requestFor('GET', '/lectionary/sanctorale/SomeEvent/extra'));
+    }
+
+    public function testUnknownEventKeyIsNotFoundUnderARiteThatHasALectionary(): void
+    {
+        // The contrast that makes the Ambrosian 200 below meaningful: under a rite that DOES have
+        // a lectionary, an event nobody curated is a 404, not an "unavailable" body.
+        $this->expectException(NotFoundException::class);
+        ( new LectionaryHandler(['sanctorale', 'NotARealEventKeyAtAll'], Rite::ROMAN) )
+            ->handle($this->requestFor('GET', '/lectionary/sanctorale/NotARealEventKeyAtAll'));
+    }
+
+    // ------------------------------------------------------- resolve both tiers, say which one
+
+    public function testIndexNamesEveryTierThatCarriesReadings(): void
+    {
+        $body = $this->get(['sanctorale']);
+
+        self::assertTrue($body['lectionary_available']);
+        self::assertSame('roman', $body['rite']);
+        self::assertSame('sanctorale', $body['section']);
+        self::assertIsArray($body['sources']);
+
+        $tiers = array_column($body['sources'], 'tier', 'source_id');
+        self::assertSame('rite', $tiers['roman'] ?? null, 'the rite-level corpus must be reported as its own tier');
+        self::assertContains('missal', $tiers, 'no per-missal lectionary was reported, but RomanMissal maps at least one');
+
+        // Every source declares the locales it has files for, and how many keys it carries.
+        foreach ($body['sources'] as $source) {
+            self::assertNotEmpty($source['locales']);
+            self::assertGreaterThan(0, $source['event_key_count']);
+        }
+    }
+
+    public function testAnEventCarriedByBothTiersReportsBothSeparately(): void
+    {
+        $index = $this->get(['sanctorale']);
+
+        // Discover an event_key the index says is carried by more than one source, rather than
+        // naming one: the national missals' lectionary keys overlap the rite-level corpus, and
+        // which key does so is data, not contract.
+        $multi = null;
+        foreach ($index['litcal_lectionary'] as $item) {
+            if (count($item['sources']) > 1) {
+                $multi = $item;
+                break;
+            }
+        }
+        self::assertNotNull($multi, 'no event_key is carried by more than one lectionary source');
+
+        $body = $this->get(['sanctorale', $multi['event_key']]);
+        self::assertSame($multi['event_key'], $body['event_key']);
+        self::assertCount(
+            count($multi['sources']),
+            $body['readings'],
+            'the item response must answer from exactly the sources the index said carry the event'
+        );
+
+        $pairs = array_map(
+            static fn (array $r): string => $r['tier'] . ':' . $r['source_id'],
+            $body['readings']
+        );
+        self::assertSame(count($pairs), count(array_unique($pairs)), 'each source must be reported once');
+        self::assertContains('rite:roman', $pairs);
+        self::assertNotEmpty(
+            array_filter($pairs, static fn (string $p): bool => str_starts_with($p, 'missal:')),
+            'a key carried by a national missal must name that missal, not be merged into the rite tier'
+        );
+    }
+
+    // -------------------------------------------------------------- absent is not empty
+
+    public function testALocaleThatOmitsAnEventIsReportedAsWithoutAnEntryNotAsAnEmptyOne(): void
+    {
+        $files = self::riteFiles();
+
+        // Find a key some locale files carry and others do not — the state that a per-locale
+        // request cannot tell apart from "translated but empty".
+        $union = [];
+        foreach ($files as $map) {
+            foreach (array_keys($map) as $key) {
+                $union[$key] = true;
+            }
+        }
+
+        $partialKey = null;
+        foreach (array_keys($union) as $key) {
+            $absent = array_keys(array_filter($files, static fn (array $m): bool => false === array_key_exists($key, $m)));
+            if ([] !== $absent && count($absent) < count($files)) {
+                $partialKey = $key;
+                break;
+            }
+        }
+        self::assertNotNull(
+            $partialKey,
+            'no event_key in the rite-level corpus is present in some locales and absent from others, '
+            . 'so this distinction cannot be exercised against real data any more'
+        );
+
+        $body = $this->get(['sanctorale', $partialKey]);
+        $rite = null;
+        foreach ($body['readings'] as $source) {
+            if ($source['tier'] === 'rite') {
+                $rite = $source;
+                break;
+            }
+        }
+        self::assertNotNull($rite);
+
+        $expectedWith    = array_values(array_keys(array_filter($files, static fn (array $m): bool => array_key_exists($partialKey, $m))));
+        $expectedWithout = array_values(array_keys(array_filter($files, static fn (array $m): bool => false === array_key_exists($partialKey, $m))));
+
+        self::assertSame($expectedWith, $rite['locales_with_entry']);
+        self::assertSame($expectedWithout, $rite['locales_without_entry']);
+        self::assertNotEmpty($rite['locales_without_entry']);
+
+        // The locales that omit it appear in neither `entries` nor the empty-entry list: "no entry"
+        // and "an entry that is empty" are different answers, and only one of them is true here.
+        foreach ($expectedWithout as $locale) {
+            self::assertArrayNotHasKey($locale, $rite['entries']);
+            self::assertNotContains($locale, $rite['locales_with_empty_entry']);
+        }
+        self::assertSame($expectedWith, array_keys($rite['entries']));
+    }
+
+    public function testAnEntryWhoseFieldsAreEmptyStringsIsReportedAsPresentAndEmpty(): void
+    {
+        $files = self::riteFiles();
+
+        // A key every locale carries, with every field an empty string in at least one of them:
+        // the placeholder convention this corpus uses for "structure in place, readings unwritten".
+        $emptyKey = null;
+        foreach (array_keys($files[array_key_first($files)]) as $key) {
+            $inAll = array_all($files, static fn (array $m): bool => array_key_exists($key, $m));
+            if (false === $inAll) {
+                continue;
+            }
+            $allEmpty = array_all(
+                $files,
+                static fn (array $m): bool => array_all(
+                    $m[$key],
+                    static fn (mixed $v): bool => is_string($v) && $v === ''
+                )
+            );
+            if ($allEmpty) {
+                $emptyKey = $key;
+                break;
+            }
+        }
+        self::assertNotNull($emptyKey, 'no all-empty placeholder entry found in the rite-level corpus');
+
+        $body = $this->get(['sanctorale', $emptyKey]);
+        $rite = null;
+        foreach ($body['readings'] as $source) {
+            if ($source['tier'] === 'rite') {
+                $rite = $source;
+                break;
+            }
+        }
+        self::assertNotNull($rite);
+
+        // Present in every locale — and flagged empty in every locale, rather than dropped.
+        self::assertSame(array_keys($files), $rite['locales_with_entry']);
+        self::assertSame([], $rite['locales_without_entry']);
+        self::assertSame(array_keys($files), $rite['locales_with_empty_entry']);
+        foreach (array_keys($files) as $locale) {
+            self::assertArrayHasKey($locale, $rite['entries']);
+            foreach ($rite['entries'][$locale] as $value) {
+                self::assertSame('', $value);
+            }
+        }
+    }
+
+    public function testAnEntryWithReadingsIsNotFlaggedEmpty(): void
+    {
+        $files = self::riteFiles();
+
+        $contentKey    = null;
+        $contentLocale = null;
+        foreach ($files as $locale => $map) {
+            foreach ($map as $key => $entry) {
+                if (is_array($entry) && array_any($entry, static fn (mixed $v): bool => is_string($v) && $v !== '')) {
+                    $contentKey    = (string) $key;
+                    $contentLocale = (string) $locale;
+                    break 2;
+                }
+            }
+        }
+        self::assertNotNull($contentKey);
+        self::assertNotNull($contentLocale);
+
+        $body = $this->get(['sanctorale', $contentKey]);
+        $rite = null;
+        foreach ($body['readings'] as $source) {
+            if ($source['tier'] === 'rite') {
+                $rite = $source;
+                break;
+            }
+        }
+        self::assertNotNull($rite);
+
+        self::assertContains($contentLocale, $rite['locales_with_entry']);
+        self::assertNotContains(
+            $contentLocale,
+            $rite['locales_with_empty_entry'],
+            "{$contentLocale} has written readings for {$contentKey}, so it must not be reported as an empty entry"
+        );
+        self::assertNotEmpty($rite['entries'][$contentLocale]);
+    }
+
+    // ------------------------------------------------------------ a rite with no lectionary
+
+    public function testAmbrosianIndexReportsNoLectionaryRatherThanNothingCurated(): void
+    {
+        $body = $this->get(['sanctorale'], Rite::AMBROSIAN);
+
+        self::assertSame('ambrosian', $body['rite']);
+        self::assertFalse($body['lectionary_available']);
+        self::assertSame([], $body['sources']);
+        self::assertSame([], $body['litcal_lectionary']);
+        self::assertArrayHasKey('message', $body);
+        self::assertStringContainsString('ambrosian', $body['message']);
+    }
+
+    public function testAmbrosianEventReportsNoLectionaryRatherThanNotFound(): void
+    {
+        // The same event_key is a 404 under a rite that has a lectionary and does not carry it
+        // (asserted above); under a rite that has none it must be a well-formed "not available".
+        $body = $this->get(['sanctorale', 'NotARealEventKeyAtAll'], Rite::AMBROSIAN);
+
+        self::assertFalse($body['lectionary_available']);
+        self::assertSame([], $body['readings']);
+        self::assertSame('NotARealEventKeyAtAll', $body['event_key']);
+        self::assertArrayHasKey('message', $body);
+    }
+
+    // ------------------------------------------------------------------ response schema
+
+    public function testResponsesValidateAgainstTheLectionaryPathSchema(): void
+    {
+        $index = $this->get(['sanctorale']);
+        self::assertNotEmpty($index['litcal_lectionary']);
+        $someKey = $index['litcal_lectionary'][0]['event_key'];
+
+        $cases = [
+            'roman index'     => [['sanctorale'], Rite::ROMAN],
+            'roman event'     => [['sanctorale', $someKey], Rite::ROMAN],
+            'ambrosian index' => [['sanctorale'], Rite::AMBROSIAN],
+            'ambrosian event' => [['sanctorale', $someKey], Rite::AMBROSIAN],
+        ];
+
+        foreach ($cases as $label => [$pathParams, $rite]) {
+            $response = ( new LectionaryHandler($pathParams, $rite) )->handle(
+                $this->requestFor('GET', '/lectionary/' . $rite->value . '/' . implode('/', $pathParams))
+            );
+            self::assertSame(200, $response->getStatusCode(), $label);
+            $decoded = json_decode((string) $response->getBody(), flags: JSON_THROW_ON_ERROR);
+            Schema::import(LitSchema::LECTIONARY_PATH->path())->in($decoded);
+            $this->addToAssertionCount(1);
+        }
+    }
+}

--- a/phpunit_tests/Handlers/MissalsHandlerI18nTest.php
+++ b/phpunit_tests/Handlers/MissalsHandlerI18nTest.php
@@ -1,0 +1,399 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\RomanMissal;
+use LiturgicalCalendar\Api\Handlers\MissalsHandler;
+use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Swaggest\JsonSchema\Schema;
+
+/**
+ * `GET /missals/{missal_id}/i18n` — issue #941 — plus the response-schema half of the same issue:
+ * `openapi.json` documented `GET /missals/{missal_id}` with the *metadata* shape of a `/missals`
+ * index row, which is not what that route emits.
+ *
+ * The translated/empty/missing three-way split is checked against every missal in the index, with
+ * the expectation computed by reading the i18n files straight off disk — an oracle independent of
+ * the handler — rather than by naming an `event_key` that a parallel rename could invalidate.
+ *
+ * One of the three states has no instance in the committed corpus: today every locale file of every
+ * missal carries an entry for every row, so `missing` is empty everywhere. It is exercised anyway,
+ * against a temporary source tree assembled by
+ * {@see self::testAKeyAbsentFromALocaleIsReportedMissingNotEmpty()} — an untested branch of a
+ * three-way split is a coin toss, and this one is the whole reason the split exists.
+ */
+#[CoversClass(MissalsHandler::class)]
+final class MissalsHandlerI18nTest extends AbstractHandlerTestCase
+{
+    private ?string $tempRoot     = null;
+    private ?string $savedApiFile = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        MissalsHandler::$missalsIndex = null;
+    }
+
+    protected function tearDown(): void
+    {
+        if (null !== $this->savedApiFile) {
+            Router::$apiFilePath = $this->savedApiFile;
+            $this->savedApiFile  = null;
+        }
+        if (null !== $this->tempRoot) {
+            self::removeTree($this->tempRoot);
+            $this->tempRoot = null;
+        }
+        MissalsHandler::$missalsIndex = null;
+        parent::tearDown();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function i18nFor(string $missalId): array
+    {
+        MissalsHandler::$missalsIndex = null;
+        $response                     = ( new MissalsHandler([$missalId, 'i18n']) )->handle(
+            $this->requestFor('GET', '/missals/' . $missalId . '/i18n')
+        );
+        self::assertSame(200, $response->getStatusCode());
+        return $this->decodeJsonBody($response);
+    }
+
+    /**
+     * The missal ids the index actually serves, discovered through the index route rather than
+     * from `RomanMissal`, whose enumeration includes editions with no data on disk.
+     *
+     * @return string[]
+     */
+    private function indexedMissalIds(): array
+    {
+        MissalsHandler::$missalsIndex = null;
+        $response                     = ( new MissalsHandler() )->handle($this->requestFor('GET', '/missals'));
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        /** @var string[] $ids */
+        $ids = array_column($body['litcal_missals'], 'missal_id');
+        self::assertNotEmpty($ids);
+        return $ids;
+    }
+
+    /**
+     * One missal's i18n files, decoded off disk.
+     *
+     * @return array<string,array<string,string>>
+     */
+    private static function i18nFilesOnDisk(string $missalId): array
+    {
+        $folder = RomanMissal::getSanctoraleI18nFilePath($missalId);
+        self::assertIsString($folder);
+        $files = glob(rtrim($folder, '/') . '/*.json');
+        self::assertIsArray($files);
+        sort($files);
+
+        $decoded = [];
+        foreach ($files as $file) {
+            $raw = file_get_contents($file);
+            self::assertIsString($raw);
+            /** @var array<string,string> $map */
+            $map                               = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+            $decoded[basename($file, '.json')] = $map;
+        }
+        return $decoded;
+    }
+
+    // -------------------------------------------------------------------- shape
+
+    public function testEveryLocaleIsReturnedSideBySide(): void
+    {
+        foreach ($this->indexedMissalIds() as $missalId) {
+            $body = $this->i18nFor($missalId);
+
+            self::assertSame($missalId, $body['missal_id']);
+            $onDisk = self::i18nFilesOnDisk($missalId);
+
+            self::assertSame(
+                array_keys($onDisk),
+                $body['locales'],
+                "{$missalId} must report every locale its i18n folder declares"
+            );
+            self::assertSame(array_keys($onDisk), array_keys($body['i18n']));
+            foreach ($onDisk as $locale => $map) {
+                self::assertSame($map, $body['i18n'][$locale], "{$missalId}/{$locale} must be returned verbatim");
+            }
+            self::assertNotEmpty($body['event_keys']);
+            self::assertSame($body['event_keys'], array_keys($body['coverage']));
+        }
+    }
+
+    public function testUnknownMissalIsNotFound(): void
+    {
+        $this->expectException(NotFoundException::class);
+        ( new MissalsHandler(['NOT_A_REAL_MISSAL', 'i18n']) )
+            ->handle($this->requestFor('GET', '/missals/NOT_A_REAL_MISSAL/i18n'));
+    }
+
+    public function testAnUnknownSubResourceIsStillAValidationError(): void
+    {
+        // Only `i18n` is a sub-resource of a missal; anything else stays the two-path-params error
+        // the route answered before this one existed.
+        $this->expectException(ValidationException::class);
+        ( new MissalsHandler(['EDITIO_TYPICA_2002', 'lectionary']) )
+            ->handle($this->requestFor('GET', '/missals/EDITIO_TYPICA_2002/lectionary'));
+    }
+
+    // -------------------------------------------------- translated vs. empty vs. missing
+
+    public function testCoverageMatchesTheLocaleFilesForEveryMissal(): void
+    {
+        $sawTranslated = false;
+        $sawEmpty      = false;
+
+        foreach ($this->indexedMissalIds() as $missalId) {
+            $body   = $this->i18nFor($missalId);
+            $onDisk = self::i18nFilesOnDisk($missalId);
+
+            foreach ($body['event_keys'] as $eventKey) {
+                $translated = [];
+                $empty      = [];
+                $missing    = [];
+                foreach ($onDisk as $locale => $map) {
+                    if (false === array_key_exists($eventKey, $map)) {
+                        $missing[] = $locale;
+                    } elseif ($map[$eventKey] === '') {
+                        $empty[] = $locale;
+                    } else {
+                        $translated[] = $locale;
+                    }
+                }
+
+                $coverage = $body['coverage'][$eventKey];
+                self::assertSame($translated, $coverage['translated'], "{$missalId}/{$eventKey} translated");
+                self::assertSame($empty, $coverage['empty'], "{$missalId}/{$eventKey} empty");
+                self::assertSame($missing, $coverage['missing'], "{$missalId}/{$eventKey} missing");
+
+                $sawTranslated = $sawTranslated || [] !== $translated;
+                $sawEmpty      = $sawEmpty || [] !== $empty;
+            }
+        }
+
+        self::assertTrue($sawTranslated, 'no translated name anywhere in the corpus — the oracle cannot be right');
+        self::assertTrue(
+            $sawEmpty,
+            'no empty-string translation anywhere in the corpus, so the translated/empty distinction '
+            . 'was not actually exercised by this run'
+        );
+    }
+
+    public function testAnEmptyTranslationIsReportedEmptyAndReturnedVerbatimRatherThanDropped(): void
+    {
+        // Find a real event_key that some locales translate and others carry as the empty string —
+        // exactly the "translated in twelve locales, empty in two" case a single-locale request
+        // cannot show. The one-request-per-locale workaround this route replaces could not tell
+        // that apart from a locale with no entry at all.
+        foreach ($this->indexedMissalIds() as $missalId) {
+            $body = $this->i18nFor($missalId);
+            foreach ($body['coverage'] as $eventKey => $coverage) {
+                if ([] === $coverage['translated'] || [] === $coverage['empty']) {
+                    continue;
+                }
+
+                foreach ($coverage['empty'] as $locale) {
+                    self::assertArrayHasKey(
+                        $eventKey,
+                        $body['i18n'][$locale],
+                        "{$missalId}/{$locale} carries {$eventKey} as an empty string, so the key must still be present"
+                    );
+                    self::assertSame('', $body['i18n'][$locale][$eventKey]);
+                    self::assertNotContains($locale, $coverage['missing']);
+                }
+                foreach ($coverage['translated'] as $locale) {
+                    self::assertNotSame('', $body['i18n'][$locale][$eventKey]);
+                }
+                return;
+            }
+        }
+
+        self::fail('no event_key is translated in some locales and empty in others; the distinction was not exercised');
+    }
+
+    public function testAKeyAbsentFromALocaleIsReportedMissingNotEmpty(): void
+    {
+        // Every committed locale file carries an entry for every row, so the third state has no
+        // instance to point at. Build one: a throwaway source tree holding a copy of one real
+        // missal plus one extra locale file that deliberately omits some of its keys. Nothing
+        // under jsondata/ is touched — `Router::$apiFilePath` is the prefix every `JsonData` path
+        // is built from, so re-pointing it moves the whole read.
+        $missalId    = 'EDITIO_TYPICA_2008';
+        $missalDir   = 'propriumdesanctis_2008';
+        $sourceDir   = JsonData::MISSALS_FOLDER->path() . '/' . $missalDir;
+        $extraLocale = 'ca';
+
+        self::assertDirectoryExists($sourceDir);
+        self::assertFileDoesNotExist(
+            $sourceDir . '/i18n/' . $extraLocale . '.json',
+            "this test assumes '{$extraLocale}' is not a real locale of {$missalId}"
+        );
+
+        $this->tempRoot = self::makeTempDir();
+        $target         = $this->tempRoot . '/jsondata/sourcedata/rite/roman/missals/' . $missalDir;
+        self::copyTree($sourceDir, $target);
+
+        $rows = json_decode((string) file_get_contents($target . '/' . $missalDir . '.json'), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($rows);
+        self::assertGreaterThanOrEqual(2, count($rows), 'need at least two rows to have one present and one absent');
+        /** @var array<int,array<string,mixed>> $rows */
+        $eventKeys  = array_map(static fn (array $row): string => (string) $row['event_key'], $rows);
+        $presentKey = $eventKeys[0];
+        $absentKeys = array_slice($eventKeys, 1);
+
+        file_put_contents(
+            $target . '/i18n/' . $extraLocale . '.json',
+            json_encode([$presentKey => 'Un nom en català'], JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE)
+        );
+
+        $this->savedApiFile  = Router::$apiFilePath;
+        Router::$apiFilePath = $this->tempRoot . DIRECTORY_SEPARATOR;
+
+        $body = $this->i18nFor($missalId);
+
+        // Put the real tree back before asserting: every `JsonData` path hangs off this prefix,
+        // the schema folder included, so leaving it redirected would send Schema::import() looking
+        // for LitCalMissalTranslationsPath.json inside the throwaway tree.
+        Router::$apiFilePath = $this->savedApiFile;
+        $this->savedApiFile  = null;
+
+        self::assertContains($extraLocale, $body['locales']);
+
+        // The key the extra locale does carry: translated, and neither empty nor missing.
+        self::assertContains($extraLocale, $body['coverage'][$presentKey]['translated']);
+        self::assertNotContains($extraLocale, $body['coverage'][$presentKey]['missing']);
+        self::assertNotContains($extraLocale, $body['coverage'][$presentKey]['empty']);
+
+        // The keys it does not: missing — NOT empty — and absent from the returned map, which is
+        // what a client reads to tell "no entry in this locale" from "entry not written yet".
+        foreach ($absentKeys as $absentKey) {
+            self::assertContains(
+                $extraLocale,
+                $body['coverage'][$absentKey]['missing'],
+                "{$absentKey} has no entry in {$extraLocale}, so it must be reported missing"
+            );
+            self::assertNotContains($extraLocale, $body['coverage'][$absentKey]['empty']);
+            self::assertNotContains($extraLocale, $body['coverage'][$absentKey]['translated']);
+            self::assertArrayNotHasKey($absentKey, $body['i18n'][$extraLocale]);
+        }
+
+        // …while the locales that carry those same keys as empty strings are still reported empty,
+        // so the two states are told apart within a single response.
+        $sawEmptyBeside = false;
+        foreach ($absentKeys as $absentKey) {
+            if ([] !== $body['coverage'][$absentKey]['empty']) {
+                $sawEmptyBeside = true;
+                $locale         = $body['coverage'][$absentKey]['empty'][0];
+                self::assertSame('', $body['i18n'][$locale][$absentKey]);
+            }
+        }
+        self::assertTrue($sawEmptyBeside, 'expected the same response to carry an empty entry alongside a missing one');
+
+        Schema::import(LitSchema::MISSAL_TRANSLATIONS->path())->in(json_decode((string) json_encode($body), flags: JSON_THROW_ON_ERROR));
+        $this->addToAssertionCount(1);
+    }
+
+    // -------------------------------------------------------------- response schemas
+
+    public function testI18nResponsesValidateAgainstTheMissalTranslationsSchema(): void
+    {
+        foreach ($this->indexedMissalIds() as $missalId) {
+            MissalsHandler::$missalsIndex = null;
+            $response                     = ( new MissalsHandler([$missalId, 'i18n']) )->handle(
+                $this->requestFor('GET', '/missals/' . $missalId . '/i18n')
+            );
+            self::assertSame(200, $response->getStatusCode());
+            $decoded = json_decode((string) $response->getBody(), flags: JSON_THROW_ON_ERROR);
+            Schema::import(LitSchema::MISSAL_TRANSLATIONS->path())->in($decoded);
+            $this->addToAssertionCount(1);
+        }
+    }
+
+    /**
+     * The other half of #941: `GET /missals/{missal_id}` returns an array of sanctorale rows, and
+     * openapi.json now says so. Validating the real response against the schema that replaced the
+     * metadata `$ref` is what keeps the documented shape and the emitted one from drifting again.
+     */
+    public function testSingleMissalResponseValidatesAgainstTheSanctoraleSchema(): void
+    {
+        foreach ($this->indexedMissalIds() as $missalId) {
+            MissalsHandler::$missalsIndex = null;
+            $response                     = ( new MissalsHandler([$missalId]) )->handle(
+                $this->requestFor('GET', '/missals/' . $missalId, ['Accept-Language' => 'en'])
+            );
+            self::assertSame(200, $response->getStatusCode());
+            $decoded = json_decode((string) $response->getBody(), flags: JSON_THROW_ON_ERROR);
+            self::assertIsArray($decoded, "{$missalId} must answer with an array of sanctorale rows, not a metadata object");
+            Schema::import(LitSchema::MISSAL_SANCTORALE->path())->in($decoded);
+            $this->addToAssertionCount(1);
+        }
+    }
+
+    // ------------------------------------------------------------------- helpers
+
+    private static function makeTempDir(): string
+    {
+        $base = sys_get_temp_dir() . '/litcal-missal-i18n-' . bin2hex(random_bytes(6));
+        self::assertTrue(mkdir($base, 0o777, true));
+        return $base;
+    }
+
+    private static function copyTree(string $from, string $to): void
+    {
+        self::assertTrue(is_dir($from));
+        if (false === is_dir($to)) {
+            self::assertTrue(mkdir($to, 0o777, true));
+        }
+        $entries = scandir($from);
+        self::assertIsArray($entries);
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $src = $from . DIRECTORY_SEPARATOR . $entry;
+            $dst = $to . DIRECTORY_SEPARATOR . $entry;
+            if (is_dir($src)) {
+                self::copyTree($src, $dst);
+            } else {
+                self::assertTrue(copy($src, $dst));
+            }
+        }
+    }
+
+    private static function removeTree(string $path): void
+    {
+        if (false === is_dir($path)) {
+            return;
+        }
+        $entries = scandir($path);
+        if (false === $entries) {
+            return;
+        }
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+            $child = $path . DIRECTORY_SEPARATOR . $entry;
+            if (is_dir($child)) {
+                self::removeTree($child);
+            } else {
+                unlink($child);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/phpunit_tests/RouterRiteSegmentTest.php
+++ b/phpunit_tests/RouterRiteSegmentTest.php
@@ -116,4 +116,35 @@ final class RouterRiteSegmentTest extends TestCase
         self::assertSame(Rite::ROMAN, Router::extractRiteSegment('data', $parts));
         self::assertSame(['widerregion', 'Europe'], $parts);
     }
+
+    /**
+     * Issue #942: `/lectionary` joined the rite-carrying routes. The rite is not decoration
+     * there — one of the two rites has no lectionary at all, and the route has to be able to
+     * say so rather than answer for the wrong corpus.
+     */
+    public function testLectionaryRouteSupportsAnAmbrosianRiteSegment(): void
+    {
+        $parts = ['ambrosian', 'sanctorale', 'StPeterClaver'];
+        self::assertSame(Rite::AMBROSIAN, Router::extractRiteSegment('lectionary', $parts));
+        self::assertSame(['sanctorale', 'StPeterClaver'], $parts);
+    }
+
+    public function testLectionaryRouteExplicitRomanIsEquivalentToBare(): void
+    {
+        $explicit = ['roman', 'sanctorale'];
+        self::assertSame(Rite::ROMAN, Router::extractRiteSegment('lectionary', $explicit));
+
+        $bare = ['sanctorale'];
+        self::assertSame(Rite::ROMAN, Router::extractRiteSegment('lectionary', $bare));
+
+        // Both spellings leave the handler the same one-part shape to parse.
+        self::assertSame($bare, $explicit);
+    }
+
+    public function testLectionarySectionNameIsNeverMistakenForARite(): void
+    {
+        $parts = ['sanctorale'];
+        self::assertSame(Rite::ROMAN, Router::extractRiteSegment('lectionary', $parts));
+        self::assertSame(['sanctorale'], $parts);
+    }
 }

--- a/phpunit_tests/Schemas/OpenApiCanonicalFormTest.php
+++ b/phpunit_tests/Schemas/OpenApiCanonicalFormTest.php
@@ -39,8 +39,14 @@ final class OpenApiCanonicalFormTest extends TestCase
 
     private const HEADER_REF = '#/components/headers/CanonicalRiteLink';
 
-    /** Route families whose first path segment takes an optional rite segment. */
-    private const RITE_ROUTES = ['calendar', 'events', 'data'];
+    /**
+     * Route families whose first path segment takes an optional rite segment.
+     *
+     * Mirrors the condition in `Router::extractRiteSegment()`; `lectionary` joined it with the
+     * sanctorale lectionary read route (#942), which needs the rite in the path precisely because
+     * one of the rites has no lectionary at all.
+     */
+    private const RITE_ROUTES = ['calendar', 'events', 'data', 'lectionary'];
 
     /**
      * Loaded lazily rather than in `setUpBeforeClass()`: the data providers below enumerate the

--- a/src/Enum/LitSchema.php
+++ b/src/Enum/LitSchema.php
@@ -17,16 +17,36 @@ enum LitSchema: string
     case DECREE_WRITE      = '/LitCalDecreeWritePayload.json';
     case I18N              = '/LitCalTranslation.json';
     case LECTIONARY        = '/Lectionary.json';
-    case METADATA          = '/LitCalMetadata.json';
-    case LITCAL            = '/LitCal.json';
-    case EVENTS            = '/LitCalEventsPath.json';
-    case TESTS             = '/LitCalTestsPath.json';
-    case TEST_SRC          = '/LitCalTest.json';
-    case MISSALS           = '/LitCalMissalsPath.json';
-    case EASTER            = '/LitCalEasterPath.json';
-    case DATA              = '/LitCalDataPath.json';
-    case SCHEMAS           = '/LitCalSchemasPath.json';
-    case VALIDATIONS       = '/LitCalValidationsPath.json';
+    /**
+     * `/lectionary` responses — the section index and a single event's readings (#942).
+     *
+     * OUTPUT, not SOURCE, and distinct from {@see self::LECTIONARY}, which validates one locale
+     * file of the stored corpus. This schema validates the aggregation the route builds *over*
+     * those files: which tier answered, which locales carry an entry, and which of those entries
+     * are the empty-string placeholder.
+     */
+    case LECTIONARY_PATH = '/LitCalLectionaryPath.json';
+    case METADATA        = '/LitCalMetadata.json';
+    case LITCAL          = '/LitCal.json';
+    case EVENTS          = '/LitCalEventsPath.json';
+    case TESTS           = '/LitCalTestsPath.json';
+    case TEST_SRC        = '/LitCalTest.json';
+    case MISSALS         = '/LitCalMissalsPath.json';
+    /**
+     * `GET /missals/{missal_id}` — the sanctorale rows of one Missal (#941).
+     *
+     * Separate from {@see self::MISSALS}, which validates the `/missals` INDEX. openapi.json used
+     * to document this route's 200 with the index's row shape, which the route does not emit.
+     */
+    case MISSAL_SANCTORALE = '/LitCalMissalSanctoralePath.json';
+    /**
+     * `GET /missals/{missal_id}/i18n` — every locale's sanctorale names for one Missal (#941).
+     */
+    case MISSAL_TRANSLATIONS = '/LitCalMissalTranslationsPath.json';
+    case EASTER              = '/LitCalEasterPath.json';
+    case DATA                = '/LitCalDataPath.json';
+    case SCHEMAS             = '/LitCalSchemasPath.json';
+    case VALIDATIONS         = '/LitCalValidationsPath.json';
     /**
      * `jsondata/supportedLocales.json` — the curated set of officially supported locales.
      *
@@ -84,6 +104,9 @@ enum LitSchema: string
             LitSchema::TESTS    => $ERRMSG . 'Tests path data not valid',
             LitSchema::TEST_SRC => $ERRMSG . 'Test data not valid',
             LitSchema::MISSALS  => $ERRMSG . 'Missals path data not valid',
+            LitSchema::MISSAL_SANCTORALE   => $ERRMSG . 'Missal sanctorale path data not valid',
+            LitSchema::MISSAL_TRANSLATIONS => $ERRMSG . 'Missal translations path data not valid',
+            LitSchema::LECTIONARY_PATH     => $ERRMSG . 'Lectionary path data not valid',
             LitSchema::EASTER   => $ERRMSG . 'Easter path data not valid',
             LitSchema::DATA     => $ERRMSG . 'Data path data not valid',
             LitSchema::SCHEMAS  => $ERRMSG . 'Schemas path data not valid',
@@ -120,6 +143,9 @@ enum LitSchema: string
             LitSchema::EVENTS,
             LitSchema::TESTS,
             LitSchema::MISSALS,
+            LitSchema::MISSAL_SANCTORALE,
+            LitSchema::MISSAL_TRANSLATIONS,
+            LitSchema::LECTIONARY_PATH,
             LitSchema::EASTER,
             LitSchema::DATA,
             LitSchema::SCHEMAS,
@@ -150,6 +176,9 @@ enum LitSchema: string
             LitSchema::TESTS->path()             => LitSchema::TESTS,
             LitSchema::TEST_SRC->path()          => LitSchema::TEST_SRC,
             LitSchema::MISSALS->path()           => LitSchema::MISSALS,
+            LitSchema::MISSAL_SANCTORALE->path()   => LitSchema::MISSAL_SANCTORALE,
+            LitSchema::MISSAL_TRANSLATIONS->path() => LitSchema::MISSAL_TRANSLATIONS,
+            LitSchema::LECTIONARY_PATH->path()     => LitSchema::LECTIONARY_PATH,
             LitSchema::EASTER->path()            => LitSchema::EASTER,
             LitSchema::DATA->path()              => LitSchema::DATA,
             LitSchema::SCHEMAS->path()           => LitSchema::SCHEMAS,

--- a/src/Enum/Route.php
+++ b/src/Enum/Route.php
@@ -11,6 +11,7 @@ enum Route: string
     case CALENDAR_NATIONAL  = '/calendar/nation';
     case CALENDAR_DIOCESAN  = '/calendar/diocese';
     case DECREES            = '/decrees';
+    case LECTIONARY         = '/lectionary';
     case TESTS              = '/tests';
     case EVENTS             = '/events';
     case EVENTS_NATIONAL    = '/events/nation';

--- a/src/Handlers/LectionaryHandler.php
+++ b/src/Handlers/LectionaryHandler.php
@@ -1,0 +1,416 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Handlers;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Enum\RomanMissal;
+use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
+use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
+use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Utilities;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Handles the `/lectionary` path of the API: a read surface over the curated lectionary
+ * source data, addressed by `event_key` rather than by computed date (issue #942).
+ *
+ * Only the `sanctorale` section is served for now:
+ *
+ * - `GET /lectionary/sanctorale` — an index of every `event_key` that has an entry in any
+ *   lectionary source, naming for each the sources that carry it.
+ * - `GET /lectionary/sanctorale/{event_key}` — every locale's readings for that event, from
+ *   every source that carries it.
+ *
+ * Both accept the optional leading rite segment (`/lectionary/roman/sanctorale`,
+ * `/lectionary/ambrosian/sanctorale`), exactly as `/calendar`, `/events` and `/data` do.
+ *
+ * ## Two tiers, and saying which one answered
+ *
+ * The sanctorale readings live in two places, and an `event_key` may be carried by both:
+ *
+ * 1. the **rite**-level corpus, `jsondata/sourcedata/rite/roman/lectionary/sanctorum/{locale}.json`;
+ * 2. a **missal**-level corpus, one folder per national missal, resolved through
+ *    {@see RomanMissal::getLectionaryFilePath()}.
+ *
+ * A client editing readings has to know which file it is looking at, so every entry returned
+ * names its `tier` and its `source_id` rather than being merged into a single answer. The
+ * missal tier is enumerated from `RomanMissal`'s explicit lectionary-path map, not by globbing
+ * the missals folder, so it does not depend on the `{dir}/{dir}.json` folder-naming convention.
+ *
+ * ## Absent is not empty
+ *
+ * A reading field that is the empty string is an established convention in this corpus: it
+ * means "the structure is in place, the reading is not written yet". That is a different state
+ * from "this locale's file has no entry for this key at all", and both are legitimate. The
+ * response therefore reports, per source, three disjoint-ish sets over the source's declared
+ * locales: `locales_with_entry`, `locales_without_entry`, and — as a subset of the first —
+ * `locales_with_empty_entry`. The raw `entries` map carries every entry verbatim, empty strings
+ * included, so nothing is flattened away.
+ *
+ * ## Rites with no lectionary
+ *
+ * There is no Ambrosian lectionary. Rather than a 500 or an empty object indistinguishable from
+ * "nothing curated yet", such a request is answered `200` with `lectionary_available: false`, no
+ * sources, and a message saying so. An unknown `event_key` under a rite that *does* have a
+ * lectionary is a `404`, so the two states never collide.
+ *
+ * ## Locale
+ *
+ * This route is deliberately locale-agnostic: it aggregates every locale a source declares, which
+ * is the whole point of it, so no `Accept-Language` negotiation takes place.
+ */
+final class LectionaryHandler extends AbstractHandler
+{
+    /** The only lectionary section addressable through this route so far. */
+    public const string SECTION_SANCTORALE = 'sanctorale';
+
+    /** Sources whose readings belong to the rite as a whole rather than to one missal. */
+    private const string TIER_RITE = 'rite';
+
+    /** Sources whose readings belong to a single Roman Missal edition. */
+    private const string TIER_MISSAL = 'missal';
+
+    private Rite $rite;
+
+    /**
+     * @param string[] $requestPathParams the path segments following `/lectionary`, rite segment already stripped
+     */
+    public function __construct(array $requestPathParams = [], Rite $rite = Rite::ROMAN)
+    {
+        parent::__construct($requestPathParams);
+        $this->rite = $rite;
+        $this->setAllowedRequestMethods([RequestMethod::GET]);
+        $this->setAllowedAcceptHeaders([AcceptHeader::JSON, AcceptHeader::YAML]);
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = static::initResponse($request);
+
+        $method = RequestMethod::from($request->getMethod());
+
+        if ($method === RequestMethod::OPTIONS) {
+            return $this->handlePreflightRequest($request, $response);
+        }
+
+        $response = $this->setAccessControlAllowOriginHeader($request, $response);
+
+        $mime     = $this->validateAcceptHeader($request, AcceptabilityLevel::LAX);
+        $response = $response->withHeader('Content-Type', $mime);
+
+        $this->validateRequestMethod($request);
+
+        if ($method !== RequestMethod::GET) {
+            throw new MethodNotAllowedException();
+        }
+
+        $numPathParams = count($this->requestPathParams);
+
+        if ($numPathParams === 0) {
+            throw new NotFoundException(
+                'The `/lectionary` path is not a resource of its own; address a section of the lectionary, '
+                . 'e.g. ' . Router::$apiPath . '/lectionary/' . $this->rite->value . '/' . self::SECTION_SANCTORALE
+            );
+        }
+
+        if ($numPathParams > 2) {
+            throw new NotFoundException(
+                'At most two path parameters are expected on the `/lectionary` path (a section, and optionally an event_key), instead '
+                . $numPathParams . ' were found'
+            );
+        }
+
+        $section = $this->requestPathParams[0];
+        if ($section !== self::SECTION_SANCTORALE) {
+            throw new NotFoundException(
+                "Unknown lectionary section '" . $section . "', the only supported value is: " . self::SECTION_SANCTORALE
+            );
+        }
+
+        $sources = $this->sanctoraleSources();
+
+        if ($numPathParams === 1) {
+            return $this->encodeResponseBody($response, $this->buildIndex($sources));
+        }
+
+        return $this->encodeResponseBody($response, $this->buildEventReadings($sources, $this->requestPathParams[1]));
+    }
+
+    /**
+     * The folder holding the rite-level sanctorale lectionary, or null when the rite has none.
+     *
+     * The Ambrosian rite currently has no lectionary data at all — no folder, not an empty one —
+     * which is why this is a match on the rite rather than a path built from it.
+     */
+    private function riteLectionaryFolder(): ?string
+    {
+        return match ($this->rite) {
+            Rite::ROMAN     => JsonData::LECTIONARY_SAINTS_FOLDER->path(),
+            Rite::AMBROSIAN => null,
+        };
+    }
+
+    /**
+     * Every lectionary source that can carry a sanctorale entry for the requested rite,
+     * in resolution order: the rite-level corpus first, then each missal that declares one.
+     *
+     * @return list<array{tier:string,source_id:string,folder:string,locales:list<string>}>
+     */
+    private function sanctoraleSources(): array
+    {
+        $sources = [];
+
+        $riteFolder = $this->riteLectionaryFolder();
+        if (null !== $riteFolder) {
+            $locales = self::localesInFolder($riteFolder);
+            if ([] !== $locales) {
+                $sources[] = [
+                    'tier'      => self::TIER_RITE,
+                    'source_id' => $this->rite->value,
+                    'folder'    => $riteFolder,
+                    'locales'   => $locales
+                ];
+            }
+        }
+
+        // The per-missal lectionaries belong to the Roman Missal editions, so they only apply
+        // to the Roman rite. `RomanMissal::$lectionaryPath` maps only the national editions:
+        // the editiones typicae take their sanctorale readings from the rite-level corpus.
+        if ($this->rite === Rite::ROMAN) {
+            foreach (RomanMissal::getMissalIds() as $missalId) {
+                $folder = RomanMissal::getLectionaryFilePath($missalId);
+                if (false === $folder) {
+                    continue;
+                }
+                $locales = self::localesInFolder($folder);
+                if ([] === $locales) {
+                    continue;
+                }
+                $sources[] = [
+                    'tier'      => self::TIER_MISSAL,
+                    'source_id' => $missalId,
+                    'folder'    => $folder,
+                    'locales'   => $locales
+                ];
+            }
+        }
+
+        return $sources;
+    }
+
+    /**
+     * The locales a lectionary folder declares, i.e. the basenames of the JSON files it holds.
+     *
+     * @return list<string>
+     */
+    private static function localesInFolder(string $folder): array
+    {
+        $folder = rtrim($folder, '/\\');
+        if (false === is_dir($folder)) {
+            return [];
+        }
+        $files = glob($folder . DIRECTORY_SEPARATOR . '*.json');
+        if (false === $files) {
+            return [];
+        }
+        sort($files);
+        return array_values(array_map(static fn (string $file): string => basename($file, '.json'), $files));
+    }
+
+    /**
+     * Decode one locale file of one source, or null when it is unreadable or is not a JSON object.
+     *
+     * A malformed or missing file must not take the whole route down: it is one locale of one
+     * source, and the well-formed answer is that the locale carries no entry.
+     */
+    private static function readLocaleFile(string $folder, string $locale): ?\stdClass
+    {
+        $file = rtrim($folder, '/\\') . DIRECTORY_SEPARATOR . $locale . '.json';
+        if (false === is_readable($file)) {
+            return null;
+        }
+        try {
+            return Utilities::jsonFileToObject($file);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Whether a readings entry carries anything at all, as opposed to being the all-empty-string
+     * placeholder that means "structure in place, readings not written yet".
+     *
+     * Recurses into nested objects because source-data readings may nest (a vigil Mass's readings
+     * belong to the event that has the vigil).
+     */
+    private static function hasReadingsContent(\stdClass $readings): bool
+    {
+        foreach (get_object_vars($readings) as $value) {
+            if (is_string($value) && $value !== '') {
+                return true;
+            }
+            if ($value instanceof \stdClass && self::hasReadingsContent($value)) {
+                return true;
+            }
+            if (is_array($value) && $value !== []) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The `GET /lectionary/{rite}/sanctorale` index: every `event_key` any source carries,
+     * with the sources that carry it.
+     *
+     * @param list<array{tier:string,source_id:string,folder:string,locales:list<string>}> $sources
+     */
+    private function buildIndex(array $sources): \stdClass
+    {
+        $out                       = new \stdClass();
+        $out->rite                 = $this->rite->value;
+        $out->section              = self::SECTION_SANCTORALE;
+        $out->lectionary_available = [] !== $sources;
+
+        $sourceSummaries = [];
+        /** @var array<string,list<array{tier:string,source_id:string}>> $eventKeys keyed by event_key, first-seen order preserved */
+        $eventKeys = [];
+
+        foreach ($sources as $source) {
+            $keysInSource = [];
+            foreach ($source['locales'] as $locale) {
+                $obj = self::readLocaleFile($source['folder'], $locale);
+                if (null === $obj) {
+                    continue;
+                }
+                foreach (array_keys(get_object_vars($obj)) as $eventKey) {
+                    $keysInSource[$eventKey] = true;
+                    if (false === array_key_exists($eventKey, $eventKeys)) {
+                        $eventKeys[$eventKey] = [];
+                    }
+                }
+            }
+
+            foreach (array_keys($keysInSource) as $eventKey) {
+                $eventKeys[$eventKey][] = ['tier' => $source['tier'], 'source_id' => $source['source_id']];
+            }
+
+            $summary                  = new \stdClass();
+            $summary->tier            = $source['tier'];
+            $summary->source_id       = $source['source_id'];
+            $summary->locales         = $source['locales'];
+            $summary->event_key_count = count($keysInSource);
+            $sourceSummaries[]        = $summary;
+        }
+
+        $out->sources = $sourceSummaries;
+
+        $items = [];
+        foreach ($eventKeys as $eventKey => $carriedBy) {
+            $item            = new \stdClass();
+            $item->event_key = (string) $eventKey;
+            $item->sources   = array_map(
+                static function (array $carrier): \stdClass {
+                    $obj            = new \stdClass();
+                    $obj->tier      = $carrier['tier'];
+                    $obj->source_id = $carrier['source_id'];
+                    return $obj;
+                },
+                $carriedBy
+            );
+            $item->api_path  = Router::$apiPath . '/lectionary/' . $this->rite->value . '/' . self::SECTION_SANCTORALE . '/' . $eventKey;
+            $items[]         = $item;
+        }
+        $out->litcal_lectionary = $items;
+
+        if ([] === $sources) {
+            $out->message = $this->noLectionaryMessage();
+        }
+
+        return $out;
+    }
+
+    /**
+     * The `GET /lectionary/{rite}/sanctorale/{event_key}` item: every locale's readings for the
+     * event, from every source that carries it.
+     *
+     * @param list<array{tier:string,source_id:string,folder:string,locales:list<string>}> $sources
+     * @throws NotFoundException when the rite has a lectionary but no source in it carries the event
+     */
+    private function buildEventReadings(array $sources, string $eventKey): \stdClass
+    {
+        $out                       = new \stdClass();
+        $out->rite                 = $this->rite->value;
+        $out->section              = self::SECTION_SANCTORALE;
+        $out->event_key            = $eventKey;
+        $out->lectionary_available = [] !== $sources;
+
+        if ([] === $sources) {
+            $out->readings = [];
+            $out->message  = $this->noLectionaryMessage();
+            return $out;
+        }
+
+        $readings = [];
+        foreach ($sources as $source) {
+            $entries      = new \stdClass();
+            $withEntry    = [];
+            $withoutEntry = [];
+            $emptyEntry   = [];
+
+            foreach ($source['locales'] as $locale) {
+                $obj = self::readLocaleFile($source['folder'], $locale);
+                if (null === $obj || false === property_exists($obj, $eventKey) || false === ( $obj->{$eventKey} instanceof \stdClass )) {
+                    $withoutEntry[] = $locale;
+                    continue;
+                }
+                $entry              = $obj->{$eventKey};
+                $entries->{$locale} = $entry;
+                $withEntry[]        = $locale;
+                if (false === self::hasReadingsContent($entry)) {
+                    $emptyEntry[] = $locale;
+                }
+            }
+
+            if ([] === $withEntry) {
+                // This source does not answer for this event_key at all; saying so for every
+                // source would bury the ones that do.
+                continue;
+            }
+
+            $item                           = new \stdClass();
+            $item->tier                     = $source['tier'];
+            $item->source_id                = $source['source_id'];
+            $item->locales                  = $source['locales'];
+            $item->locales_with_entry       = $withEntry;
+            $item->locales_without_entry    = $withoutEntry;
+            $item->locales_with_empty_entry = $emptyEntry;
+            $item->entries                  = $entries;
+            $readings[]                     = $item;
+        }
+
+        if ([] === $readings) {
+            throw new NotFoundException(
+                "No sanctorale lectionary entry found for event_key '" . $eventKey . "' in the " . $this->rite->value
+                . ' rite. The full list of available event_key values is at '
+                . Router::$apiPath . '/lectionary/' . $this->rite->value . '/' . self::SECTION_SANCTORALE
+            );
+        }
+
+        $out->readings = $readings;
+
+        return $out;
+    }
+
+    private function noLectionaryMessage(): string
+    {
+        return 'No sanctorale lectionary data is defined for the ' . $this->rite->value . ' rite.';
+    }
+}

--- a/src/Handlers/MissalsHandler.php
+++ b/src/Handlers/MissalsHandler.php
@@ -19,6 +19,21 @@ use Psr\Http\Message\ServerRequestInterface;
 
 final class MissalsHandler extends AbstractHandler
 {
+    /**
+     * The sub-resource segment of `GET /missals/{missal_id}/i18n`.
+     *
+     * `GET /missals/{missal_id}` folds exactly one negotiated locale's name into each sanctorale
+     * row, which is the right default for a calendar consumer but lossy for an editor: it carries
+     * one name per row, no note of which locale it came from, and no way to see that a key is
+     * translated in twelve locales and left empty in two (issue #941).
+     *
+     * The aggregated view is served here as an opt-in sidecar rather than as a `?locales=all`
+     * variant of the row response, for two reasons. It leaves the row shape untouched, so no
+     * existing consumer has to learn a second spelling of `name`; and it is the natural target for
+     * the corresponding `PUT`/`PATCH` (issue #943), which writes locale files, not rows.
+     */
+    private const string I18N_SUBRESOURCE = 'i18n';
+
     public MissalsParams $params;
     public static ?MissalMetadataMap $missalsIndex = null;
 
@@ -195,6 +210,8 @@ final class MissalsHandler extends AbstractHandler
                 // of the MissalMetadataMap instance
                 return $this->encodeResponseBody($response, MissalsHandler::$missalsIndex);
             }
+        } elseif ($numPathParams === 2 && $this->requestPathParams[1] === self::I18N_SUBRESOURCE) {
+            return $this->handleGetI18nRequest($response, $this->requestPathParams[0]);
         } elseif ($numPathParams > 1) {
             throw new ValidationException('Only one path parameter expected for the `/missals` path but ' . $numPathParams . ' path parameters were found');
         } else {
@@ -231,6 +248,109 @@ final class MissalsHandler extends AbstractHandler
             $description = "Could not find a Missal with id '" . $missalId . "', available values are: " . implode(', ', MissalsHandler::$missalsIndex->getMissalIDs());
             throw new NotFoundException($description);
         }
+    }
+
+
+    /**
+     * Serves `GET /missals/{missal_id}/i18n`: every locale's sanctorale names for the missal,
+     * keyed by locale then by `event_key` (issue #941).
+     *
+     * The `i18n` map is the locale files verbatim, which is what makes the two states the corpus
+     * actually distinguishes survive the round trip: a key **absent** from a locale's map has no
+     * entry in that locale's file at all, while a key mapped to the **empty string** has an entry
+     * whose translation has not been written yet. The empty string is an established convention
+     * here rather than an accident — `propriumdesanctis_2008/i18n/de.json` carries all three of
+     * its keys as `""`, and `hu.json` carries two of the three that way.
+     *
+     * Because reading that distinction off a fourteen-locale map is exactly the work the issue
+     * says clients should not have to do, `coverage` states it directly, per `event_key`: which
+     * locales translate it, which carry it empty, and which omit it entirely.
+     */
+    private function handleGetI18nRequest(ResponseInterface $response, string $missalId): ResponseInterface
+    {
+        if (null === MissalsHandler::$missalsIndex) {
+            throw new ServiceUnavailableException('Missals index temporarily unavailable');
+        }
+
+        if (false === MissalsHandler::$missalsIndex->hasMissal($missalId)) {
+            $description = "Could not find a Missal with id '" . $missalId . "', available values are: " . implode(', ', MissalsHandler::$missalsIndex->getMissalIDs());
+            throw new NotFoundException($description);
+        }
+
+        $i18nPath = RomanMissal::getSanctoraleI18nFilePath($missalId);
+        if (false === $i18nPath) {
+            throw new NotFoundException('The Missal with id ' . $missalId . ' has no i18n data');
+        }
+
+        $files = glob(rtrim($i18nPath, '/\\') . DIRECTORY_SEPARATOR . '*.json');
+        if (false === $files) {
+            throw new ServiceUnavailableException('Unable to read the i18n folder for missal ' . $missalId);
+        }
+        sort($files);
+
+        $missalJsonFile = RomanMissal::getSanctoraleFileName($missalId);
+        if (false === $missalJsonFile) {
+            throw new NotFoundException('Unable to find missal file for missal ' . $missalId);
+        }
+
+        /** @var array<int,\stdClass&object{event_key:string}> $missalRows */
+        $missalRows = Utilities::jsonFileToObjectArray($missalJsonFile);
+        $eventKeys  = array_values(array_map(static fn (\stdClass $row): string => (string) $row->event_key, $missalRows));
+
+        $locales  = [];
+        $i18n     = new \stdClass();
+        $coverage = new \stdClass();
+
+        /** @var array<string,array<string,string>> $namesByLocale */
+        $namesByLocale = [];
+
+        foreach ($files as $file) {
+            $locale    = basename($file, '.json');
+            $locales[] = $locale;
+
+            $names = [];
+            foreach (Utilities::jsonFileToArray($file) as $key => $value) {
+                if (is_string($key) && is_string($value)) {
+                    $names[$key] = $value;
+                }
+            }
+            $namesByLocale[$locale] = $names;
+
+            $localeNames = new \stdClass();
+            foreach ($names as $key => $value) {
+                $localeNames->{$key} = $value;
+            }
+            $i18n->{$locale} = $localeNames;
+        }
+
+        foreach ($eventKeys as $eventKey) {
+            $translated = [];
+            $empty      = [];
+            $missing    = [];
+            foreach ($locales as $locale) {
+                if (false === array_key_exists($eventKey, $namesByLocale[$locale])) {
+                    $missing[] = $locale;
+                } elseif ($namesByLocale[$locale][$eventKey] === '') {
+                    $empty[] = $locale;
+                } else {
+                    $translated[] = $locale;
+                }
+            }
+            $eventCoverage             = new \stdClass();
+            $eventCoverage->translated = $translated;
+            $eventCoverage->empty      = $empty;
+            $eventCoverage->missing    = $missing;
+            $coverage->{$eventKey}     = $eventCoverage;
+        }
+
+        $out             = new \stdClass();
+        $out->missal_id  = $missalId;
+        $out->locales    = $locales;
+        $out->event_keys = $eventKeys;
+        $out->i18n       = $i18n;
+        $out->coverage   = $coverage;
+
+        return $this->encodeResponseBody($response, $out);
     }
 
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -13,6 +13,7 @@ use LiturgicalCalendar\Api\Handlers\AbstractHandler;
 use LiturgicalCalendar\Api\Handlers\CalendarHandler;
 use LiturgicalCalendar\Api\Handlers\EasterHandler;
 use LiturgicalCalendar\Api\Handlers\EventsHandler;
+use LiturgicalCalendar\Api\Handlers\LectionaryHandler;
 use LiturgicalCalendar\Api\Handlers\MetadataHandler;
 use LiturgicalCalendar\Api\Handlers\TestsHandler;
 use LiturgicalCalendar\Api\Handlers\RegionalDataHandler;
@@ -114,7 +115,8 @@ class Router
      * when present.
      *
      * The calendar route (`calendar`, or the empty root route), the events route
-     * (`events`) and the regional-data route (`data`) carry a rite segment. A leading
+     * (`events`), the regional-data route (`data`) and the lectionary route
+     * (`lectionary`) carry a rite segment. A leading
      * segment whose value is a valid
      * {@see Rite} case (`roman`, `ambrosian`) selects that rite and is removed from
      * `$requestPathParts` so the remaining 0/1/2/3-part shape parsing runs identically
@@ -137,7 +139,7 @@ class Router
      */
     public static function extractRiteSegment(string $route, array &$requestPathParts): Rite
     {
-        if ($route === 'calendar' || $route === '' || $route === 'events' || $route === 'data') {
+        if ($route === 'calendar' || $route === '' || $route === 'events' || $route === 'data' || $route === 'lectionary') {
             $maybeRite = Rite::tryFrom((string) ( $requestPathParts[0] ?? '' ));
             if ($maybeRite !== null) {
                 array_shift($requestPathParts);
@@ -208,7 +210,7 @@ class Router
     {
         // The root route resolves to the calendar handler, but canonicalising `/` to
         // `/calendar/roman` would rename the endpoint rather than merely make the rite explicit.
-        if ($riteSegmentExplicit || false === in_array($route, ['calendar', 'events', 'data'], true)) {
+        if ($riteSegmentExplicit || false === in_array($route, ['calendar', 'events', 'data', 'lectionary'], true)) {
             return null;
         }
 
@@ -352,6 +354,14 @@ class Router
                         RequestMethod::PATCH,
                         RequestMethod::DELETE
                     ]);
+                } elseif (count($requestPathParts) === 2 && $requestPathParts[1] === 'i18n') {
+                    // `/missals/{missal_id}/i18n` is the read-only aggregated-translations sidecar
+                    // (#941). The write methods that will eventually land on it belong to #943 and
+                    // are not routed yet, so an unauthenticated write cannot reach the handler.
+                    $missalsHandler->setAllowedRequestMethods([
+                        RequestMethod::GET,
+                        RequestMethod::POST
+                    ]);
                 } else {
                     $missalsHandler->setAllowedRequestMethods([]);
                 }
@@ -475,6 +485,21 @@ class Router
                     AcceptHeader::YAML
                 ]);
                 $this->handler = $schemasHandler;
+                break;
+            case 'lectionary':
+                // Read-only surface over the curated lectionary source data (#942): GET only,
+                // one path part for a section index and two for a single event_key within it.
+                $lectionaryHandler = new LectionaryHandler($requestPathParts, $rite);
+                if (count($requestPathParts) <= 2) {
+                    $lectionaryHandler->setAllowedRequestMethods([RequestMethod::GET]);
+                } else {
+                    $lectionaryHandler->setAllowedRequestMethods([]);
+                }
+                $lectionaryHandler->setAllowedAcceptHeaders([
+                    AcceptHeader::JSON,
+                    AcceptHeader::YAML
+                ]);
+                $this->handler = $lectionaryHandler;
                 break;
             case 'validations':
                 $validationsHandler = new ValidationsHandler($requestPathParts);


### PR DESCRIPTION
Two read routes the sanctorale editor needs, designed as one surface rather than two bolted-on endpoints.

Unblocks **LiturgicalCalendarFrontend#503** (the sanctorale editor: an event's structure, its names and its readings shown together — the last two were not readable at all), and precedes **#943**, the corresponding writes.

Closes #941
Closes #942

## #941 — one locale's names is a lossy answer

`GET /missals/{missal_id}` folds a single negotiated locale's name into each sanctorale row: one name per row, no note of which locale it came from, and no way to see that a key is translated in twelve locales and left empty in two.

**Chosen surface: the sidecar `GET /missals/{missal_id}/i18n`**, not a `?locales=all` variant of the row response — the reason the issue gave, and it holds up: it leaves the row shape untouched so no existing consumer has to learn a second spelling of `name`, and it is the natural target for #943, which writes *locale files*, not rows. The current single-locale row response stays the default, which is right for calendar consumers.

```json
{
  "missal_id": "EDITIO_TYPICA_2008",
  "locales": ["de","en","es","fr","hr","hu","id","it","la","nl","pl","pt","sk","vi"],
  "event_keys": ["StPioPietrelcina", "OurLadyOfGuadalupe", "JuanDiego"],
  "i18n":     { "hu": { "StPioPietrelcina": "Pietralcinai Szent Pio, pap", "OurLadyOfGuadalupe": "", "JuanDiego": "" }, "…": {} },
  "coverage": { "StPioPietrelcina": { "translated": ["en","es","fr","hr","hu","id","it","la","nl","pl","sk","vi"], "empty": ["de","pt"], "missing": [] } }
}
```

`i18n` is each locale file **verbatim**, which is what makes absent-vs-empty survive the round trip: a key **absent** from a locale's map has no entry in that file, a key mapped to the **empty string** has an entry whose translation is not written yet. `coverage` states that three-way split per `event_key` so a client need not derive it from a fourteen-locale map — that derivation being exactly the work the issue says clients should not have to do.

### Schema drift, also fixed

`openapi.json` documented this route family's `200` for `/missals/{missal_id}` as `LitCalMissalsPath.json#/definitions/Missal` — the *metadata* shape of a `/missals` index row (`missal_id, name, region, year_published, year_limits, locales, api_path`). The route returns an array of sanctorale rows. It now points at a new `LitCalMissalSanctoralePath.json`, whose item is `PropriumDeSanctis.json#/definitions/PropriumDeSanctis` (the response *is* the source rows with the negotiated `name` folded in — `name` was already optional there), and a test validates every missal's real response against it so the two cannot drift apart again.

## #942 — the sanctorale lectionary had no read route at all

```text
GET /lectionary/{rite}/sanctorale              → index: every event_key, and which sources carry it
GET /lectionary/{rite}/sanctorale/{event_key}  → every locale's readings, per source
```

Built on `DecreesHandler`'s across-every-locale aggregation (`DecreesHandler.php:324-333`) rather than re-derived.

**Which tier answered.** The readings live in two tiers — the rite-wide corpus (`rite/roman/lectionary/sanctorum/{locale}.json`, 6 locales, 211 keys) and one folder per national Missal (`US_2011`, `IT_1983`) — and an `event_key` may be carried by both. Every entry names its `tier` and `source_id` instead of being merged into one answer, so a client editing readings knows which file it is looking at. The missal tier is enumerated from `RomanMissal`'s explicit lectionary-path map, **not** by globbing, so it carries no dependency on the `{dir}/{dir}.json` folder-naming convention #940 is fixing.

**Absent vs. empty.** Per source: `locales` (every locale the source declares) splits into `locales_with_entry` / `locales_without_entry`, and `locales_with_empty_entry` — a subset of the first — flags the all-empty-string placeholder. `entries` carries the source entries verbatim, empty strings included. Real data exercises both: some `event_key` in the rite corpus is present in five locale files and absent from the sixth, while many are present everywhere and wholly empty.

**A rite with no lectionary.** Ambrosian answers `200`:

```json
{ "rite": "ambrosian", "section": "sanctorale", "lectionary_available": false,
  "sources": [], "litcal_lectionary": [],
  "message": "No sanctorale lectionary data is defined for the ambrosian rite." }
```

…and the same for the item route with `"readings": []`. An unknown `event_key` under a rite that *does* have a lectionary is a `404`, so "this rite has none" and "nobody curated this event" never collide — neither a 500 nor an empty object indistinguishable from "nothing curated".

`lectionary` joins `calendar`/`events`/`data` as a rite-carrying route (`Router::extractRiteSegment()`, `Router::canonicalRiteUrl()`), so the bare spelling is deprecated and advertises the canonical explicit one; `OpenApiCanonicalFormTest::RITE_ROUTES` is widened to cover it, and the new paths pass its Link-header and deprecation invariants.

## Tests

`phpunit_tests/Handlers/LectionaryHandlerTest.php` (14) and `phpunit_tests/Handlers/MissalsHandlerI18nTest.php` (8), plus three `Router::extractRiteSegment()` cases.

Fixtures are **discovered** by reading the source files with `json_decode` — an oracle independent of the handler's own code path — rather than naming an `event_key`. Two reasons: a hard-coded key is a hostage to the rename landing in parallel under #939, and a discovered fixture proves the property holds of the data as it is rather than of the one row somebody remembered. The tests fail loudly (`assertNotNull` / `fail`) if the corpus ever stops containing an instance of a distinction, rather than passing vacuously.

One state has no instance in the committed corpus: every missal locale file currently carries an entry for every row, so `coverage.missing` is empty everywhere. It is exercised anyway, against a throwaway source tree assembled in `sys_get_temp_dir()` with `Router::$apiFilePath` re-pointed at it — nothing under `jsondata/` is touched. An untested branch of a three-way split is a coin toss, and this is the branch the split exists for.

New OUTPUT schemas, all declaring `SchemaRole::OUTPUT` via `LitSchema::role()`: `LitCalLectionaryPath.json`, `LitCalMissalTranslationsPath.json`, `LitCalMissalSanctoralePath.json`. Every handler response is validated against them in-process.

## Verification

| command | result |
|---------------------------|---------------------------------------------------------|
| `composer lint`           | exit 0 |
| `composer analyse`        | `[OK] No errors` (PHPStan level 10) |
| `composer parallel-lint`  | 811 files, no syntax error |
| `composer lint:jsondata`  | `OK — 23 file(s) match their canonical encoding` |
| `composer lint:openapi`   | `Your API description is valid.` |
| `composer test:quick`     | `Tests: 4317, Assertions: 188309, Warnings: 1, Skipped: 11` — 0 failures |

The single warning is `DiskSourceDataWriterTest`'s `mkdir(): File exists`; both files involved are byte-identical to `origin/development` and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuyQTWwdmkzsxxjBEJcBG3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lectionary endpoints for browsing sanctorale sources and retrieving event readings by rite and event key.
  * Added missal translation endpoints with locale-specific entries and translated, empty and missing coverage details.
  * Added Roman and Ambrosian rite paths, including clear responses when a lectionary is unavailable.

* **Documentation**
  * Expanded OpenAPI documentation and response schemas for lectionary and missal endpoints.
  * Updated missal responses to return sanctorale data with the selected locale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->