### PR TITLE
ops(publish-consumer): ship the systemd unit as an opt-in deploy template

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -54,17 +54,38 @@ render "${SRC_DIR}/systemd/litcal-fpm-reload.service.in" < /dev/null > "${UNIT_D
 render "${SRC_DIR}/systemd/litcal-websocket.service.in"  < /dev/null > "${UNIT_DIR}/litcal-websocket.service"
 chmod 0644 "${UNIT_DIR}/litcal-fpm-reload.path" "${UNIT_DIR}/litcal-fpm-reload.service" "${UNIT_DIR}/litcal-websocket.service"
 
+# The source-data publish consumer is an OPTIONAL accelerator: the two cron entries
+# documented in docs/ops/change-request-runbook.md are a complete deployment without
+# it. So it is opt-in rather than required — an existing /etc/litcal-deploy.env that
+# predates this unit keeps working untouched, which is why PUBLISH_CONSUMER_UNIT is
+# absent from the required-variable check above.
+if [ -n "${PUBLISH_CONSUMER_UNIT:-}" ]; then
+  render "${SRC_DIR}/systemd/litcal-publish-consumer.service.in" < /dev/null > "${UNIT_DIR}/${PUBLISH_CONSUMER_UNIT}"
+  chmod 0644 "${UNIT_DIR}/${PUBLISH_CONSUMER_UNIT}"
+fi
+
 install -m 0755 -o root -g root "${SRC_DIR}/sbin/litcal-fpm-reload.sh" /usr/local/sbin/litcal-fpm-reload.sh
 
 systemctl daemon-reload
 systemctl enable litcal-fpm-reload.path "$WS_UNIT"
+if [ -n "${PUBLISH_CONSUMER_UNIT:-}" ]; then
+  systemctl enable "$PUBLISH_CONSUMER_UNIT"
+fi
 
 # Restart, not `enable --now`. `--now` starts a unit that is stopped and does nothing at
 # all to one already running, so re-running this installer with updated unit content
 # would leave the old definition live and report success — the same silent no-op this
 # script exists to remove from the deploy path.
 systemctl restart litcal-fpm-reload.path "$WS_UNIT"
+# Safe to restart unconditionally, unlike the WebSocket unit: an interrupted publish
+# releases its claim, and one stranded by a hard kill is reclaimed after the grace period.
+if [ -n "${PUBLISH_CONSUMER_UNIT:-}" ]; then
+  systemctl restart "$PUBLISH_CONSUMER_UNIT"
+fi
 
 echo "installed. verify with:"
 echo "  systemctl status litcal-fpm-reload.path"
 echo "  systemctl status $WS_UNIT"
+if [ -n "${PUBLISH_CONSUMER_UNIT:-}" ]; then
+  echo "  systemctl status $PUBLISH_CONSUMER_UNIT"
+fi

--- a/deploy/litcal-deploy.env.example
+++ b/deploy/litcal-deploy.env.example
@@ -29,3 +29,12 @@ RUN_GROUP=www-data
 # systemd unit names. FPM_UNIT is whatever this host calls its PHP-FPM service.
 FPM_UNIT=php8.4-fpm
 WS_UNIT=litcal-websocket.service
+
+# OPTIONAL. The source-data publish consumer (bin/publish-sourcedata-consumer), a
+# long-lived worker that publishes approved change requests the instant they are
+# approved instead of waiting for the next cron tick. Leave this EMPTY to skip
+# installing it entirely: the two cron entries in docs/ops/change-request-runbook.md
+# are a complete, correct deployment on their own, and running both is also fine.
+# It additionally needs Redis (REDIS_SOCKET or REDIS_HOST) and ext-redis; without
+# them the unit starts and exits rather than degrading quietly.
+PUBLISH_CONSUMER_UNIT=litcal-publish-consumer.service

--- a/deploy/systemd/litcal-publish-consumer.service.in
+++ b/deploy/systemd/litcal-publish-consumer.service.in
@@ -1,0 +1,50 @@
+# Template. Rendered by deploy/install.sh against /etc/litcal-deploy.env and
+# installed to /etc/systemd/system/. Do not commit a rendered copy: this
+# repository is public and the real values are host-specific.
+#
+# Long-lived consumer for the source-data publish stream. It is an OPTIONAL
+# accelerator, and installing it is opt-in: set PUBLISH_CONSUMER_UNIT in
+# /etc/litcal-deploy.env to install it, leave it empty to skip. The two cron
+# entries in docs/ops/change-request-runbook.md ("The two cron entries") are a
+# complete and correct deployment on their own; this unit only removes that
+# interval's latency by waking on a Redis XADD the instant a batch becomes
+# publishable. Running both at once is safe and expected — the claim protocol is
+# proven against two concurrent OS processes, and a redundant attempt finds
+# nothing claimable rather than double-publishing.
+#
+# Unlike litcal-websocket.service, this process is safe to restart at any time.
+# It re-reads src/ on start like any PHP process, and a publish interrupted
+# mid-flight either releases its claim or is reclaimed after the grace period.
+[Unit]
+Description=Liturgical Calendar source-data publish consumer
+After=network-online.target redis-server.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=@RUN_USER@
+Group=@RUN_GROUP@
+# The app root, NOT public/. bin/publish-sourcedata-consumer resolves its .env*
+# chain relative to the process CWD, so pointing this elsewhere silently starves
+# it of GITHUB_APP_* and DB_* and it exits 1. (The WebSocket unit points at
+# public/ for an unrelated reason — its engine cache is CWD-relative.)
+WorkingDirectory=@API_ROOT@
+ExecStart=@PHP_BIN@ @API_ROOT@/bin/publish-sourcedata-consumer
+Restart=on-failure
+RestartSec=5
+# Misconfiguration exits 1 immediately, and without a ceiling systemd would
+# retry that every RestartSec forever and fill the journal. Five failures in
+# five minutes stops it, leaving a `failed` unit an operator can actually see.
+StartLimitIntervalSec=300
+StartLimitBurst=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=litcal-publish-consumer
+
+# Hardening (adjust per ops policy) — matches liturgical-calendar-reconciler.service.
+ProtectSystem=full
+PrivateTmp=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/ops/change-request-runbook.md
+++ b/docs/ops/change-request-runbook.md
@@ -805,50 +805,39 @@ unit below sets them through `EnvironmentFile=`, which always reaches `getenv()`
 when PHP's `variables_order` includes `E` — which the CLI commonly omits. The helper reads both layers, so
 it works either way.
 
-Install it exactly as `deploy/systemd/liturgical-calendar-reconciler.service` installs the OpenFGA outbox
-consumer:
+It ships as a template, `deploy/systemd/litcal-publish-consumer.service.in`, rendered by
+`deploy/install.sh` against `/etc/litcal-deploy.env` the same way the WebSocket unit is. It is **opt-in**:
+the installer touches it only when `PUBLISH_CONSUMER_UNIT` is set, so a host that has never heard of this
+consumer keeps installing exactly what it installed before.
 
-```ini
-[Unit]
-Description=Liturgical Calendar source-data publish/merge consumer
-After=network-online.target postgresql.service redis-server.service
-Wants=network-online.target
-
-[Service]
-Type=simple
-User=litcal
-Group=litcal
-WorkingDirectory=/opt/liturgical-calendar
-EnvironmentFile=/opt/liturgical-calendar/.env.local
-ExecStart=/usr/bin/php /opt/liturgical-calendar/bin/publish-sourcedata-consumer
-Restart=on-failure
-RestartSec=5
-StandardOutput=journal
-StandardError=journal
-SyslogIdentifier=litcal-sourcedata-consumer
-
-# Hardening (adjust per ops policy)
-ProtectSystem=full
-PrivateTmp=true
-NoNewPrivileges=true
-
-[Install]
-WantedBy=multi-user.target
+```sh
+# In /etc/litcal-deploy.env — leave empty, or omit the line, to skip the consumer entirely.
+PUBLISH_CONSUMER_UNIT=litcal-publish-consumer.service
 ```
-
-Save that as `/etc/systemd/system/liturgical-calendar-sourcedata-consumer.service` (there is no
-`deploy/systemd/` copy of it the way there is for the OpenFGA outbox reconciler — this consumer is
-optional in a way the outbox reconciler is not, so it is documented here rather than shipped as a unit
-this repository installs by default), then:
 
 ```bash
-sudo systemctl daemon-reload
-sudo systemctl enable --now liturgical-calendar-sourcedata-consumer.service
-sudo systemctl status liturgical-calendar-sourcedata-consumer.service
+sudo deploy/install.sh
+sudo systemctl status litcal-publish-consumer.service
 ```
 
-If it is not installed, or `ext-redis` is missing, or it exits (its exit code 2 specifically means
-`ext-redis` is not installed — see the script's own docblock), do nothing: the two cron entries above
+A template rather than the copy-paste unit this section used to carry, because the values that differ
+between hosts are exactly the ones a copied unit gets wrong: this deployment runs as
+`johnromandorazio:psacln` under a Plesk PHP at `/opt/plesk/php/8.4/bin/php`, not as `litcal` under
+`/usr/bin/php`. The template takes all four from `@RUN_USER@`, `@RUN_GROUP@`, `@PHP_BIN@` and
+`@API_ROOT@`, so there is nothing host-specific left to mistype.
+
+Two differences from the reconciler unit are deliberate. `WorkingDirectory` is the **app root**, not
+`public/`: `bin/publish-sourcedata-consumer` resolves its `.env*` chain relative to the process CWD, so
+pointing it elsewhere starves it of `GITHUB_APP_*` and `DB_*` and it exits 1. And there is no
+`EnvironmentFile=`, because that same Dotenv chain already reads `.env`, `.env.local`,
+`.env.development`, `.env.test`, `.env.staging` and `.env.production` from that directory.
+
+`StartLimitIntervalSec=300` / `StartLimitBurst=5` cap the restart loop: a misconfiguration exits 1
+immediately, and without a ceiling systemd would retry every `RestartSec` forever and fill the journal.
+Five failures in five minutes leaves a `failed` unit an operator can actually see.
+
+If `PUBLISH_CONSUMER_UNIT` is left empty, or `ext-redis` is missing, or the unit exits (its exit code 2
+specifically means `ext-redis` is not installed — see the script's own docblock), do nothing: the two cron entries above
 keep publishing and polling on their own schedule with no operator action required. Running the consumer
 alongside the cron entries is also safe — the claim protocol (below) and the poller's `WHERE
 publication_status = 'open'` guard both make a redundant attempt a no-op, not a double-publish or a

--- a/docs/ops/change-request-runbook.md
+++ b/docs/ops/change-request-runbook.md
@@ -806,9 +806,16 @@ when PHP's `variables_order` includes `E` — which the CLI commonly omits. The 
 it works either way.
 
 It ships as a template, `deploy/systemd/litcal-publish-consumer.service.in`, rendered by
-`deploy/install.sh` against `/etc/litcal-deploy.env` the same way the WebSocket unit is. It is **opt-in**:
-the installer touches it only when `PUBLISH_CONSUMER_UNIT` is set, so a host that has never heard of this
-consumer keeps installing exactly what it installed before.
+`deploy/install.sh` against `/etc/litcal-deploy.env` the same way the WebSocket unit is.
+
+**Shipping the template installs nothing on its own.** No deploy path touches systemd: the CI deploy in
+`.github/workflows/deploy.yaml` runs as a chrooted user that cannot `sudo`, so it drops a
+`tmp/restart.txt` sentinel and a root-owned path unit does the privileged work (see
+`docs/ops/deploy-sentinel-runbook.md`). `deploy/install.sh` is a manual root step, run by hand when unit
+content or paths change. So the template is a reproducible recipe, not an automatic install.
+
+It is **opt-in** on top of that: the installer touches it only when `PUBLISH_CONSUMER_UNIT` is set, so a
+host that has never heard of this consumer keeps installing exactly what it installed before.
 
 ```sh
 # In /etc/litcal-deploy.env — leave empty, or omit the line, to skip the consumer entirely.


### PR DESCRIPTION
## Why

`bin/publish-sourcedata-consumer` had no reproducible install. The runbook carried a copy-paste systemd unit instead, and deliberately so — it argued the consumer is optional in a way the outbox reconciler is not, so it should be documented rather than shipped as a unit this repository installs by default.

That reasoning holds. The copy-paste part does not: the inline unit hardcoded `User=litcal`, `/opt/liturgical-calendar` and `/usr/bin/php`, while the deployment it is written for runs as `johnromandorazio:psacln` under a Plesk PHP at `/opt/plesk/php/8.4/bin/php`. Those four values are exactly what a copied unit gets wrong, and getting them wrong yields a unit that starts and immediately exits.

## What changed

- **`deploy/systemd/litcal-publish-consumer.service.in`** — rendered against `/etc/litcal-deploy.env` like the WebSocket unit, taking `@RUN_USER@`, `@RUN_GROUP@`, `@PHP_BIN@`, `@API_ROOT@`.
- **`deploy/install.sh`** — renders, enables and restarts it **only when `PUBLISH_CONSUMER_UNIT` is set**. It is deliberately absent from the required-variable check, so an existing `/etc/litcal-deploy.env` keeps working untouched.
- **`deploy/litcal-deploy.env.example`** — documents the new optional variable.
- **`docs/ops/change-request-runbook.md`** — the "consumer as an optional accelerator" section now describes the template instead of a unit to copy, so prose and repository agree.

## The "installs by default" concern is structurally impossible

Worth stating explicitly, since it is what the original decision guarded against: **no deploy path touches systemd.** The CI deploy in `.github/workflows/deploy.yaml` runs as a chrooted user that cannot `sudo`, so it drops a `tmp/restart.txt` sentinel and a root-owned path unit does the privileged work. `deploy/install.sh` is a manual root step, run by hand when unit content or paths change. The template is a reproducible recipe; `PUBLISH_CONSUMER_UNIT` is a second guard on top of a step nobody runs automatically.

## Deliberate differences from `liturgical-calendar-reconciler.service`

- **`WorkingDirectory` is the app root, not `public/`.** `bin/publish-sourcedata-consumer` resolves its `.env*` chain relative to the process CWD, so pointing it elsewhere starves it of `GITHUB_APP_*` and `DB_*` and it exits 1. (The WebSocket unit points at `public/` for an unrelated reason — its engine cache is CWD-relative.)
- **No `EnvironmentFile=`**, because that same Dotenv chain already reads `.env`, `.env.local`, `.env.development`, `.env.test`, `.env.staging`, `.env.production` from that directory.
- **`StartLimitIntervalSec=300` / `StartLimitBurst=5`**, which neither sibling unit has. A misconfiguration exits 1 immediately, and without a ceiling systemd retries every `RestartSec` forever and fills the journal. Five failures in five minutes leaves a `failed` unit an operator can see.

## Verified on the deployment

Installed and running on `catholicdigitalcommons.org` (`api/dev`):

```
● litcal-publish-consumer.service - Liturgical Calendar source-data publish consumer
     Loaded: loaded (/etc/systemd/system/litcal-publish-consumer.service; enabled)
     Active: active (running)   Memory: 15.4M   (no restarts)
```

Pre-flight before starting: `.env.staging` and the GitHub App private key both readable by `johnromandorazio`, and that account is in the `redis` group for `/var/run/redis/redis-server.sock`. The consumer also starts cleanly when run by hand as that user from that directory.

Context: this was reached while confirming that publication is live. Both cron entries are present and succeeding every 5 minutes (`published=0 stopped_on_failure=false parked=0`), and `/health` reports `source_data_publisher: ok`. **Cron alone was already a complete, correct deployment** — this unit only removes the interval's latency, exactly as the runbook says.

## Follow-up not in this PR

`/etc/litcal-deploy.env` on the host still needs `PUBLISH_CONSUMER_UNIT=litcal-publish-consumer.service` added, so a future `deploy/install.sh` manages the unit rather than leaving the hand-installed copy unmanaged. The unit runs correctly without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011r2AEViGig1EQXoP6ZNuUs
