### PR TITLE
test: fail closed on the three isolation gaps the apiFilePath seam cannot reach

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,14 @@ WS_MAX_REQUEST_RATE=3
 # Leave empty to fall back to unauthenticated requests (subject to UNAUTHENTICATED_RATE_LIMIT).
 WS_API_KEY=
 
+# Set to "true" ONLY when the API server on API_PORT serves a throwaway checkout.
+# Routes/ReadWrite/DecreesTest drives a real PUT -> PATCH -> DELETE lifecycle against the live
+# server, so the writes land in that server's own jsondata/sourcedata — a tree this test process
+# cannot redirect, and which an interrupted run leaves modified rather than restored. Off CI the
+# test therefore skips unless you opt in here. Leave unset if :8000 serves a working tree you care
+# about; the same write path is covered in-process by phpunit_tests/Handlers/DecreesHandlerWriteTest.
+API_TEST_SERVER_DISPOSABLE=
+
 ##
 # API Configuration
 # These variables control where the API launches and how the Unit Test server connects to it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -550,6 +550,22 @@ Two things a class that repoints the root must get right:
 - **Class-level guards must `throw`, never `self::fail()`.** PHPUnit 12 cannot render a failure raised from `setUpBeforeClass()` and crashes the runner
   with `Call to undefined method BeforeFirstTestMethodFailed::test()`. A `markTestSkipped()` there is fine, and skips the whole class.
 
+**The `Router::$apiFilePath` seam does not reach everything, and where it does not, fail closed instead (#945).** Two cases:
+
+- **A write that happens in the server process.** `Routes/ReadWrite/DecreesTest` drives a real `PUT` → `PATCH` → `DELETE` over HTTP, so the mutation lands
+  in whatever checkout the server was started from; repointing the *test* process changes nothing, and an interruption leaves `decrees.json` **modified**
+  rather than deleted — the harder state to notice, since a modified decrees corpus reorders under `ksort` and a `jq -S` comparison is blind to it. CI is
+  safe by construction (the job's checkout is thrown away), so that test runs there and is opt-in elsewhere: set `API_TEST_SERVER_DISPOSABLE=true` only once
+  the server on `API_PORT` serves a throwaway tree. Prefer covering the write path in-process, the way `Handlers/DecreesHandlerWriteTest` does.
+- **A test whose safety depends on a runtime mode.** The queue-mode suites assert a tracked calendar survives a `DELETE`, which is true only while queue
+  mode engages — an assertion made *after* the request, so a disk-mode fallback would report the deletion rather than prevent it. `Support/RequiresQueueMode`
+  asserts the mode in `setUp()` instead. It passes by construction today; what it pins is the invariant, so that a change to what queue mode *requires*
+  fails up front rather than by deleting source data.
+
+`Handlers/EasterHandlerTest` is the third of the family and needs no seam: it puts a file where `engineCache/easter/` belongs to simulate an unwritable
+cache, and nothing tracked is at risk, so `setUp()` simply unlinks a stray one — an interrupted run costs the next run nothing rather than silently
+disabling the cache until somebody notices.
+
 **Test Groups:**
 
 - Regular tests: Fast validation tests.

--- a/phpunit_tests/Handlers/EasterHandlerTest.php
+++ b/phpunit_tests/Handlers/EasterHandlerTest.php
@@ -15,6 +15,18 @@ final class EasterHandlerTest extends AbstractHandlerTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        // testAnUnwritableCacheDoesNotCostTheClientItsResponse simulates an unwritable cache by
+        // putting a regular FILE where this directory belongs, and removes it in a `finally`. A run
+        // that never reaches that `finally` — a fatal, an OOM kill, a `timeout`, a Ctrl-C — leaves
+        // the file behind, and from then on the handler silently cannot cache anything until
+        // somebody notices and deletes it by hand. Nothing tracked is at risk (`engineCache/**` is
+        // gitignored), so the fix is to make the next run self-healing rather than to fence the
+        // write off (#945).
+        if (is_file(self::CACHE_DIR)) {
+            unlink(self::CACHE_DIR);
+        }
+
         // Each test starts from a cold cache — the handler's ETag and 304
         // branches only run on cache misses.
         if (is_dir(self::CACHE_DIR)) {

--- a/phpunit_tests/Handlers/RegionalDataQueueModeTest.php
+++ b/phpunit_tests/Handlers/RegionalDataQueueModeTest.php
@@ -12,6 +12,7 @@ use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Api\Services\ChangeRequestReview;
 use LiturgicalCalendar\Api\Services\SourceData\ChangeRequestSourceDataWriter;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
+use LiturgicalCalendar\Tests\Support\RequiresQueueMode;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
@@ -29,6 +30,13 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(ChangeRequestReview::class)]
 final class RegionalDataQueueModeTest extends AbstractHandlerTestCase
 {
+    use RequiresQueueMode;
+
+    // Declared so a host with no DB_* configuration SKIPS this class rather than erroring out of
+    // setUp() on the TRUNCATE below — and, with assertQueueModeIsActive(), so the two ways this
+    // suite can lose its safety net are both handled explicitly (#945).
+    protected static bool $requiresDatabase = true;
+
     /** @var array<string, string|false> */
     private array $originalEnv = [];
 
@@ -51,6 +59,11 @@ final class RegionalDataQueueModeTest extends AbstractHandlerTestCase
         $_ENV['OPENFGA_API_URL']         = 'http://localhost:8083';
         $_ENV['OPENFGA_STORE_ID']        = 'no-such-store-regional-queue-test';
         $_ENV['OPENFGA_MODEL_ID']        = 'no-such-model-regional-queue-test';
+
+        // Every "the file is still on disk" assertion below depends on this, and one of these
+        // tests DELETEs a real tracked national calendar. Confirm the mode before any of them
+        // can act on it, rather than after (#945).
+        self::assertQueueModeIsActive();
     }
 
     protected function tearDown(): void

--- a/phpunit_tests/Handlers/RegionalDataWriteResponseSchemaTest.php
+++ b/phpunit_tests/Handlers/RegionalDataWriteResponseSchemaTest.php
@@ -9,6 +9,7 @@ use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Handlers\RegionalDataHandler;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
 use LiturgicalCalendar\Tests\Support\OpenApiPathItemTrait;
+use LiturgicalCalendar\Tests\Support\RequiresQueueMode;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Swaggest\JsonSchema\Schema;
@@ -49,6 +50,7 @@ use Swaggest\JsonSchema\Schema;
 final class RegionalDataWriteResponseSchemaTest extends AbstractHandlerTestCase
 {
     use OpenApiPathItemTrait;
+    use RequiresQueueMode;
 
     protected static bool $requiresDatabase = true;
 
@@ -72,6 +74,10 @@ final class RegionalDataWriteResponseSchemaTest extends AbstractHandlerTestCase
         $_ENV['OPENFGA_API_URL']         = 'http://localhost:8083';
         $_ENV['OPENFGA_STORE_ID']        = 'no-such-store-regional-response-schema-test';
         $_ENV['OPENFGA_MODEL_ID']        = 'no-such-model-regional-response-schema-test';
+
+        // This suite PATCHes real wider-region and national calendars. In queue mode that touches
+        // nothing; in the disk-mode fallback it would rewrite tracked source data (#945).
+        self::assertQueueModeIsActive();
     }
 
     protected function tearDown(): void

--- a/phpunit_tests/Routes/ReadWrite/DecreesTest.php
+++ b/phpunit_tests/Routes/ReadWrite/DecreesTest.php
@@ -14,6 +14,9 @@ use LiturgicalCalendar\Tests\ApiTestCase;
  *
  * To keep data files in their original state, the full-lifecycle test wraps mutating
  * steps in a try/finally block that issues a cleanup DELETE even on assertion failure.
+ * That cleanup is best-effort, and the mutation happens in the *server* process against
+ * whatever checkout that server was started from — so it is additionally gated on the
+ * served tree being disposable; see skipUnlessTheServedTreeIsDisposable().
  *
  * @group slow
  */
@@ -32,6 +35,61 @@ final class DecreesTest extends ApiTestCase
         if ($response->getStatusCode() === 405 && getenv('CI') === false) {
             $this->markTestSkipped('Server predates decrees write paths (stale local build); exercised in CI.');
         }
+    }
+
+    /**
+     * Refuse to mutate source data in a tree that is not disposable (#945).
+     *
+     * The full-lifecycle test drives `PUT` -> `PATCH` -> `DELETE` against the **live** server, so
+     * the writes happen in the server process, against whatever checkout that server was started
+     * from. That puts it out of reach of the `Router::$apiFilePath` seam by construction:
+     * `ShadowProjectRootTrait` repoints the *test* process, which changes nothing here. And unlike
+     * the in-process cases #921 and #935 fixed, an interruption here leaves `decrees.json`
+     * **modified** rather than deleted — the harder state to notice, because a modified decrees
+     * corpus reorders under `ksort` and a `jq -S` comparison is blind to it.
+     *
+     * CI is safe by construction: the workflow runs `composer start` in the job's own checkout,
+     * which is thrown away afterwards, so the test always runs there and coverage is unaffected.
+     * A developer machine is not: the server on the configured port typically serves a real working
+     * tree — possibly one another agent or editor is using — and dirtying it is a cost the test has
+     * no way to undo reliably.
+     *
+     * So the mutation is opt-in off CI. Set `API_TEST_SERVER_DISPOSABLE=true` once the server on
+     * this port is known to serve a throwaway tree. This fails closed: the default is to skip, and
+     * a developer who has not thought about it does not silently pay for it.
+     */
+    private function skipUnlessTheServedTreeIsDisposable(): void
+    {
+        if (getenv('CI') !== false || self::envFlagIsTrue('API_TEST_SERVER_DISPOSABLE')) {
+            return;
+        }
+
+        $this->markTestSkipped(
+            'This test PUTs, PATCHes and DELETEs against the live server, mutating jsondata/sourcedata '
+            . 'in whatever checkout that server was started from — which this test process cannot '
+            . 'redirect, and an interrupted run leaves modified rather than restored. '
+            . 'Set API_TEST_SERVER_DISPOSABLE=true once the server serves a throwaway tree. '
+            . 'Always runs in CI, where the checkout is disposable by construction. '
+            . 'The same write path is covered in-process by Handlers/DecreesHandlerWriteTest, which '
+            . 'uses ShadowProjectRootTrait.'
+        );
+    }
+
+    /**
+     * True when $name is set to "true" (case-insensitively) in the environment.
+     *
+     * Reads `getenv()` first so a shell export is honoured, then `$_ENV` — the phpunit bootstrap
+     * loads `.env.local` with `Dotenv::createMutable()`, which populates both, but an inherited
+     * variable reaches only one of them.
+     */
+    private static function envFlagIsTrue(string $name): bool
+    {
+        $value = getenv($name);
+        if (false === $value) {
+            $value = isset($_ENV[$name]) && is_string($_ENV[$name]) ? $_ENV[$name] : null;
+        }
+
+        return is_string($value) && 'true' === strtolower(trim($value));
     }
 
     /**
@@ -201,6 +259,7 @@ final class DecreesTest extends ApiTestCase
      */
     public function testFullLifecycleCreatePatchDelete(): void
     {
+        $this->skipUnlessTheServedTreeIsDisposable();
         if (!self::isDatabaseConfigured()) {
             $this->markTestSkipped('Database not configured — authorization middleware requires database connection');
         }

--- a/phpunit_tests/Routes/ReadWrite/DecreesTest.php
+++ b/phpunit_tests/Routes/ReadWrite/DecreesTest.php
@@ -32,7 +32,7 @@ final class DecreesTest extends ApiTestCase
      */
     private function skipIfStaleServer(\Psr\Http\Message\ResponseInterface $response): void
     {
-        if ($response->getStatusCode() === 405 && getenv('CI') === false) {
+        if ($response->getStatusCode() === 405 && false === self::runningInCi()) {
             $this->markTestSkipped('Server predates decrees write paths (stale local build); exercised in CI.');
         }
     }
@@ -60,7 +60,7 @@ final class DecreesTest extends ApiTestCase
      */
     private function skipUnlessTheServedTreeIsDisposable(): void
     {
-        if (getenv('CI') !== false || self::envFlagIsTrue('API_TEST_SERVER_DISPOSABLE')) {
+        if (self::runningInCi() || self::envFlagIsTrue('API_TEST_SERVER_DISPOSABLE')) {
             return;
         }
 
@@ -73,6 +73,32 @@ final class DecreesTest extends ApiTestCase
             . 'The same write path is covered in-process by Handlers/DecreesHandlerWriteTest, which '
             . 'uses ShadowProjectRootTrait.'
         );
+    }
+
+    /**
+     * Whether this process is running in CI.
+     *
+     * Deliberately not `getenv('CI') !== false`. `CI=false` is a real export on a developer
+     * machine — Create React App treats `CI=true` as warnings-are-errors, so people set it — and
+     * mere presence would then read as "in CI" and let the mutating lifecycle below run against a
+     * working tree, which is exactly the harm the guard exists to prevent.
+     *
+     * Deliberately not {@see self::envFlagIsTrue()} either. That requires the literal string
+     * `true`, which GitHub Actions does set, but plenty of CI systems spell it `CI=1`. Under a
+     * strict test the lifecycle would silently SKIP there, turning a coverage guarantee into a
+     * false green — the failure mode this repository keeps being bitten by.
+     *
+     * So: set, and not one of the recognised falsy spellings.
+     */
+    private static function runningInCi(): bool
+    {
+        $value = getenv('CI');
+        if (false === $value) {
+            $value = isset($_ENV['CI']) && is_string($_ENV['CI']) ? $_ENV['CI'] : null;
+        }
+
+        return is_string($value)
+            && false === in_array(strtolower(trim($value)), ['', '0', 'false', 'no', 'off'], true);
     }
 
     /**
@@ -316,7 +342,7 @@ final class DecreesTest extends ApiTestCase
             $deleteStatus   = $deleteResponse->getStatusCode();
             // Mirror skipIfStaleServer(): on a stale local build the PUT above raised a skip,
             // and the cleanup DELETE also gets a 405 — don't let that turn the skip into a failure.
-            if ($deleteStatus !== 405 || getenv('CI') !== false) {
+            if ($deleteStatus !== 405 || self::runningInCi()) {
                 $this->assertContains(
                     $deleteStatus,
                     [200, 404],

--- a/phpunit_tests/Support/RequiresQueueMode.php
+++ b/phpunit_tests/Support/RequiresQueueMode.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Support;
+
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
+
+/**
+ * A precondition for suites whose safety depends on queue mode actually engaging (#945).
+ *
+ * The queue-mode write tests assert that a real tracked calendar — `HR.json`, `Europe.json` — is
+ * still on disk after the handler has been asked to delete or amend it. That is the correct
+ * assertion for queue mode, where nothing is written to disk at all. But it is also the *only*
+ * thing standing between those requests and the tracked source data, and it is checked AFTER the
+ * request: if the write ever went to disk instead, the suite would report the deletion rather
+ * than prevent it. Restoring from git is easy; noticing is not, which is the shape #921 and #935
+ * were.
+ *
+ * What this actually guards. Each of those suites forces `SOURCEDATA_CHANGE_REQUESTS` and the
+ * `OPENFGA_*` variables in its own `setUp()`, and declares `$requiresDatabase`, which skips the
+ * class outright when `DB_*` is unset. So under today's `SourceDataWriteMode` the mode cannot help
+ * but engage, and this assertion passes by construction. It is not therefore idle: it pins the
+ * invariant rather than the environment. The realistic way queue mode "silently fails to engage"
+ * is a change to what it *requires* — a new mandatory variable, a reachability probe added to
+ * `stackAvailable()`, a reordering of the fail-safe fallback — and any of those turns a suite of
+ * green assertions into a suite that deletes tracked files. Stubbing `stackAvailable()` to return
+ * false makes this assertion fail in `setUp()`, with `HR.json` untouched; without it, the same
+ * stub reaches the DELETE.
+ *
+ * Cheap, and it fails closed. That is the whole argument for it.
+ */
+trait RequiresQueueMode
+{
+    /**
+     * Refuse to continue unless source-data writes are being queued rather than written to disk.
+     *
+     * Call at the END of `setUp()` — after the environment the mode is read from has been put in
+     * place, and before any test body can issue a write.
+     */
+    private static function assertQueueModeIsActive(): void
+    {
+        if (SourceDataWriteMode::changeRequestsEnabled()) {
+            return;
+        }
+
+        self::fail(
+            'Queue mode is not active, so this suite would write to disk and mutate tracked source '
+            . 'data under jsondata/sourcedata (#945). '
+            . sprintf('%s is "%s"; ', SourceDataWriteMode::FLAG, is_string($_ENV[SourceDataWriteMode::FLAG] ?? null) ? $_ENV[SourceDataWriteMode::FLAG] : '<unset>')
+            . 'queue mode additionally requires DB_HOST/DB_NAME/DB_USER/DB_PASSWORD and '
+            . 'OPENFGA_API_URL/OPENFGA_STORE_ID/OPENFGA_MODEL_ID to be set, since it falls back to '
+            . 'disk mode rather than accepting edits nobody could approve.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

#921 and #935 removed the last tests that mutate tracked files under `jsondata/` in the working tree, and `ShadowProjectRootTrait` makes the rule cheap to follow. Three cases remained that the `Router::$apiFilePath` seam **cannot reach**. None was a live defect; all three are the shape of #921/#935, and each now fails closed.

### 1 — `Routes/ReadWrite/DecreesTest` mutates whatever tree the server serves

The lifecycle test drives a real `PUT` → `PATCH` → `DELETE` against the live server, so the mutation happens **in the server process**, against whatever checkout that server was started from — repointing the *test* process changes nothing. An interruption leaves `decrees.json` modified rather than deleted, which is the harder state to notice: a modified decrees corpus reorders under `ksort` and a `jq -S` comparison is blind to it.

The issue proposed pointing the server at a fixture tree via a compose change. Worth recording that the premise doesn't hold: the API isn't in `docker-compose.yml` at all — it's started by `composer start`, and `Router::$apiFilePath` derives from `public/index.php`'s own location. **CI is already safe by construction**, since the workflow runs `composer start` in the job's own disposable checkout. So the hazard is purely local, and the fix is an opt-in rather than a new seam through production path resolution:

- CI: always runs, coverage unchanged.
- Elsewhere: skips unless `API_TEST_SERVER_DISPOSABLE=true`. Documented in `.env.example`.

The same write path is covered in-process by `Handlers/DecreesHandlerWriteTest`, which uses `ShadowProjectRootTrait`.

### 2 — queue-mode `RegionalData*` tests depend on queue mode actually engaging

They assert a tracked calendar survives a `DELETE` — correct for queue mode, and the only thing standing between the request and `HR.json`. Being an assertion made *after* the request, a disk-mode fallback would report the deletion rather than prevent it.

`Support/RequiresQueueMode` asserts the mode in `setUp()` instead. **It passes by construction today** — those suites force the flag and the FGA variables themselves — and the docblock says so plainly rather than implying it catches a live hole. What it pins is the invariant: a later change to what queue mode *requires* (a new mandatory variable, a reachability probe in `stackAvailable()`) now fails up front instead of by deleting source data. `RegionalDataQueueModeTest` additionally declares `$requiresDatabase`, so a host with no `DB_*` skips the class rather than erroring out of `setUp()` on its `TRUNCATE`.

### 3 — `Handlers/EasterHandlerTest` leaves a file where a directory belongs

It puts a regular file where `engineCache/easter/` belongs, to simulate an unwritable cache without needing root or a read-only mount. Nothing tracked is at risk, but a run that never reaches its `finally` left the file behind and silently disabled the cache until someone removed it by hand. `setUp()` now unlinks a stray one.

## Testing

Each guard was verified to actually fire, not assumed:

| Part | Proof |
|---|---|
| 1 | Skips by default with the served checkout's `decrees.json` md5 unchanged. With the flag set it passes the gate and stops at the next one (`Database not configured`) — so both branches are exercised without writing. |
| 2 | Stubbing `SourceDataWriteMode::stackAvailable()` to return `false` fails in `setUp()` with `HR.json` intact. |
| 3 | Planted a stray file at `engineCache/easter`; the next run healed it to a directory and passed. |

`composer test:quick` on the merge result with `development` (which now carries #952): **4376 tests, 188699 assertions, 12 skipped, 0 failures**. `composer lint` and `composer lint:md` green.

Closes #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuyQTWwdmkzsxxjBEJcBG3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test cleanup so interrupted cache tests recover automatically.
  * Prevented tests from modifying tracked source data when required safety modes are inactive.

* **Tests**
  * Added safeguards for tests requiring queue mode or disposable API test servers.
  * Tests now skip safely when required database or environment configuration is unavailable.
  * Documented test isolation requirements and safer alternatives for write-heavy scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->