### PR TITLE
docs(ops): record the staging cutover and correct two rite-calendar runbook steps (#955)

### DIFF
--- a/docs/ops/rite-calendar-migration-runbook.md
+++ b/docs/ops/rite-calendar-migration-runbook.md
@@ -98,19 +98,27 @@ itself is left in the model unchanged — it is only removed at the prune milest
    Run from a local checkout the command above resolves whatever store that checkout points at
    (a local dev store, not production) and writes those values, so edit the one VPS file instead.
 
-   Edit it as its owner, and land it with `cp` rather than a shell redirect — `cp` opens its
-   source before truncating its destination, whereas `sed > file` / `cat tmp > file` truncates
-   first and leaves the file EMPTY if the left-hand command then fails. A zero-byte `.env.staging`
-   takes the API down immediately, since phpdotenv reads it per request (observed 2026-09-01). For
-   the same reason, do not build the replacement as a different user: a `mktemp` file made by
-   `ubuntu` is mode 600 and unreadable to the owner the write runs as.
+   Edit it as its owner, and never point a shell redirect at the live file: a redirect truncates
+   its destination BEFORE the command on its left runs, so `sed ... > .env.staging` or
+   `cat tmp > .env.staging` leaves the file EMPTY if that command then fails. A zero-byte
+   `.env.staging` takes the API down immediately, since phpdotenv reads it per request (observed
+   2026-09-01).
+
+   Write a temp copy in the SAME directory instead, validate it, and `mv` it into place. `cp -p`
+   seeds the temp with the live file's owner, group and mode, so the replacement keeps them; the
+   redirect then truncates only that temp; and `mv` within one directory is an atomic rename, so
+   no in-flight request can read a half-written file. Build the temp as the same user that
+   performs the write — a `mktemp` file made by `ubuntu` is mode 600 and unreadable to the user
+   performing the write.
 
    ```bash
    sudo -u <owner> bash -c 'cd <deploy-dir> \
      && cp -p .env.staging .env.staging.bak.<label> \
-     && t=$(mktemp) \
-     && sed "s/^OPENFGA_MODEL_ID=<old>$/OPENFGA_MODEL_ID=<new>/" .env.staging.bak.<label> > "$t" \
-     && [ -s "$t" ] && cp "$t" .env.staging && rm -f "$t"'
+     && cp -p .env.staging .env.staging.new \
+     && sed "s/^OPENFGA_MODEL_ID=<old>$/OPENFGA_MODEL_ID=<new>/" .env.staging.bak.<label> > .env.staging.new \
+     && grep -q "^OPENFGA_MODEL_ID=<new>$" .env.staging.new \
+     && mv .env.staging.new .env.staging \
+     || rm -f .env.staging.new'
    ```
 
    Then confirm owner/group/mode are unchanged (`stat -c %U:%G,%a .env.staging`) and that the API
@@ -161,10 +169,16 @@ they preserve *whether a caller may write*, and nothing else. In particular they
   `resource_id` stored on the change-request row. After Step 4 rewrites those to the new type, a
   user still holding only the legacy tuple stops seeing those batches in their review queue.
 
-Both resume as soon as Step 3 has run. This is deliberate and fail-closed: that path decides
-governance rather than access, and silently auto-approving off a legacy tuple during the migration
-window would be worse than queueing for a human. Nothing is lost — queued requests are approved
-normally once the tuples are migrated.
+Both resume as soon as Step 3 has run, but not in the same way, and the difference decides what
+an operator has to chase afterwards. Reviewer-queue visibility is evaluated per query, so it
+returns in full on its own. Auto-approval is evaluated ONCE, on the way in:
+`ChangeRequestSourceDataWriter` calls `ChangeRequestReview::administers()` at submit time and
+records the batch as `submitted` when it is false, and nothing re-evaluates it later. So a request
+that queued during the window stays queued — it needs an explicit reviewer approval; only new
+submissions auto-approve again. This is deliberate and fail-closed: that path decides governance
+rather than access, and silently auto-approving off a legacy tuple during the migration window
+would be worse than queueing for a human. Nothing is lost, but "approved normally" means by a
+human, not retroactively.
 
 **Therefore: run Step 3 immediately after Step 2.** Do not leave the two separated by a maintenance
 window or a working day; every minute in between is a minute in which legitimate change requests
@@ -234,11 +248,20 @@ skipped (same meaning as in the dry run).
 suggests: `bin/doctrine-migrations` is excluded from the rsync payload
 (`.github/deploy/rsync-exclude.txt`) precisely because migrations are applied in-process, and
 `deploy.yaml` POSTs `/_ops/migrate` after every rsync. So on `api/dev` the migration lands at
-deploy time, as part of Step 2. Check the state rather than assuming, using the deploy token
-from that host's `.env`:
+deploy time, as part of Step 2. Check the state rather than assuming.
+
+`DEPLOY_TOKEN` is a shared secret and is not set in an operator shell by default — read it from
+that host's env file rather than assuming it is exported, or the request goes out with an empty
+header and `DeployTokenMiddleware` fails closed on it. Pass it through a curl config on stdin
+rather than in `-H`, which would put it in the process argument list where any other user on the
+VPS can read it with `ps`. `BASE` must be an `https://` URL; `--proto '=https'` makes curl refuse
+to send the token over anything else rather than trusting a route-level redirect:
 
 ```bash
-curl -fsS -H "X-Deploy-Token: $DEPLOY_TOKEN" "${BASE}/${SUBDIR}/_ops/migrate/status"
+DEPLOY_TOKEN=$(sed -n 's/^DEPLOY_TOKEN=//p' .env.staging)
+printf 'header = "X-Deploy-Token: %s"\n' "$DEPLOY_TOKEN" \
+  | curl -fsS --proto '=https' -K - "${BASE}/${SUBDIR}/_ops/migrate/status"
+unset DEPLOY_TOKEN
 ```
 
 Only where you have a CLI checkout (local, CI) is the command:
@@ -251,9 +274,11 @@ composer db:migrate
 cannot be rearranged: the deploy applies the migration, so Step 4 completes at Step 2 time,
 before the tuples move. The effect is to widen the Step 2 window described above rather than to
 create a new hazard — change-request rows name `rite_calendar` while their tuples are still
-legacy, so those requests queue for a reviewer instead of auto-approving, and resume the moment
-Step 3 runs. Nothing is corrupted and no row is lost. It is one more reason to run Step 3
-immediately after Step 2.
+legacy, so those requests queue for a reviewer instead of auto-approving. New submissions
+auto-approve again as soon as Step 3 runs, but the ones that queued during the window stay
+queued and need an explicit reviewer approval: auto-approval is decided once, at submit time.
+Nothing is corrupted and no row is lost. It is one more reason to run Step 3 immediately after
+Step 2.
 
 `Version20260901130000` rewrites two Postgres tables from `general_roman_calendar[_test]` onto
 `rite_calendar[_test]`: `sourcedata_change_requests.resource_type`/`resource_id`, and the JSONB

--- a/docs/ops/rite-calendar-migration-runbook.md
+++ b/docs/ops/rite-calendar-migration-runbook.md
@@ -133,7 +133,7 @@ outright rather than silently doing nothing.
 
 ## Step 2 — Deploy this API version
 
-Deploy the #955 build to the target environment. Both `OpenFgaAuthorizationMiddleware::forRiteCalendar()`
+Deploy the #955 build — PR #965, the change this runbook accompanies — to the target environment. Both `OpenFgaAuthorizationMiddleware::forRiteCalendar()`
 and `::forMissals()` check the object `rite_calendar:{rite}/{subResource}` first, with a legacy
 fallback — but the two do **not** fall back the same way, and conflating them is a real
 operational hazard (an operator could wrongly conclude Ambrosian missal grants stop being honoured
@@ -255,12 +255,23 @@ that host's env file rather than assuming it is exported, or the request goes ou
 header and `DeployTokenMiddleware` fails closed on it. Pass it through a curl config on stdin
 rather than in `-H`, which would put it in the process argument list where any other user on the
 VPS can read it with `ps`. `BASE` must be an `https://` URL; `--proto '=https'` makes curl refuse
-to send the token over anything else rather than trusting a route-level redirect:
+to send the token over anything else rather than trusting a route-level redirect.
+
+Read it by absolute path, not from whatever the current directory happens to be, and check that
+it is non-empty before calling curl — a wrong path yields an EMPTY token, and the request then
+goes out with an empty header and comes back a fail-closed 401/403 that looks like a token
+problem rather than a path problem. No `sudo` is needed for this read: `.env.staging` is mode 640
+and group `psacln`, which the operator account is in.
 
 ```bash
-DEPLOY_TOKEN=$(sed -n 's/^DEPLOY_TOKEN=//p' .env.staging)
-printf 'header = "X-Deploy-Token: %s"\n' "$DEPLOY_TOKEN" \
-  | curl -fsS --proto '=https' -K - "${BASE}/${SUBDIR}/_ops/migrate/status"
+D=/var/www/vhosts/johnromanodorazio.com/httpdocs/LiturgicalCalendar/api/dev
+DEPLOY_TOKEN=$(sed -n 's/^DEPLOY_TOKEN=//p' "$D/.env.staging")
+if [ -z "$DEPLOY_TOKEN" ]; then
+  echo "no DEPLOY_TOKEN in $D/.env.staging" >&2
+else
+  printf 'header = "X-Deploy-Token: %s"\n' "$DEPLOY_TOKEN" \
+    | curl -fsS --proto '=https' -K - "${BASE}/${SUBDIR}/_ops/migrate/status"
+fi
 unset DEPLOY_TOKEN
 ```
 

--- a/docs/ops/rite-calendar-migration-runbook.md
+++ b/docs/ops/rite-calendar-migration-runbook.md
@@ -90,6 +90,31 @@ itself is left in the model unchanged — it is only removed at the prune milest
    the latest authorization model already in that store (it does not create or upload one), and —
    with `--update-env` — writes the resulting `OPENFGA_STORE_ID` and `OPENFGA_MODEL_ID` into the
    `.env.*` file(s) and Docker Compose `.env` files in this repo and its siblings.
+
+   **That command is for a checkout, not for the deployed vhost, and running it in the wrong place
+   re-pins the wrong store.** The deployed API's pin against the PRODUCTION store lives in exactly
+   one file — `api/dev/.env.staging` on the VPS, the only `.env*` that deployment has, so there is
+   no Dotenv precedence to reason about. `api/v4` and `api/v5` carry no `OPENFGA_*` keys at all.
+   Run from a local checkout the command above resolves whatever store that checkout points at
+   (a local dev store, not production) and writes those values, so edit the one VPS file instead.
+
+   Edit it as its owner, and land it with `cp` rather than a shell redirect — `cp` opens its
+   source before truncating its destination, whereas `sed > file` / `cat tmp > file` truncates
+   first and leaves the file EMPTY if the left-hand command then fails. A zero-byte `.env.staging`
+   takes the API down immediately, since phpdotenv reads it per request (observed 2026-09-01). For
+   the same reason, do not build the replacement as a different user: a `mktemp` file made by
+   `ubuntu` is mode 600 and unreadable to the owner the write runs as.
+
+   ```bash
+   sudo -u <owner> bash -c 'cd <deploy-dir> \
+     && cp -p .env.staging .env.staging.bak.<label> \
+     && t=$(mktemp) \
+     && sed "s/^OPENFGA_MODEL_ID=<old>$/OPENFGA_MODEL_ID=<new>/" .env.staging.bak.<label> > "$t" \
+     && [ -s "$t" ] && cp "$t" .env.staging && rm -f "$t"'
+   ```
+
+   Then confirm owner/group/mode are unchanged (`stat -c %U:%G,%a .env.staging`) and that the API
+   still answers (`curl -o /dev/null -w '%{http_code}' <base>/calendars`). No restart is needed.
 3. Re-run the pre-flight model check above and confirm `"rite_calendar"` now appears in the output.
 
 **Nothing else in this runbook can start until this step is confirmed done.** Steps 2 and 3 both
@@ -205,9 +230,30 @@ skipped (same meaning as in the dry run).
 
 ## Step 4 — Apply the Doctrine migration
 
+**On a deployed vhost this step runs itself**, and cannot be run the way the command below
+suggests: `bin/doctrine-migrations` is excluded from the rsync payload
+(`.github/deploy/rsync-exclude.txt`) precisely because migrations are applied in-process, and
+`deploy.yaml` POSTs `/_ops/migrate` after every rsync. So on `api/dev` the migration lands at
+deploy time, as part of Step 2. Check the state rather than assuming, using the deploy token
+from that host's `.env`:
+
+```bash
+curl -fsS -H "X-Deploy-Token: $DEPLOY_TOKEN" "${BASE}/${SUBDIR}/_ops/migrate/status"
+```
+
+Only where you have a CLI checkout (local, CI) is the command:
+
 ```bash
 composer db:migrate
 ```
+
+**This inverts the Step 3 → Step 4 order on any auto-migrating deployment**, and the sequence
+cannot be rearranged: the deploy applies the migration, so Step 4 completes at Step 2 time,
+before the tuples move. The effect is to widen the Step 2 window described above rather than to
+create a new hazard — change-request rows name `rite_calendar` while their tuples are still
+legacy, so those requests queue for a reviewer instead of auto-approving, and resume the moment
+Step 3 runs. Nothing is corrupted and no row is lost. It is one more reason to run Step 3
+immediately after Step 2.
 
 `Version20260901130000` rewrites two Postgres tables from `general_roman_calendar[_test]` onto
 `rite_calendar[_test]`: `sourcedata_change_requests.resource_type`/`resource_id`, and the JSONB
@@ -221,11 +267,11 @@ written.
 
 **Record the cutover date here, at the moment this step is run in each environment:**
 
-| Environment | Cutover date (this step run) | Operator |
-|-------------|------------------------------|----------|
-| Dev         |                              |          |
-| Staging     |                              |          |
-| Production  |                              |          |
+| Environment | Cutover date (this step run) | Operator                                      |
+|-------------|------------------------------|-----------------------------------------------|
+| Dev         |                              |                                               |
+| Staging     | 2026-09-01T20:23:37Z         | `deploy.yaml` (automatic, at the #965 deploy) |
+| Production  |                              |                                               |
 
 An `audit_log` row timestamped before its environment's date above names `general_roman_calendar` /
 `general_roman_calendar_test`; a row timestamped after names `rite_calendar` / `rite_calendar_test`.


### PR DESCRIPTION
The #955 rite-calendar rollout is complete on the dev/staging vhost. This records the cutover date the runbook asks for, and corrects two instructions that don't match how that deployment actually works — both found by running the rollout.

## Rollout state (dev/staging vhost)

| Step | Status |
|---|---|
| 1 — model uploaded, `OPENFGA_MODEL_ID` re-pinned | done — `01M1FHYEDWG8E1CKD4VAKCYZ9V` (cdcf-infra [#42](https://github.com/CatholicOS/cdcf-infra/pull/42), [#43](https://github.com/CatholicOS/cdcf-infra/pull/43)) |
| 2 — API deployed | done, 2026-09-01T20:23Z |
| 3 — tuples migrated | done — 1 candidate, 1 copied, 0 skipped, exit 0 |
| 4 — Doctrine migration | done, 2026-09-01T20:23:37Z, applied by the deploy |
| 5 — frontend | separate repo |
| 6 — prune | deferred |

The copied tuple was verified by reading it back from the store rather than trusting the script's own report:

```
user:378257854701764610 admin rite_calendar:roman/decrees
```

## Correction 1 — Step 4 runs itself on a deployed vhost

`composer db:migrate` cannot run there: `bin/doctrine-migrations` is excluded from the rsync payload *precisely because* migrations are applied in-process, and `deploy.yaml` POSTs `/_ops/migrate` after every rsync. Following the runbook as written gives `Could not open input file: bin/doctrine-migrations`. The step now documents the `/_ops/migrate/status` check and keeps `composer db:migrate` for checkouts.

This also **inverts the documented Step 3 → Step 4 order**, unavoidably — the deploy migrates, so Step 4 completes at Step 2 time. That widens the Step 2 window the runbook already describes rather than adding a hazard: change-request rows named `rite_calendar` while their tuples were still legacy, so those requests queued for a reviewer instead of auto-approving, and resumed when Step 3 ran. Nothing corrupted.

## Correction 2 — Step 1's re-pin command is for a checkout, not the vhost

`./scripts/setup-openfga.sh --update-env` run from a local clone resolves whatever store *that clone* points at — a local dev store, not production — and writes those values. The deployed pin against the production store is one file: `api/dev/.env.staging`, the only `.env*` that deployment has.

The safe edit shape is now spelled out because getting it wrong took the API down for ~2 minutes: a shell redirect truncates its destination **before** the command on its left runs, so `cat "$tmp" > .env.staging` — where `$tmp` was a `mktemp` file owned by `ubuntu`, mode 600 and unreadable to the user the write ran as — emptied the live file and then failed to refill it. phpdotenv reads per request, so a zero-byte `.env.staging` is an instant outage. `cp` opens its source before truncating its destination, and the pipeline must run as the file's owner. Restored from backup; endpoint returned 200 immediately.

Docs only — no code paths touched. `composer lint:md` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kGisCz5Gscvc9GGRQAUpz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the production calendar migration runbook with safer instructions for changing deployment configuration while preserving file ownership.
  - Documented automatic database migration during deployment and status verification, including safeguards for missing deployment credentials.
  - Clarified deployment sequencing, including the migration occurring before subsequent deployment steps.
  - Recorded the staging cutover timestamp, automated deployment operator, and associated pull request reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->