### PR TITLE
fix(ambrosian): derive the sanctorale inventory per edition and sort missals by edition (#963, #964)

### DIFF
--- a/phpunit_tests/Models/MissalsPath/MissalMetadataMapOrderTest.php
+++ b/phpunit_tests/Models/MissalsPath/MissalMetadataMapOrderTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Models\MissalsPath;
 
+use LiturgicalCalendar\Api\ApcuCache;
+use LiturgicalCalendar\Api\ApcuShimStore;
 use LiturgicalCalendar\Api\Enum\MissalCatalog;
 use LiturgicalCalendar\Api\Enum\MissalSource;
 use LiturgicalCalendar\Api\Enum\Rite;
@@ -166,6 +168,82 @@ final class MissalMetadataMapOrderTest extends TestCase
                 self::rank($source, $previous) <=> self::rank($source, $current),
                 "{$previous->missal_id} must not follow {$current->missal_id}"
             );
+        }
+    }
+
+    /**
+     * A cache hit is sorted too, rather than trusted.
+     *
+     * `buildIndex()` returns early on an APCu hit, before the `sortByEdition()` calls on the build path.
+     * The key `litcal_missals_index_{rite}` is unversioned, so an entry written by pre-#964 code comes
+     * back in declaration order and the whole fix would be inert until the 600-second TTL expired — and
+     * more importantly the ordering guarantee would hold only for the path that happens to build the
+     * index, which is a structural gap rather than a post-deploy window.
+     *
+     * The cache is primed by REVERSING a freshly built index, which for both maps is precisely the
+     * declaration-order shape a stale entry carries. `assertNotSame` on the primed order is the
+     * precondition: without it a sort-on-read that never ran would still pass.
+     *
+     * ext-apcu is absent under CLI here, so this drives `phpunit_tests/Support/ApcuShim.php` — the same
+     * namespaced stand-in `ApcuCacheDetectionTest` uses, and the reason `ApcuCache` lives in
+     * `LiturgicalCalendar\Api` at all. The binding probe below is not ceremony: PHP caches the resolved
+     * function in each call site's run-time cache, so on a host WITH a real ext-apcu an earlier test can
+     * bind `ApcuCache`'s unqualified `apcu_*` calls to the global functions for the life of the process,
+     * and the primed entry would then simply never be seen.
+     */
+    public function testACacheHitIsSortedRatherThanTrusted(): void
+    {
+        require_once dirname(__DIR__, 2) . '/Support/ApcuShim.php';
+
+        $usableProperty = new \ReflectionProperty(ApcuCache::class, 'usable');
+        $usableBefore   = $usableProperty->getValue();
+        $key            = 'litcal_missals_index_' . Rite::ROMAN->value;
+        $probeKey       = $key . '_binding_probe';
+
+        $usableProperty->setValue(null, true);
+
+        try {
+            ApcuShimStore::store($probeKey, 'bound', 10);
+            $probe = ApcuCache::fetch($probeKey, $found);
+            ApcuShimStore::delete($probeKey);
+            if (true !== $found || 'bound' !== $probe) {
+                self::markTestSkipped('ApcuCache is not bound to phpunit_tests/Support/ApcuShim.php in this process');
+            }
+
+            ApcuShimStore::delete($key);
+            $fresh = new MissalMetadataMap(Rite::ROMAN);
+            $fresh->buildIndex();
+
+            $missalsProperty = new \ReflectionProperty(MissalMetadataMap::class, 'missals');
+            $allProperty     = new \ReflectionProperty(MissalMetadataMap::class, 'allMissals');
+
+            /** @var array<string,MissalMetadata> $builtIndex */
+            $builtIndex = $missalsProperty->getValue($fresh);
+            /** @var array<string,MissalMetadata> $builtCatalogue */
+            $builtCatalogue = $allProperty->getValue($fresh);
+
+            $expectedIndex     = array_keys($builtIndex);
+            $expectedCatalogue = array_keys($builtCatalogue);
+
+            $staleIndex     = array_reverse($builtIndex, true);
+            $staleCatalogue = array_reverse($builtCatalogue, true);
+
+            self::assertNotSame($expectedIndex, array_keys($staleIndex), 'the primed entry must be mis-ordered, or this test proves nothing');
+            self::assertNotSame($expectedCatalogue, array_keys($staleCatalogue));
+
+            ApcuShimStore::store($key, ['missals' => $staleIndex, 'allMissals' => $staleCatalogue], 600);
+
+            $fromCache = new MissalMetadataMap(Rite::ROMAN);
+            $fromCache->buildIndex();
+
+            self::assertSame($expectedIndex, $fromCache->getMissalIDs(), 'a cached index must come back sorted, not in whatever order it was stored');
+            /** @var array<string,MissalMetadata> $cachedCatalogue */
+            $cachedCatalogue = $allProperty->getValue($fromCache);
+            self::assertSame($expectedCatalogue, array_keys($cachedCatalogue), 'the cached full catalogue must be sorted on read too');
+        } finally {
+            ApcuShimStore::delete($key);
+            ApcuShimStore::delete($probeKey);
+            $usableProperty->setValue(null, $usableBefore);
         }
     }
 

--- a/phpunit_tests/Models/MissalsPath/MissalMetadataMapOrderTest.php
+++ b/phpunit_tests/Models/MissalsPath/MissalMetadataMapOrderTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\MissalsPath;
+
+use LiturgicalCalendar\Api\Enum\MissalCatalog;
+use LiturgicalCalendar\Api\Enum\MissalSource;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Models\MissalsPath\MissalMetadata;
+use LiturgicalCalendar\Api\Models\MissalsPath\MissalMetadataMap;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The order missals come out of the index in (#964).
+ *
+ * `buildIndex()` used to iterate `MissalSource::getMissalIds()` and preserve that order all the way into
+ * the response, so the listing was a property of how somebody happened to edit an array. For the Roman
+ * rite that looked right by accident — `RomanMissal::$values` is declared roughly chronologically. For the
+ * Ambrosian rite it is not: #959 appended the older `EDITIO_TYPICA_1976` after the existing 2024 edition,
+ * so declaration order is reverse-chronological and the divergence became live.
+ *
+ * These tests pin the order as a function of the DATA — tier, then `since_year`, then `missal_id` — which
+ * is what makes it survive somebody adding an edition in the middle of an array.
+ */
+#[CoversClass(MissalMetadataMap::class)]
+final class MissalMetadataMapOrderTest extends TestCase
+{
+    private static string $savedApiPath;
+    private static string $savedApiFilePath;
+
+    public static function setUpBeforeClass(): void
+    {
+        Router::getApiPaths();
+        self::$savedApiPath     = Router::$apiPath;
+        self::$savedApiFilePath = Router::$apiFilePath;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Router::$apiPath     = self::$savedApiPath;
+        Router::$apiFilePath = self::$savedApiFilePath;
+    }
+
+    /**
+     * The full catalogue a rite declares, in the order the index holds it.
+     *
+     * `$allMissals` is what `include_empty` reaches, and it is the only place the Ambrosian divergence is
+     * visible today, since `buildIndex()` skips the data-less 1976 edition from the built index while
+     * `produceMetadata()` keeps it. No public accessor returns it in order — `getMissalRegions()` collapses
+     * it to unique regions and `getMissalYears()` sorts numerically — so reflection is the only way to ask
+     * the question this class exists to answer.
+     *
+     * @return string[]
+     */
+    private static function catalogueOrder(MissalMetadataMap $map): array
+    {
+        $property = new \ReflectionProperty(MissalMetadataMap::class, 'allMissals');
+        /** @var array<string,MissalMetadata> $all */
+        $all = $property->getValue($map);
+
+        return array_keys($all);
+    }
+
+    /**
+     * Chronological within the tier, typical editions first — and NOT the enum's declaration order, which
+     * for this rite is reverse-chronological. That inequality is the whole point: with only one Ambrosian
+     * edition shipping sanctorale data, this catalogue is the only surface on which a data-derived order
+     * and a declaration-derived one give different answers today.
+     */
+    public function testTheAmbrosianCatalogueIsChronologicalNotInDeclarationOrder(): void
+    {
+        $map = new MissalMetadataMap(Rite::AMBROSIAN);
+        $map->buildIndex();
+
+        $declared  = MissalCatalog::for(Rite::AMBROSIAN)->getMissalIds();
+        $catalogue = self::catalogueOrder($map);
+
+        self::assertSame(['EDITIO_TYPICA_1976', 'EDITIO_TYPICA_2024'], $catalogue);
+        self::assertNotSame(
+            $declared,
+            $catalogue,
+            'declaration order and listing order must differ here, or this test proves nothing'
+        );
+    }
+
+    /**
+     * The Roman listing, spelled out. This DOES differ from what the API returned before #964 — the
+     * national block was `US_2011, IT_1983, IT_2020, NL_1978, CA_2011, CA_2016`, which was
+     * `RomanMissal::$values`' edit history and nothing more. The typical-edition block is unchanged.
+     *
+     * `CA_2011` precedes `US_2011` because they share a `since_year` and the third key is `missal_id`
+     * ascending — an explicit tie-break rather than a reliance on PHP's sort being stable, which would
+     * have quietly restored declaration order for exactly that pair.
+     */
+    public function testTheRomanCatalogueIsOrderedByTierThenYearThenId(): void
+    {
+        $map = new MissalMetadataMap(Rite::ROMAN);
+        $map->buildIndex();
+
+        self::assertSame(
+            [
+                'EDITIO_TYPICA_1970',
+                'EDITIO_TYPICA_1971',
+                'EDITIO_TYPICA_1975',
+                'EDITIO_TYPICA_2002',
+                'EDITIO_TYPICA_2008',
+                'NL_1978',
+                'IT_1983',
+                'CA_2011',
+                'US_2011',
+                'CA_2016',
+                'IT_2020'
+            ],
+            self::catalogueOrder($map)
+        );
+
+        // The built index is the same order with the editions that ship no sanctorale data removed.
+        self::assertSame(
+            ['EDITIO_TYPICA_1970', 'EDITIO_TYPICA_2002', 'EDITIO_TYPICA_2008', 'IT_1983', 'US_2011'],
+            $map->getMissalIDs()
+        );
+    }
+
+    /** @return array<string,array{Rite}> */
+    public static function riteProvider(): array
+    {
+        return [
+            'roman'     => [Rite::ROMAN],
+            'ambrosian' => [Rite::AMBROSIAN]
+        ];
+    }
+
+    /**
+     * The invariant behind both spellings above, asserted pairwise so a rite added later is covered by
+     * adding one row to the provider rather than by hand-listing its editions.
+     *
+     * A missal declared anywhere in its rite's `$values` lands where its tier and year put it; nothing in
+     * the sequence may depend on where it was written down.
+     *
+     * @param Rite $rite the rite whose catalogue is under test
+     */
+    #[DataProvider('riteProvider')]
+    public function testEveryAdjacentPairIsOrderedByTheDeclaredKeys(Rite $rite): void
+    {
+        $map = new MissalMetadataMap($rite);
+        $map->buildIndex();
+
+        $source    = MissalCatalog::for($rite);
+        $catalogue = self::catalogueOrder($map);
+        self::assertGreaterThan(1, count($catalogue), 'a single-edition rite cannot exercise an ordering');
+
+        $property = new \ReflectionProperty(MissalMetadataMap::class, 'allMissals');
+        /** @var array<string,MissalMetadata> $all */
+        $all = $property->getValue($map);
+
+        for ($i = 1; $i < count($catalogue); ++$i) {
+            $previous = $all[$catalogue[$i - 1]];
+            $current  = $all[$catalogue[$i]];
+
+            self::assertLessThanOrEqual(
+                0,
+                self::rank($source, $previous) <=> self::rank($source, $current),
+                "{$previous->missal_id} must not follow {$current->missal_id}"
+            );
+        }
+    }
+
+    /**
+     * The sort key, restated as data so the assertion above compares something rather than re-running the
+     * implementation's comparator. `isEditioTypica()` is negated because typical editions come FIRST.
+     *
+     * @return array{int,int,string}
+     */
+    private static function rank(MissalSource $source, MissalMetadata $missal): array
+    {
+        return [
+            $source->isEditioTypica($missal->missal_id) ? 0 : 1,
+            $missal->year_limits->since_year,
+            $missal->missal_id
+        ];
+    }
+}

--- a/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+++ b/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
@@ -6,6 +6,7 @@ namespace LiturgicalCalendar\Tests\Models\ValidationsPath;
 
 use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\MissalCatalog;
 use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
@@ -148,6 +149,71 @@ final class CheckableInventoryTest extends TestCase
     }
 
     /**
+     * The Ambrosian sanctorale is derived one item per edition from the missal registry, exactly as the
+     * Roman one is. It used to be two singletons hard-wired to `propriumdesanctis_2024`, so a second
+     * edition's sanctorale and translations would silently never have been validated (#963).
+     *
+     * Driven off `MissalCatalog::for(Rite::AMBROSIAN)` rather than a list written down here, because that
+     * is the only thing that can tell derivation apart from a lucky singleton: the rite ships exactly one
+     * edition with data today, so both approaches yield one item. Declaring a data-bearing edition on
+     * `AmbrosianMissal` fails this test until the inventory carries it.
+     *
+     * The interface, not the enum — a third rite must need no edit in `CheckableInventory` or here.
+     */
+    public function testTheAmbrosianSanctoraleIsDerivedPerEditionAndSkipsDatalessEditions(): void
+    {
+        $source   = MissalCatalog::for(Rite::AMBROSIAN);
+        $declared = $source->getMissalIds();
+        $ids      = array_map(static fn (CheckableItem $i): string => $i->id, CheckableInventory::all());
+
+        self::assertGreaterThan(
+            1,
+            count($declared),
+            'the rite must declare more than one edition, or this test cannot distinguish a derivation from a singleton'
+        );
+
+        $withData = 0;
+        foreach ($declared as $missalId) {
+            if (false === $source->getSanctoraleFileName($missalId)) {
+                self::assertNotContains("sanctorale:ambrosian:{$missalId}", $ids, "{$missalId} ships no sanctorale data and must contribute no item");
+                self::assertNotContains("sanctorale:ambrosian:{$missalId}:i18n", $ids);
+                continue;
+            }
+
+            ++$withData;
+            self::assertContains("sanctorale:ambrosian:{$missalId}", $ids);
+            self::assertContains("sanctorale:ambrosian:{$missalId}:i18n", $ids);
+
+            $item = CheckableInventory::byId("sanctorale:ambrosian:{$missalId}");
+            self::assertNotNull($item);
+            self::assertSame(Rite::AMBROSIAN, $item->rite);
+            self::assertSame(LitSchema::PROPRIUMDESANCTIS, $item->schema);
+            self::assertNull($item->region, 'the Ambrosian rite has no national tier, so region is always null');
+            self::assertFileExists($item->path, "{$item->id} points at a file that does not exist");
+            // The registry's own answer for THIS id, not the edition-pinned JsonData constant: that is the
+            // difference the hard-wired version could not express.
+            self::assertSame(
+                $source->getSanctoraleFileName($missalId),
+                $item->path,
+                "{$item->id} must point at the file the registry declares for its own edition"
+            );
+        }
+
+        self::assertGreaterThan(0, $withData, 'at least one Ambrosian edition ships sanctorale data');
+
+        // The unqualified singleton is gone, and nothing else claims to be an Ambrosian sanctorale.
+        self::assertNotContains('sanctorale:ambrosian', $ids);
+        self::assertNotContains('sanctorale:ambrosian:i18n', $ids);
+
+        $derived = array_values(array_filter(
+            $ids,
+            static fn (string $id): bool => str_starts_with($id, 'sanctorale:ambrosian:')
+                && false === str_ends_with($id, ':i18n')
+        ));
+        self::assertCount($withData, $derived);
+    }
+
+    /**
      * The mapping the client's scope predicate depends on: `null` means "applies to the whole rite",
      * a nation code means "only that nation's calendar". Deliberately NOT produceMetadata()'s 'VA',
      * which is a nation code and would be simply false on the Ambrosian items.
@@ -157,7 +223,7 @@ final class CheckableInventoryTest extends TestCase
         self::assertNull(CheckableInventory::byId('temporale:roman')?->region);
         self::assertNull(CheckableInventory::byId('sanctorale:roman:EDITIO_TYPICA_1970')?->region);
         self::assertNull(CheckableInventory::byId('temporale:ambrosian')?->region);
-        self::assertNull(CheckableInventory::byId('sanctorale:ambrosian')?->region);
+        self::assertNull(CheckableInventory::byId('sanctorale:ambrosian:EDITIO_TYPICA_2024')?->region);
 
         self::assertSame('US', CheckableInventory::byId('sanctorale:roman:US_2011')?->region);
         self::assertSame('IT', CheckableInventory::byId('sanctorale:roman:IT_1983')?->region);
@@ -193,8 +259,10 @@ final class CheckableInventoryTest extends TestCase
         sort($ambrosian);
         self::assertSame(
             [
-                'sanctorale:ambrosian',
-                'sanctorale:ambrosian:i18n',
+                // Per edition, not one hard-wired pair: EDITIO_TYPICA_1976 is declared but ships no
+                // sanctorale data, so it contributes nothing here (#963).
+                'sanctorale:ambrosian:EDITIO_TYPICA_2024',
+                'sanctorale:ambrosian:EDITIO_TYPICA_2024:i18n',
                 'temporale:ambrosian',
                 'temporale:ambrosian:i18n',
                 // Test definitions are rite-scoped, not nation-scoped (region is always null), so the

--- a/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+++ b/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
@@ -172,7 +172,7 @@ final class CheckableInventoryTest extends TestCase
             'the rite must declare more than one edition, or this test cannot distinguish a derivation from a singleton'
         );
 
-        $withData = 0;
+        $expected = [];
         foreach ($declared as $missalId) {
             if (false === $source->getSanctoraleFileName($missalId)) {
                 self::assertNotContains("sanctorale:ambrosian:{$missalId}", $ids, "{$missalId} ships no sanctorale data and must contribute no item");
@@ -180,7 +180,8 @@ final class CheckableInventoryTest extends TestCase
                 continue;
             }
 
-            ++$withData;
+            $expected[] = "sanctorale:ambrosian:{$missalId}";
+            $expected[] = "sanctorale:ambrosian:{$missalId}:i18n";
             self::assertContains("sanctorale:ambrosian:{$missalId}", $ids);
             self::assertContains("sanctorale:ambrosian:{$missalId}:i18n", $ids);
 
@@ -199,18 +200,24 @@ final class CheckableInventoryTest extends TestCase
             );
         }
 
-        self::assertGreaterThan(0, $withData, 'at least one Ambrosian edition ships sanctorale data');
+        self::assertNotEmpty($expected, 'at least one Ambrosian edition ships sanctorale data');
 
         // The unqualified singleton is gone, and nothing else claims to be an Ambrosian sanctorale.
         self::assertNotContains('sanctorale:ambrosian', $ids);
         self::assertNotContains('sanctorale:ambrosian:i18n', $ids);
 
-        $derived = array_values(array_filter(
+        // The exact SET, not a count. `derivedAmbrosianSanctorale()`'s docblock plans for a
+        // `sanctorale:ambrosian:{id}:lectionary` sibling once `getLectionaryFilePath()` returns a path; a
+        // count assertion would fold that arrival into a bare `3 !== 2` that names nothing and sends the
+        // next reader looking in the wrong place. As a set, the surprising id names itself in the diff and
+        // adopting it is a deliberate one-line edit here.
+        $actual = array_values(array_filter(
             $ids,
-            static fn (string $id): bool => str_starts_with($id, 'sanctorale:ambrosian:')
-                && false === str_ends_with($id, ':i18n')
+            static fn (string $id): bool => str_starts_with($id, 'sanctorale:ambrosian')
         ));
-        self::assertCount($withData, $derived);
+        sort($expected);
+        sort($actual);
+        self::assertSame($expected, $actual, 'the inventory holds exactly the derived Ambrosian sanctorale items and nothing else');
     }
 
     /**

--- a/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+++ b/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
@@ -181,9 +181,19 @@ final class CheckableInventoryTest extends TestCase
             }
 
             $expected[] = "sanctorale:ambrosian:{$missalId}";
-            $expected[] = "sanctorale:ambrosian:{$missalId}:i18n";
             self::assertContains("sanctorale:ambrosian:{$missalId}", $ids);
-            self::assertContains("sanctorale:ambrosian:{$missalId}:i18n", $ids);
+
+            // Conditional exactly as production is: `derivedAmbrosianSanctorale()` `continue`s on a
+            // missing sanctorale file, but guards the `i18n` item separately on
+            // `getSanctoraleI18nFilePath()`. Demanding the translations folder whenever the structure
+            // file exists would red this test for an edition whose data landed before its
+            // translations — an ordinary sequence, and the inventory behaving exactly as designed.
+            if (false !== $source->getSanctoraleI18nFilePath($missalId)) {
+                $expected[] = "sanctorale:ambrosian:{$missalId}:i18n";
+                self::assertContains("sanctorale:ambrosian:{$missalId}:i18n", $ids);
+            } else {
+                self::assertNotContains("sanctorale:ambrosian:{$missalId}:i18n", $ids, "{$missalId} declares no i18n folder, so no translations item may be emitted");
+            }
 
             $item = CheckableInventory::byId("sanctorale:ambrosian:{$missalId}");
             self::assertNotNull($item);

--- a/src/Models/MissalsPath/MissalMetadataMap.php
+++ b/src/Models/MissalsPath/MissalMetadataMap.php
@@ -5,6 +5,7 @@ namespace LiturgicalCalendar\Api\Models\MissalsPath;
 use LiturgicalCalendar\Api\ApcuCache;
 use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\MissalCatalog;
+use LiturgicalCalendar\Api\Enum\MissalSource;
 use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
 use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
@@ -194,6 +195,58 @@ final class MissalMetadataMap implements \IteratorAggregate, \JsonSerializable
         $this->includeEmpty = $includeEmpty;
     }
 
+    /**
+     * Order a rite's missals by what the data says about them, not by where somebody put them in an array.
+     *
+     * The listing used to come out in `MissalSource::getMissalIds()` order, and for the Roman rite that
+     * looked right by convention rather than by construction: `RomanMissal::$values` simply happens to be
+     * declared roughly chronologically. `AmbrosianMissal::$values` is not — #959 appended the older
+     * `EDITIO_TYPICA_1976` after the existing 2024 edition — so once 1976 ships sanctorale data the
+     * default listing would have shown the second edition before the first, with nothing to say the order
+     * was arbitrary (#964).
+     *
+     * Three keys, in order:
+     *
+     * 1. **`isEditioTypica()` descending.** Typical editions first, keeping the Roman response's existing
+     *    two-block shape (the five typical editions, then the national ones) rather than interleaving
+     *    `NL_1978` and `IT_1983` among them. Asked of the source, never `str_starts_with('EDITIO_TYPICA_')`
+     *    — see {@see MissalSource::isEditioTypica()} on why the prefix is a naming convention, not a tier.
+     * 2. **`year_limits['since_year']` ascending.** Chronological within each block, which is the intent
+     *    the Roman declaration order was approximating.
+     * 3. **`missal_id` ascending.** An explicit tie-break, not cosmetics: `US_2011` and `CA_2011` share a
+     *    `since_year`, and leaning on PHP's stable sort to keep them in declaration order would reintroduce
+     *    exactly the "correct by convention" fragility this method exists to remove.
+     *
+     * Note that this DOES visibly reorder the existing Roman national block, from
+     * `US_2011, IT_1983, IT_2020, NL_1978, CA_2011, CA_2016` to
+     * `NL_1978, IT_1983, CA_2011, US_2011, CA_2016, IT_2020`. That is accepted: the previous order was a
+     * property of the enum's edit history, not of the missals. The typical-edition block is unchanged.
+     *
+     * `uasort` rather than `usort`: both maps are keyed by `missal_id`, and {@see self::hasMissal()} and
+     * {@see self::getMissalMetadata()} are key lookups.
+     *
+     * @param array<string,MissalMetadata> $missals
+     * @return array<string,MissalMetadata>
+     */
+    private static function sortByEdition(array $missals, MissalSource $source): array
+    {
+        uasort($missals, static function (MissalMetadata $a, MissalMetadata $b) use ($source): int {
+            $tier = $source->isEditioTypica($b->missal_id) <=> $source->isEditioTypica($a->missal_id);
+            if (0 !== $tier) {
+                return $tier;
+            }
+
+            $year = $a->year_limits->since_year <=> $b->year_limits->since_year;
+            if (0 !== $year) {
+                return $year;
+            }
+
+            return strcmp($a->missal_id, $b->missal_id);
+        });
+
+        return $missals;
+    }
+
     public function buildIndex(): void
     {
         // #836: both the decision and the calls belong to ApcuCache, which lives in
@@ -287,6 +340,11 @@ final class MissalMetadataMap implements \IteratorAggregate, \JsonSerializable
         // NOT from a rite conditional, which would silently fall through to the Roman catalogue
         // for a rite this file has not been taught about yet.
         $this->allMissals = $source->produceMetadata();
+
+        // Both maps are ordered here rather than left in the order the loop above happened to visit
+        // them, which is `getMissalIds()`'s declaration order (#964).
+        $this->missals    = self::sortByEdition($this->missals, $source);
+        $this->allMissals = self::sortByEdition($this->allMissals, $source);
 
         ApcuCache::store($this->cacheKey(), [
             'missals'    => $this->missals,

--- a/src/Models/MissalsPath/MissalMetadataMap.php
+++ b/src/Models/MissalsPath/MissalMetadataMap.php
@@ -271,8 +271,19 @@ final class MissalMetadataMap implements \IteratorAggregate, \JsonSerializable
             /** @var array<string,MissalMetadata> $allMissals */
             $allMissals = $cached['allMissals'];
 
-            $this->missals    = $missals;
-            $this->allMissals = $allMissals;
+            // Sorted again on read rather than trusted from the entry (#964). The key
+            // (`litcal_missals_index_{rite}`) is unversioned, so an entry written by a revision whose
+            // ordering differed — pre-#964 code, most immediately — comes back in whatever order it was
+            // stored in, and this early return never reaches the sort on the miss path below. Versioning
+            // the key instead would fix only the entries alive at one deploy and would rely on somebody
+            // remembering to bump a constant whenever the ordering changes: the "correct by convention"
+            // failure #964 exists to remove. Sorting on read cannot be forgotten, and a `uasort` over
+            // eleven items is negligible next to the guarantee that sorted order is a postcondition of
+            // `buildIndex()` no matter who wrote the entry or when.
+            $cachedSource = MissalCatalog::for($this->rite);
+
+            $this->missals    = self::sortByEdition($missals, $cachedSource);
+            $this->allMissals = self::sortByEdition($allMissals, $cachedSource);
             return;
         }
 

--- a/src/Models/ValidationsPath/CheckableInventory.php
+++ b/src/Models/ValidationsPath/CheckableInventory.php
@@ -7,6 +7,7 @@ namespace LiturgicalCalendar\Api\Models\ValidationsPath;
 use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\LectionaryCategory;
 use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\MissalCatalog;
 use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Enum\RomanMissal;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
@@ -24,9 +25,10 @@ use LiturgicalCalendar\Api\Services\ResourceExistenceChecker;
  * The inventory has two halves, and only the smaller one is written down here.
  *
  * The *static* half is the source data that exists once per rite: the temporale, the decrees, and
- * the Roman missal sanctorale editions. Even that is only half-listed — `RomanMissal` already
- * registers every edition and already knows which have a sanctorale file, so those items are
- * derived; the remainder have dedicated `JsonData` constants and are listed explicitly.
+ * each rite's missal sanctorale editions. Even that is only half-listed — every rite's
+ * {@see \LiturgicalCalendar\Api\Enum\MissalSource} already registers its editions and already knows
+ * which have a sanctorale file, so those items are derived per edition; the remainder have dedicated
+ * `JsonData` constants and are listed explicitly.
  *
  * The *enumerated* half is the per-calendar source data, which is not listed at all and today is
  * the larger of the two. National calendars, wider regions and diocesan calendars come from
@@ -179,10 +181,11 @@ final class CheckableInventory
     /**
      * The half of the inventory that does not read calendar source data.
      *
-     * `derivedRomanSanctorale()` and `explicitItems()` build their paths from the `RomanMissal` and
-     * `JsonData` registries, both in-memory: neither calls {@see self::metadata()}, so neither can
-     * fail for the reason the enumerating producers can. That is what makes this half usable as a
-     * fallback when the full lookup throws — see {@see self::staticByPath()}.
+     * `derivedRomanSanctorale()`, `derivedAmbrosianSanctorale()` and `explicitItems()` build their
+     * paths from the missal registries (reached through {@see MissalCatalog::for()}) and `JsonData`,
+     * all in-memory: none calls {@see self::metadata()}, so none can fail for the reason the
+     * enumerating producers can. That is what makes this half usable as a fallback when the full
+     * lookup throws — see {@see self::staticByPath()}.
      *
      * `testDefinitionItems()` is deliberately NOT part of this. It does not depend on
      * `CalendarMetadataProvider` either, but it globs, and a failed glob raises here by design; a
@@ -197,6 +200,7 @@ final class CheckableInventory
     {
         return array_merge(
             self::derivedRomanSanctorale(),
+            self::derivedAmbrosianSanctorale(),
             self::explicitItems()
         );
     }
@@ -340,6 +344,77 @@ final class CheckableInventory
         return $items;
     }
 
+    /**
+     * The Ambrosian sanctorale, derived per edition exactly as the Roman one is.
+     *
+     * This used to be two hard-wired singletons pointing at `JsonData::AMBROSIAN_SANCTORALE_FILE` and
+     * `..._I18N_FOLDER`, both pinned to `propriumdesanctis_2024`. That was indistinguishable from correct
+     * while the rite declared one edition, and became wrong the moment #959 coined `EDITIO_TYPICA_1976`:
+     * a second edition's sanctorale and translations would simply never have been validated, and
+     * `/validations` would have gone on reporting a green, complete-looking inventory (#963). Silence, not
+     * an error — the same family as #822/#833/#834/#835.
+     *
+     * Written against {@see MissalSource} through {@see MissalCatalog::for()} rather than against
+     * `AmbrosianMissal` directly, so a third rite is a `match` arm in the catalog and nothing here.
+     *
+     * Two deliberate differences from {@see self::derivedRomanSanctorale()}:
+     *
+     * - `region` is always null. It is not the Roman `str_starts_with('EDITIO_TYPICA_')` test transplanted:
+     *   the Ambrosian rite has no national tier at all, every declared id being a typical edition — an
+     *   invariant pinned by `MissalCatalogTest::testEveryDeclaredAmbrosianEditionIsTypicalSoTheRiteHasNoNationalTier`.
+     * - No `:lectionary` item. The Roman version finds one beside each sanctorale file; for this rite the
+     *   lectionary is declared per edition on `AmbrosianMissal::$lectionaryPath`, and every entry is
+     *   `false` because no Ambrosian lectionary data ships (#957). Deriving a path anyway would produce an
+     *   item pointing at a folder that is not merely missing but not yet decided on. When that data lands,
+     *   the item belongs here, built from `getLectionaryFilePath()` — the registry's own per-edition
+     *   answer — never from `dirname($file) . '/lectionary'`.
+     *
+     * @return list<CheckableItem>
+     */
+    private static function derivedAmbrosianSanctorale(): array
+    {
+        $source = MissalCatalog::for(Rite::AMBROSIAN);
+        $items  = [];
+
+        foreach ($source->getMissalIds() as $missalId) {
+            $file = $source->getSanctoraleFileName($missalId);
+            if (false === $file) {
+                continue;
+            }
+
+            $name = $source->getName($missalId);
+
+            $items[] = new CheckableItem(
+                "sanctorale:ambrosian:{$missalId}",
+                'file',
+                Rite::AMBROSIAN,
+                null,
+                $name,
+                LitSchema::PROPRIUMDESANCTIS,
+                self::STEPS,
+                $file
+            );
+
+            // No `covers` step, for the same reason the Roman missal i18n folders carry none: the locales
+            // an edition is held to are scanned from this very folder, so the comparison is a tautology.
+            $i18n = $source->getSanctoraleI18nFilePath($missalId);
+            if (false !== $i18n) {
+                $items[] = new CheckableItem(
+                    "sanctorale:ambrosian:{$missalId}:i18n",
+                    'folder',
+                    Rite::AMBROSIAN,
+                    null,
+                    "{$name} translations",
+                    LitSchema::I18N,
+                    self::STEPS,
+                    rtrim($i18n, '/')
+                );
+            }
+        }
+
+        return $items;
+    }
+
     /** @return list<CheckableItem> */
     private static function explicitItems(): array
     {
@@ -403,26 +478,6 @@ final class CheckableInventory
                 LitSchema::I18N,
                 self::STEPS,
                 JsonData::AMBROSIAN_TEMPORALE_I18N_FOLDER->path()
-            ),
-            new CheckableItem(
-                'sanctorale:ambrosian',
-                'file',
-                Rite::AMBROSIAN,
-                null,
-                'Ambrosian Proprium de Sanctis',
-                LitSchema::PROPRIUMDESANCTIS,
-                self::STEPS,
-                JsonData::AMBROSIAN_SANCTORALE_FILE->path()
-            ),
-            new CheckableItem(
-                'sanctorale:ambrosian:i18n',
-                'folder',
-                Rite::AMBROSIAN,
-                null,
-                'Ambrosian Proprium de Sanctis translations',
-                LitSchema::I18N,
-                self::STEPS,
-                JsonData::AMBROSIAN_SANCTORALE_I18N_FOLDER->path()
             )
         ];
     }


### PR DESCRIPTION
Closes #963. Closes #964.

Both are consequences of the Ambrosian rite gaining a second missal edition (`EDITIO_TYPICA_1976`, coined by #959) while two code paths still assumed one edition or leaned on array declaration order. Neither bites today — which is the point: both fail silently the day 1976 gains source data.

## #963 — `/validations` was hard-wired to a single Ambrosian edition

`CheckableInventory` declared two singletons pointing at `JsonData::AMBROSIAN_SANCTORALE_FILE`, pinned to `propriumdesanctis_2024`. A second edition's sanctorale and `i18n/` folder would simply never be validated, while `/validations` reported a green, complete-looking inventory — the same "checks that report untruths" family as #822/#833/#834/#835.

Replaced with `derivedAmbrosianSanctorale()`, mirroring the Roman `derivedRomanSanctorale()`: written against the `MissalSource` interface via `MissalCatalog::for()`, so a third rite needs no further change, and skipping editions that ship no data. `region` is always `null` — the Ambrosian rite has no national tier, an invariant already pinned by `MissalCatalogTest`.

This restores the original design's intent. The plan document that introduced the inventory records why it was flattened — *"There is one Ambrosian sanctorale and no registry to derive an edition from"* — a reason that stopped being true when #959 created the registry.

**Breaking for `/validations` consumers.** Inventory ids and labels change:

| | before | after |
| --- | --- | --- |
| id | `sanctorale:ambrosian` | `sanctorale:ambrosian:EDITIO_TYPICA_2024` |
| id | `sanctorale:ambrosian:i18n` | `sanctorale:ambrosian:EDITIO_TYPICA_2024:i18n` |
| label | `Ambrosian Proprium de Sanctis` | `Messale Ambrosiano, Editio 2024` |

Now consistent with the Roman `sanctorale:roman:{missal_id}` pattern. Coordinated as **UnitTestInterface#101**, which hardcodes the old ids in `e2e/ws-protocol.spec.ts`.

## #964 — listing order followed declaration order, not edition year

`MissalMetadataMap::buildIndex()` preserved `getMissalIds()` order into the response. `AmbrosianMissal::$values` is reverse-chronological, so once 1976 has data the listing would show the second edition before the first.

`sortByEdition()` now sorts by `isEditioTypica()` DESC → `since_year` ASC → `missal_id` ASC, applied to both the built index and the full catalogue. The third key is load-bearing, not cosmetic: `US_2011` and `CA_2011` share `since_year = 2011`, and leaning on PHP's stable sort to break that tie would reintroduce the very "correct by convention, not by construction" fragility this fixes.

**This visibly reorders the existing Roman response, and that is intended.** The typical block is unchanged; the national block becomes chronological:

```text
before:  US_2011, IT_1983, IT_2020, NL_1978, CA_2011, CA_2016
after:   NL_1978, IT_1983, CA_2011, US_2011, CA_2016, IT_2020
```

`getMissalRegions()` likewise changes `VA, US, IT` → `VA, IT, US`, which appears in a parameter-validation message.

## Verification

```text
composer test:quick    4524 tests, 189189 assertions, 0 failures, 12 skipped
composer analyse       [OK] No errors (PHPStan level 10)
composer lint          clean
composer lint:md       0 issues
```

No existing ordering assertion was weakened: the Roman assertions are `assertContains`, and the only exact-list ones are the single-element Ambrosian index. The #963 test is driven off `getMissalIds()` and asserts the exact expected id set rather than a count, so a future `:lectionary` sibling names itself in the diff instead of surfacing as an opaque count mismatch.

## Notes

- `include_empty` does not widen the listing body today (`jsonSerialize()` reads `$missals` only), so the new catalogue order is not yet observable over HTTP; the test reaches it by reflection. Pre-existing, out of scope.
- The APCu index key and value shape are unchanged, so a running php-fpm may serve the pre-sort order until the 600s TTL expires after deploy. Self-healing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Missal catalogues are now displayed in a consistent, data-driven order: typical editions first, followed by publication year and edition identifier.
  - Ambrosian sanctorale and translation resources are now generated for each registered edition that provides the relevant data.
  - Inventory listings now reflect supported missal editions automatically, including edition-specific resource identifiers.

- **Bug Fixes**
  - Corrected catalogue ordering so it no longer depends on declaration order.
  - Improved handling of editions without available sanctorale data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->