### PR TITLE
fix(lectionary): correct the Assumption's readings and the orphaned Croatian key (#958, #969)

### DIFF
--- a/jsondata/sourcedata/rite/roman/lectionary/sanctorum/en.json
+++ b/jsondata/sourcedata/rite/roman/lectionary/sanctorum/en.json
@@ -47,18 +47,18 @@
     },
     "Assumption": {
         "vigil": {
-            "first_reading": "Acts 3:1-10",
-            "responsorial_psalm": "Psalm 18 (19)",
-            "second_reading": "Galatians 1:11-20",
-            "gospel_acclamation": "John 21:17d",
-            "gospel": "John 21:15-19"
+            "first_reading": "1 Chronicles 15:3-4, 15-16; 16:1-2",
+            "responsorial_psalm": "Psalm 132:6-7, 9-10, 13-14",
+            "second_reading": "1 Corinthians 15:54b-57",
+            "gospel_acclamation": "Luke 11:28",
+            "gospel": "Luke 11:27-28"
         },
         "day": {
-            "first_reading": "Acts 12:1-11",
-            "responsorial_psalm": "Psalm 33 (34)",
-            "second_reading": "2 Timothy 4:6-8,17-18",
-            "gospel_acclamation": "Matthew 16:18",
-            "gospel": "Matthew 16:13-19"
+            "first_reading": "Revelation 11:19a; 12:1-6a, 10ab",
+            "responsorial_psalm": "Psalm 45:10, 11, 12, 16",
+            "second_reading": "1 Corinthians 15:20-27",
+            "gospel_acclamation": "",
+            "gospel": "Luke 1:39-56"
         }
     },
     "ExaltationCross": {

--- a/jsondata/sourcedata/rite/roman/lectionary/sanctorum/fr.json
+++ b/jsondata/sourcedata/rite/roman/lectionary/sanctorum/fr.json
@@ -47,18 +47,18 @@
     },
     "Assumption": {
         "vigil": {
-            "first_reading": "Actes 3, 1-10",
-            "responsorial_psalm": "Psaume 18 (19)",
-            "second_reading": "Galates 1, 11-20",
-            "gospel_acclamation": "Jean 21, 17d",
-            "gospel": "Jean 21, 15-19"
+            "first_reading": "1 Chroniques 15, 3-4.15-16; 16, 1-2",
+            "responsorial_psalm": "Psaume 132, 6-7.9-10.13-14",
+            "second_reading": "1 Corinthiens 15, 54b-57",
+            "gospel_acclamation": "Luc 11, 28",
+            "gospel": "Luc 11, 27-28"
         },
         "day": {
-            "first_reading": "Actes 12, 1-11",
-            "responsorial_psalm": "Psaume 33 (34)",
-            "second_reading": "2 Timothée 4, 6-8.17-18",
-            "gospel_acclamation": "Matthieu 16, 18",
-            "gospel": "Matthieu 16, 13-19"
+            "first_reading": "Apocalypse 11, 19a; 12, 1-6a.10ab",
+            "responsorial_psalm": "Psaume 45, 10.11.12.16",
+            "second_reading": "1 Corinthiens 15, 20-27",
+            "gospel_acclamation": "",
+            "gospel": "Luc 1, 39-56"
         }
     },
     "ExaltationCross": {

--- a/jsondata/sourcedata/rite/roman/lectionary/sanctorum/hr.json
+++ b/jsondata/sourcedata/rite/roman/lectionary/sanctorum/hr.json
@@ -978,7 +978,7 @@
         "gospel_acclamation": "",
         "gospel": ""
     },
-    "StsIoannemBrebeuf": {
+    "StsJeanBrebeuf": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",

--- a/jsondata/sourcedata/rite/roman/lectionary/sanctorum/it.json
+++ b/jsondata/sourcedata/rite/roman/lectionary/sanctorum/it.json
@@ -47,18 +47,18 @@
     },
     "Assumption": {
         "vigil": {
-            "first_reading": "Atti 3, 1-10",
-            "responsorial_psalm": "Salmo 18 (19)",
-            "second_reading": "Galati 1, 11-20",
-            "gospel_acclamation": "Giovanni 21, 17d",
-            "gospel": "Giovanni 21, 15-19"
+            "first_reading": "1 Cronache 15, 3-4.15-16; 16, 1-2",
+            "responsorial_psalm": "Salmo 132, 6-7.9-10.13-14",
+            "second_reading": "1 Corinzi 15, 54b-57",
+            "gospel_acclamation": "Luca 11, 28",
+            "gospel": "Luca 11, 27-28"
         },
         "day": {
-            "first_reading": "Atti 12, 1-11",
-            "responsorial_psalm": "Salmo 33 (34)",
-            "second_reading": "2 Timoteo 4, 6-8.17-18",
-            "gospel_acclamation": "Matteo 16, 18",
-            "gospel": "Matteo 16, 13-19"
+            "first_reading": "Apocalisse 11, 19a; 12, 1-6a.10ab",
+            "responsorial_psalm": "Salmo 45, 10.11.12.16",
+            "second_reading": "1 Corinzi 15, 20-27",
+            "gospel_acclamation": "",
+            "gospel": "Luca 1, 39-56"
         }
     },
     "ExaltationCross": {

--- a/jsondata/sourcedata/rite/roman/lectionary/sanctorum/la.json
+++ b/jsondata/sourcedata/rite/roman/lectionary/sanctorum/la.json
@@ -47,18 +47,18 @@
     },
     "Assumption": {
         "vigil": {
-            "first_reading": "Actus 3, 1-10",
-            "responsorial_psalm": "Psalmo 18 (19)",
-            "second_reading": "Galatas 1, 11-20",
-            "gospel_acclamation": "Ioannem 21, 17d",
-            "gospel": "Ioannem 21, 15-19"
+            "first_reading": "I Paralipomenon 15, 3-4.15-16; 16, 1-2",
+            "responsorial_psalm": "Psalmo 132, 6-7.9-10.13-14",
+            "second_reading": "I Corinthios 15, 54b-57",
+            "gospel_acclamation": "Lucam 11, 28",
+            "gospel": "Lucam 11, 27-28"
         },
         "day": {
-            "first_reading": "Actus 12, 1-11",
-            "responsorial_psalm": "Psalmo 33 (34)",
-            "second_reading": "II Timotheo 4, 6-8.17-18",
-            "gospel_acclamation": "Matthæum 16, 18",
-            "gospel": "Matthæum 16, 13-19"
+            "first_reading": "Apocalypsis 11, 19a; 12, 1-6a.10ab",
+            "responsorial_psalm": "Psalmo 45, 10.11.12.16",
+            "second_reading": "I Corinthios 15, 20-27",
+            "gospel_acclamation": "",
+            "gospel": "Lucam 1, 39-56"
         }
     },
     "ExaltationCross": {

--- a/jsondata/sourcedata/rite/roman/lectionary/sanctorum/nl.json
+++ b/jsondata/sourcedata/rite/roman/lectionary/sanctorum/nl.json
@@ -47,18 +47,18 @@
     },
     "Assumption": {
         "vigil": {
-            "first_reading": "Actus 3, 1-10",
-            "responsorial_psalm": "Psalmo 18 (19)",
-            "second_reading": "Galatas 1, 11-20",
-            "gospel_acclamation": "Ioannem 21, 17d",
-            "gospel": "Ioannem 21, 15-19"
+            "first_reading": "I Paralipomenon 15, 3-4.15-16; 16, 1-2",
+            "responsorial_psalm": "Psalmo 132, 6-7.9-10.13-14",
+            "second_reading": "I Corinthios 15, 54b-57",
+            "gospel_acclamation": "Lucam 11, 28",
+            "gospel": "Lucam 11, 27-28"
         },
         "day": {
-            "first_reading": "Actus 12, 1-11",
-            "responsorial_psalm": "Psalmo 33 (34)",
-            "second_reading": "II Timotheo 4, 6-8.17-18",
-            "gospel_acclamation": "Matthæum 16, 18",
-            "gospel": "Matthæum 16, 13-19"
+            "first_reading": "Apocalypsis 11, 19a; 12, 1-6a.10ab",
+            "responsorial_psalm": "Psalmo 45, 10.11.12.16",
+            "second_reading": "I Corinthios 15, 20-27",
+            "gospel_acclamation": "",
+            "gospel": "Lucam 1, 39-56"
         }
     },
     "ExaltationCross": {

--- a/phpunit_tests/Handlers/LectionaryHandlerTest.php
+++ b/phpunit_tests/Handlers/LectionaryHandlerTest.php
@@ -10,6 +10,8 @@ use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Handlers\LectionaryHandler;
 use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\ShadowProjectRootTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Swaggest\JsonSchema\Schema;
 
@@ -26,6 +28,8 @@ use Swaggest\JsonSchema\Schema;
 #[CoversClass(LectionaryHandler::class)]
 final class LectionaryHandlerTest extends AbstractHandlerTestCase
 {
+    use ShadowProjectRootTrait;
+
     /** @var array<string,array<string,mixed>>|null decoded rite-level sanctorum files, keyed by locale */
     private static ?array $riteFiles = null;
 
@@ -178,57 +182,100 @@ final class LectionaryHandlerTest extends AbstractHandlerTestCase
 
     // -------------------------------------------------------------- absent is not empty
 
+    /**
+     * The one distinction of the four that can no longer be discovered from the shipped corpus.
+     *
+     * It used to be: `hr.json` spelled St Jean de Brébeuf's key `StsIoannemBrebeuf`, so exactly two
+     * keys were carried by some locales and not others. That was a data defect, not a feature —
+     * Croatian readers got no readings and the Croatian entry was orphaned — and #969 fixed it, which
+     * `LectionaryCorpusTest` now keeps fixed. The handler behaviour still needs covering, so the
+     * divergence is manufactured in a shadow project root instead of being borrowed from a bug.
+     *
+     * Nothing tracked is touched: `Router::$apiFilePath` is the seam every `JsonData::…->path()`
+     * resolves against, for the handler AND for this test's own oracle, and the shadow lives under
+     * `sys_get_temp_dir()`.
+     */
     public function testALocaleThatOmitsAnEventIsReportedAsWithoutAnEntryNotAsAnEmptyOne(): void
     {
+        $realRoot   = Router::$apiFilePath;
+        $shadowRoot = self::createShadowProjectRoot($realRoot, 'litcal-lectionary-partial');
+
+        try {
+            Router::$apiFilePath = $shadowRoot . DIRECTORY_SEPARATOR;
+            self::$riteFiles     = null;
+
+            $partialKey = self::dropOneKeyFromOneLocale();
+            $files      = self::riteFiles();
+
+            $body = $this->get(['sanctorale', $partialKey]);
+            $rite = null;
+            foreach ($body['readings'] as $source) {
+                if ($source['tier'] === 'rite') {
+                    $rite = $source;
+                    break;
+                }
+            }
+            self::assertNotNull($rite);
+
+            $expectedWith    = array_values(array_keys(array_filter($files, static fn (array $m): bool => array_key_exists($partialKey, $m))));
+            $expectedWithout = array_values(array_keys(array_filter($files, static fn (array $m): bool => false === array_key_exists($partialKey, $m))));
+
+            self::assertSame($expectedWith, $rite['locales_with_entry']);
+            self::assertSame($expectedWithout, $rite['locales_without_entry']);
+            self::assertNotEmpty($rite['locales_without_entry']);
+
+            // The locales that omit it appear in neither `entries` nor the empty-entry list: "no entry"
+            // and "an entry that is empty" are different answers, and only one of them is true here.
+            foreach ($expectedWithout as $locale) {
+                self::assertArrayNotHasKey($locale, $rite['entries']);
+                self::assertNotContains($locale, $rite['locales_with_empty_entry']);
+            }
+            self::assertSame($expectedWith, array_keys($rite['entries']));
+        } finally {
+            Router::$apiFilePath = $realRoot;
+            self::$riteFiles     = null;
+            self::removeTree($shadowRoot);
+        }
+    }
+
+    /**
+     * Remove one universally-declared `event_key` from exactly one locale file of the shadow corpus.
+     *
+     * `Router::$apiFilePath` must already point at the shadow root when this is called.
+     *
+     * @return string The key that is now carried by every locale but one.
+     */
+    private static function dropOneKeyFromOneLocale(): string
+    {
         $files = self::riteFiles();
+        self::assertGreaterThan(1, count($files), 'the rite-level sanctorale corpus needs at least two locales');
 
-        // Find a key some locale files carry and others do not — the state that a per-locale
-        // request cannot tell apart from "translated but empty".
-        $union = [];
-        foreach ($files as $map) {
-            foreach (array_keys($map) as $key) {
-                $union[$key] = true;
-            }
-        }
+        $locales = array_keys($files);
+        $victim  = end($locales);
+        self::assertIsString($victim);
 
-        $partialKey = null;
-        foreach (array_keys($union) as $key) {
-            $absent = array_keys(array_filter($files, static fn (array $m): bool => false === array_key_exists($key, $m)));
-            if ([] !== $absent && count($absent) < count($files)) {
-                $partialKey = $key;
+        $key = null;
+        foreach (array_keys($files[$victim]) as $candidate) {
+            if (array_all($files, static fn (array $m): bool => array_key_exists($candidate, $m))) {
+                $key = $candidate;
                 break;
             }
         }
-        self::assertNotNull(
-            $partialKey,
-            'no event_key in the rite-level corpus is present in some locales and absent from others, '
-            . 'so this distinction cannot be exercised against real data any more'
+        self::assertNotNull($key, 'no event_key is declared by every locale of the rite-level corpus');
+
+        $map = $files[$victim];
+        unset($map[$key]);
+
+        $path    = JsonData::LECTIONARY_SAINTS_FOLDER->path() . DIRECTORY_SEPARATOR . $victim . '.json';
+        $written = file_put_contents(
+            $path,
+            json_encode($map, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR)
         );
+        self::assertNotFalse($written, 'could not rewrite the shadow locale file ' . $path);
 
-        $body = $this->get(['sanctorale', $partialKey]);
-        $rite = null;
-        foreach ($body['readings'] as $source) {
-            if ($source['tier'] === 'rite') {
-                $rite = $source;
-                break;
-            }
-        }
-        self::assertNotNull($rite);
+        self::$riteFiles = null;
 
-        $expectedWith    = array_values(array_keys(array_filter($files, static fn (array $m): bool => array_key_exists($partialKey, $m))));
-        $expectedWithout = array_values(array_keys(array_filter($files, static fn (array $m): bool => false === array_key_exists($partialKey, $m))));
-
-        self::assertSame($expectedWith, $rite['locales_with_entry']);
-        self::assertSame($expectedWithout, $rite['locales_without_entry']);
-        self::assertNotEmpty($rite['locales_without_entry']);
-
-        // The locales that omit it appear in neither `entries` nor the empty-entry list: "no entry"
-        // and "an entry that is empty" are different answers, and only one of them is true here.
-        foreach ($expectedWithout as $locale) {
-            self::assertArrayNotHasKey($locale, $rite['entries']);
-            self::assertNotContains($locale, $rite['locales_with_empty_entry']);
-        }
-        self::assertSame($expectedWith, array_keys($rite['entries']));
+        return $key;
     }
 
     public function testAnEntryWhoseFieldsAreEmptyStringsIsReportedAsPresentAndEmpty(): void

--- a/phpunit_tests/Handlers/LectionaryHandlerTest.php
+++ b/phpunit_tests/Handlers/LectionaryHandlerTest.php
@@ -266,7 +266,15 @@ final class LectionaryHandlerTest extends AbstractHandlerTestCase
         $map = $files[$victim];
         unset($map[$key]);
 
-        $path    = JsonData::LECTIONARY_SAINTS_FOLDER->path() . DIRECTORY_SEPARATOR . $victim . '.json';
+        $path = JsonData::LECTIONARY_SAINTS_FOLDER->path() . DIRECTORY_SEPARATOR . $victim . '.json';
+
+        // The path is correct only because the caller repointed `Router::$apiFilePath` at the shadow
+        // root first. Enforce that precondition here rather than trusting the docblock: this is the
+        // write that would damage tracked source data if the seam were moved, reordered, or this
+        // helper were ever called from a context that had not repointed it (#921, #935). It is the
+        // same fence `ShadowProjectRootTrait::removeTree()` puts around the deletion side.
+        self::assertStringStartsWith(sys_get_temp_dir() . DIRECTORY_SEPARATOR, $path, 'refusing to write outside the shadow root');
+
         $written = file_put_contents(
             $path,
             json_encode($map, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR)

--- a/phpunit_tests/LectionaryCorpusTest.php
+++ b/phpunit_tests/LectionaryCorpusTest.php
@@ -19,6 +19,13 @@ use Swaggest\JsonSchema\Schema;
  * It asserts *structure*, deliberately not completeness. 85% of entries carry at least one empty-string
  * reading, and `Lectionary.json` admits them on purpose — filling them in is #712. A green here means
  * the structure is in place, which is exactly what the inventory item's label says.
+ *
+ * One cross-file invariant is asserted on top of that: within a single lectionary folder, every locale
+ * file must carry the same `event_key` SET. Validating each file in isolation cannot see a key that one
+ * locale spells differently from the rest, and that is exactly how `StsIoannemBrebeuf` survived in the
+ * Croatian sanctorale — a well-formed file whose key named a celebration nothing declares, orphaning the
+ * readings in one direction and leaving Croatian readers with none in the other (#969). Note that the
+ * comparison is over sets, never counts: all six sanctorale files held exactly 210 keys throughout.
  */
 #[CoversNothing]
 final class LectionaryCorpusTest extends TestCase
@@ -82,5 +89,79 @@ final class LectionaryCorpusTest extends TestCase
         }
 
         $this->assertSame([], $failures, "Lectionary files failed schema validation:\n" . implode("\n", $failures));
+    }
+
+    /**
+     * Within one lectionary folder, every locale file must declare the same set of `event_key`s.
+     *
+     * A folder is one section of one corpus — `lectionary/sanctorum`, `lectionary/feriale_per_annum_I`,
+     * a nation's `lectionary/`, a diocese's — and its files are the same readings in different languages.
+     * A key present in some of them and absent from the others is either a typo or an untranslated entry;
+     * both want fixing, and neither is visible to per-file schema validation.
+     *
+     * Folders holding a single file are skipped: there is nothing to compare them against.
+     */
+    public function testEveryLocaleFileInALectionaryFolderDeclaresTheSameKeySet(): void
+    {
+        /** @var array<string, array<string, list<string>>> $folders folder => file => sorted keys */
+        $folders = [];
+
+        foreach (self::lectionaryFiles() as $file) {
+            $contents = file_get_contents($file);
+            $this->assertIsString($contents, "could not read {$file}");
+
+            /** @var array<string, mixed> $data */
+            $data = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+
+            $keys = array_keys($data);
+            sort($keys);
+            $folders[dirname($file)][basename($file)] = $keys;
+        }
+
+        $this->assertNotEmpty($folders, 'no lectionary folders were discovered');
+
+        $root     = dirname(__DIR__) . DIRECTORY_SEPARATOR;
+        $failures = [];
+        $compared = 0;
+
+        foreach ($folders as $folder => $files) {
+            if (count($files) < 2) {
+                continue;
+            }
+
+            ++$compared;
+
+            $union = [];
+            foreach ($files as $keys) {
+                $union = array_merge($union, $keys);
+            }
+            $union = array_unique($union);
+            sort($union);
+
+            foreach ($union as $key) {
+                $present = array_keys(array_filter($files, static fn (array $keys): bool => in_array($key, $keys, true)));
+
+                if (count($present) === count($files)) {
+                    continue;
+                }
+
+                $missing    = array_values(array_diff(array_keys($files), $present));
+                $failures[] = sprintf(
+                    '%s: "%s" is declared by [%s] but missing from [%s]',
+                    str_replace($root, '', $folder),
+                    $key,
+                    implode(', ', $present),
+                    implode(', ', $missing)
+                );
+            }
+        }
+
+        $this->assertGreaterThan(15, $compared, 'expected around 22 multi-locale lectionary folders');
+
+        $this->assertSame(
+            [],
+            $failures,
+            "Lectionary locale files within a folder disagree on their event_key set:\n" . implode("\n", $failures)
+        );
     }
 }

--- a/phpunit_tests/LectionaryCorpusTest.php
+++ b/phpunit_tests/LectionaryCorpusTest.php
@@ -120,7 +120,16 @@ final class LectionaryCorpusTest extends TestCase
 
         $this->assertNotEmpty($folders, 'no lectionary folders were discovered');
 
-        $root     = dirname(__DIR__) . DIRECTORY_SEPARATOR;
+        $root = dirname(__DIR__) . DIRECTORY_SEPARATOR;
+
+        // Pin the one folder this invariant was written for, by name. A count guard alone is not
+        // enough: 22 folders qualify, but 11 of them are small calendar-tier folders, so discovery
+        // could lose `sanctorum` — the six-locale corpus where #969 happened — and still clear any
+        // plausible threshold, leaving the test green having never compared what it exists to guard.
+        $sanctorum = $root . 'jsondata/sourcedata/rite/roman/lectionary/sanctorum';
+        $this->assertArrayHasKey($sanctorum, $folders, 'the rite-level sanctorale folder was not discovered');
+        $this->assertGreaterThan(1, count($folders[$sanctorum]), 'the rite-level sanctorale folder must hold several locale files');
+
         $failures = [];
         $compared = 0;
 


### PR DESCRIPTION
Closes #958. Closes #969.

Two data-integrity defects in the Roman sanctorale lectionary, plus the test that would have caught one of them.

## #958 — the Assumption carried Sts Peter and Paul's readings

In five of six locales the `Assumption` entry was a verbatim copy of `StsPeterPaulAp`. Croatian was the exception and was correct — which is what identifies this as copy-paste rather than a deliberate shared reference. `Acts 12:1-11` is Peter's deliverance from prison; it is not an Assumption reading in any year of the cycle.

Fixed in `en`, `it`, `la`, `fr`, `nl` by taking **which** passages from `hr.json` — confirmed to match the Roman Lectionary — and rendering the book names in each locale's own convention, verified against an existing citation of the same book in the same file rather than translated from memory. `StsPeterPaulAp` is untouched: it was the correct source of the copy.

**Three renderings could not be verified in-file and want a native-speaker check before merge:**

| locale | rendering | why unverified |
| --- | --- | --- |
| it | `1 Cronache` | 0 occurrences in `it.json`; taken from `dioceses/IT/romamo_it/lectionary/it_IT.json`, which has `2 Cronache 7, 16` |
| fr | `1 Chroniques` | Chronicles appears nowhere in the French corpus |
| la, nl | `I Paralipomenon` | appears nowhere; fits the file's own conventions (Roman numerals for numbered books, genitive OT titles) |

`grep -rl 'Chroniques\|Paralipomenon'` returns only the files this branch touches, so these three are the complete set — no unflagged guess.

## #969 — a Croatian key was misspelled, orphaning it in both directions

`hr.json` keyed St Jean de Brébeuf under `StsIoannemBrebeuf`; every other locale and the calendar itself use `StsJeanBrebeuf`. Croatian readers got no readings, and the Croatian entry was keyed to an `event_key` the General Roman Calendar never declares. Renamed; the value is untouched.

### The test — the substantive half

`LectionaryCorpusTest` validated each file against `Lectionary.json` **in isolation** — *"asserts structure, deliberately not completeness"* — which is exactly how a well-formed file with a wrong key survived. It now also asserts that within one lectionary folder every locale file carries the same `event_key` **set**.

Sets, not counts: all six files held exactly 210 keys throughout, which is why this was invisible. Introduced as a hard assertion with no grandfathering — a scan of all 26 lectionary folders (22 multi-locale) found exactly one divergence, this one.

**Mutation-checked.** Reverting the rename fails it, verbatim:

```text
jsondata/sourcedata/rite/roman/lectionary/sanctorum: "StsIoannemBrebeuf" is declared by [hr.json] but missing from [en.json, fr.json, it.json, la.json, nl.json]
jsondata/sourcedata/rite/roman/lectionary/sanctorum: "StsJeanBrebeuf" is declared by [en.json, fr.json, it.json, la.json, nl.json] but missing from [hr.json]
```

The test also pins the sanctorum folder by name, so losing it from discovery fails loudly rather than passing green having compared only the 11 small calendar-tier folders.

### Collateral: a test was using this bug as its fixture

`LectionaryHandlerTest::testALocaleThatOmitsAnEventIsReportedAsWithoutAnEntry…` searched the live corpus for a key some locales lacked — i.e. it depended on the defect — and failed once fixed. It now manufactures the divergence in a `ShadowProjectRootTrait` root, with all four original assertions intact, `Router::$apiFilePath` and the static cache restored in `finally`, and an `assertStringStartsWith(sys_get_temp_dir(), …)` fencing the write so nothing tracked can be touched (#921, #935).

## The stronger invariant, measured but not asserted

#969 also names *"every `event_key` resolves to a declared celebration"*. Scanned rather than assumed: exactly **one** key fails today — the one this branch fixes — so **zero** afterwards. All 17 tier-level folders are clean. Left as a follow-up, with two traps that produce false orphans recorded for whoever picks it up: `ImmaculateHeart` is temporale-declared but sanctorum-assigned via `LectionaryCategory::SANCTORUM_EVENTS`, and nation sources live at `nations/{CC}/{CC}.json`.

## Verification

```text
composer test:quick     4520 tests, 189266 assertions, 0 failures, 12 skipped
composer lint           clean
composer lint:md        0 issues
composer lint:jsondata  OK — 23 files canonical (no \uXXXX escaping; Brébeuf, Croatian and Latin preserved literally)
```

## Found alongside, filed separately

- **#971** — `NativityJohnBaptist`'s vigil readings duplicate its day readings in *all six* locales. Same family, but by construction invisible to the new check, since every file agrees.
- **#972** — `nl.json` is byte-identical to `la.json`: the Dutch sanctorale lectionary is an untranslated Latin placeholder. It is why the Dutch fix here takes the Latin rendering.
- **#973** — psalm numbering is split within the same file (`Psalm 45 (46)` vs `Psalm 45:10, …`), which are different psalms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the Assumption feast’s vigil and day readings across English, French, Italian, Latin, and Dutch lectionary data.
  - Removed incorrect duplicated readings previously shown for the Assumption celebration.
  - Corrected the Croatian entry label for St Jean de Brébeuf.
- **Tests**
  - Added validation to ensure locale lectionary files maintain consistent event coverage.
  - Improved checks for reporting locales with missing lectionary entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->